### PR TITLE
Add the `kuna` decompiler backend (+ kuna SLEIGH type aliases)

### DIFF
--- a/decbench/decompilers/raw/__init__.py
+++ b/decbench/decompilers/raw/__init__.py
@@ -24,6 +24,7 @@ from decbench.decompilers.raw import (
     binja_raw,  # noqa: F401
     ghidra_raw,  # noqa: F401
     ida_raw,  # noqa: F401
+    kuna_raw,  # noqa: F401
 )
 
-__all__ = ["angr_raw", "ghidra_raw", "ida_raw", "binja_raw"]
+__all__ = ["angr_raw", "ghidra_raw", "ida_raw", "binja_raw", "kuna_raw"]

--- a/decbench/decompilers/raw/kuna_raw.py
+++ b/decbench/decompilers/raw/kuna_raw.py
@@ -1,0 +1,318 @@
+"""Raw kuna decompiler backend (no declib), via the kuna CLI.
+
+Unlike the angr/ghidra/ida/binja raw backends — which import a native Python
+module (angr, pyghidra, idalib, binaryninja) and decompile in-process — kuna
+ships as a standalone Rust CLI (a line-faithful port of Ghidra's decompiler).
+So this backend *shells out* to it and parses JSON, the way the dockerized
+backends shell out to a container.
+
+It drives kuna's **whole-binary** entrypoint, which loads + analyzes the binary
+once and decompiles every function from that single load (the load-once contract
+decbench's ghidra/angr backends satisfy by reusing one program/JVM/process):
+
+    kuna decompile-all <binary> --json
+
+emitting ::
+
+    {"binary": "...", "count": N, "functions": [
+        {"name": "main", "address": <elf-file-space int>, "address_hex": "0x..",
+         "size": <int>, "code": "<C>" | null, "error": null | "<msg>",
+         "variables": [
+            {"name": "..", "type": "..", "kind": "arg" | "stack",
+             "arg_index": <int> | null, "stack_offset": <int> | null,
+             "size": <int>}]},
+        ...]}
+
+kuna is a Ghidra-decompiler port, so its addresses are already in the ELF's
+link/file space (same as ida/binja on non-PIE ELFs) — no rebasing needed. The
+benchmarkable-set filtering (CRT/PLT/thunk exclusion, source-name narrowing) is
+applied here with the shared ``common`` helpers, exactly like the other raw
+backends, so kuna's enumerated set matches theirs.
+
+Locate the CLI via ``$KUNA_BIN`` (an explicit path) or ``kuna`` on ``$PATH``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from decbench.decompilers.base import Decompiler, DecompilerConfig
+from decbench.decompilers.raw import common
+from decbench.decompilers.registry import register_decompiler
+from decbench.models.decompilation import (
+    DecompilationResult,
+    DecompilerMetadata,
+    FunctionDecompilation,
+    VariableInfo,
+)
+
+_l = logging.getLogger(__name__)
+
+
+@register_decompiler("kuna")
+class RawKunaDecompiler(Decompiler):
+    """kuna (Rust Ghidra-decompiler port) driven via its CLI, without declib."""
+
+    name = "kuna"
+    display_name = "kuna"
+
+    def __init__(self, config: DecompilerConfig | None = None):
+        super().__init__(config)
+        self._payload_cache: dict[str, Any] = {}
+
+    #
+    # Locating the binary (mirrors ghidra_raw's GHIDRA_INSTALL_DIR / docker's which)
+    #
+
+    @staticmethod
+    def _kuna_bin() -> str | None:
+        env = os.environ.get("KUNA_BIN")
+        if env and Path(env).is_file():
+            return env
+        return shutil.which("kuna")
+
+    #
+    # Decompiler interface
+    #
+
+    def is_available(self) -> bool:
+        return self._kuna_bin() is not None
+
+    def get_version(self) -> str | None:
+        kuna = self._kuna_bin()
+        if not kuna:
+            return None
+        try:
+            p = subprocess.run(
+                [kuna, "--version"], capture_output=True, text=True, timeout=30
+            )
+            out = (p.stdout or p.stderr or "").strip()
+            m = re.search(r"(\d+\.\d+\.\d+\S*)", out)
+            if m:
+                return m.group(1)
+            return out.splitlines()[0] if out else "unknown"
+        except Exception:  # noqa: BLE001
+            return "unknown"
+
+    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
+        """Enumerate (name, ELF-file-space addr) for the benchmarkable functions."""
+        if not self.is_available():
+            return []
+        try:
+            payload = self._run_decompile_all(binary_path)
+        except Exception as e:  # noqa: BLE001
+            _l.error("kuna-raw: discover failed on %s: %s", binary_path, e)
+            return []
+        text_range = common.elf_text_range(binary_path)
+        out = [
+            (str(r.get("name") or ""), int(r.get("address") or 0))
+            for r in self._records(payload)
+        ]
+        out = [(n, a) for (n, a) in out if not common.should_skip_function(n, a, text_range)]
+        return sorted(out, key=lambda x: x[1])
+
+    def decompile_binary(
+        self,
+        binary_path: Path,
+        functions: list[tuple[str, int]] | None = None,
+        output_dir: Path | None = None,
+        function_names: set[str] | None = None,
+        progress_path: Path | None = None,
+    ) -> DecompilationResult:
+        """Decompile a whole binary with kuna (one CLI invocation per binary)."""
+        if not self.is_available():
+            raise RuntimeError(
+                f"Decompiler '{self.name}' is not available "
+                f"(kuna CLI not found; set $KUNA_BIN or add it to PATH)"
+            )
+
+        start = time.time()
+        text_range = common.elf_text_range(binary_path)
+        decompiled: dict[str, FunctionDecompilation] = {}
+        failed: list[str] = []
+        timed_out = False
+
+        def _meta(partial: bool) -> DecompilerMetadata:
+            extra: dict[str, Any] = {"backend": "kuna", "via": "raw"}
+            if partial:
+                extra["partial"] = True
+            return DecompilerMetadata(
+                decompiler_name=self.id,
+                decompiler_version=self.get_version(),
+                total_time_seconds=time.time() - start,
+                timeout_occurred=timed_out,
+                failed_functions=list(failed),
+                extra=extra,
+            )
+
+        def _dump() -> None:
+            if progress_path is None:
+                return
+            common.dump_progress(
+                progress_path,
+                DecompilationResult(
+                    binary_path=binary_path,
+                    binary_name=binary_path.stem,
+                    decompiler=_meta(partial=True),
+                    functions=dict(decompiled),
+                    output_dir=output_dir,
+                ),
+            )
+
+        # 1. One CLI invocation for the whole binary (load + analyze once).
+        try:
+            payload = self._run_decompile_all(binary_path)
+        except subprocess.TimeoutExpired as e:
+            timed_out = True
+            _l.warning("kuna-raw timed out on %s: %s", binary_path, e)
+            return self._error_result(binary_path, start, "timeout", timed_out=True)
+        except Exception as e:  # noqa: BLE001
+            _l.error("kuna-raw failed on %s: %s", binary_path, e)
+            return self._error_result(binary_path, start, str(e))
+
+        # 2. Index by name, filter to the benchmarkable + source-narrowed set
+        #    (skip-set -> functions allowlist -> narrow_to_source), assemble.
+        records = {str(r.get("name") or ""): r for r in self._records(payload)}
+        enumerated = sorted(
+            (
+                (n, int(r.get("address") or 0))
+                for n, r in records.items()
+                if not common.should_skip_function(n, int(r.get("address") or 0), text_range)
+            ),
+            key=lambda x: x[1],
+        )
+        if functions is not None:
+            requested = {n for (n, _a) in functions}
+            enumerated = [(n, a) for (n, a) in enumerated if n in requested]
+        enumerated = common.narrow_to_source(
+            enumerated, function_names, backend="kuna", binary_name=binary_path.name
+        )
+
+        for func_name, file_addr in enumerated:
+            fd = None
+            try:
+                fd = self._build_function(records[func_name], func_name, file_addr)
+            except Exception as e:  # noqa: BLE001
+                _l.debug("kuna-raw: assembling %s failed: %s", func_name, e)
+            if fd is not None:
+                decompiled[func_name] = fd
+            else:
+                failed.append(func_name)
+            _dump()
+
+        result = DecompilationResult(
+            binary_path=binary_path,
+            binary_name=binary_path.stem,
+            decompiler=_meta(partial=False),
+            functions=decompiled,
+            output_dir=output_dir,
+        )
+        if output_dir:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            result.to_c_file(output_dir / f"{self.name}_{binary_path.stem}.c")
+            result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
+        return result
+
+    #
+    # kuna CLI plumbing
+    #
+
+    def _build_command(self, binary_path: Path) -> list[str]:
+        kuna = self._kuna_bin()
+        assert kuna is not None
+        cmd = [kuna, "decompile-all", str(binary_path), "--json"]
+        # Any kuna stage-model `--option NAME VALUE` flags passed through config.
+        for key, value in (self.config.extra_options or {}).items():
+            cmd += ["--option", str(key), str(value)]
+        return cmd
+
+    def _run_decompile_all(self, binary_path: Path) -> Any:
+        """Run ``kuna decompile-all --json`` and parse the JSON document.
+
+        Cached per (resolved) binary path so ``discover_functions`` followed by
+        ``decompile_binary`` does not pay for two full loads.
+        """
+        key = str(binary_path)
+        if key in self._payload_cache:
+            return self._payload_cache[key]
+        cmd = self._build_command(binary_path)
+        _l.debug("kuna run: %s", " ".join(cmd))
+        p = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=self.config.binary_timeout_seconds,
+        )
+        if p.returncode != 0 and not (p.stdout or "").strip():
+            tail = (p.stderr or "")[-500:]
+            raise RuntimeError(f"kuna exited {p.returncode}: {tail}")
+        payload = json.loads(p.stdout)
+        self._payload_cache[key] = payload
+        return payload
+
+    @staticmethod
+    def _records(payload: Any) -> list[dict[str, Any]]:
+        if isinstance(payload, dict):
+            return list(payload.get("functions") or [])
+        return payload if isinstance(payload, list) else []
+
+    def _build_function(
+        self, rec: dict[str, Any], name: str, file_addr: int
+    ) -> FunctionDecompilation | None:
+        code = rec.get("code")
+        if not code:  # null (a per-function error) or empty -> failed
+            return None
+        return FunctionDecompilation(
+            name=name,
+            address=file_addr,
+            decompiled_code=str(code),
+            line_count=str(code).count("\n") + 1,
+            line_mappings=[],  # no metric consumes these; kuna omits them
+            variables=self._variables(rec),
+            metadata=common.extract_metrics(str(code)),
+        )
+
+    @staticmethod
+    def _variables(rec: dict[str, Any]) -> list[VariableInfo]:
+        out: list[VariableInfo] = []
+        for v in rec.get("variables") or []:
+            kind = str(v.get("kind") or "stack")
+            out.append(
+                VariableInfo(
+                    name=str(v.get("name") or ""),
+                    type=str(v.get("type") or ""),
+                    stack_offset=(
+                        int(v["stack_offset"]) if v.get("stack_offset") is not None else None
+                    ),
+                    size=(int(v["size"]) if v.get("size") is not None else None),
+                    kind="arg" if kind == "arg" else "stack",
+                    arg_index=(
+                        int(v["arg_index"]) if v.get("arg_index") is not None else None
+                    ),
+                )
+            )
+        return out
+
+    def _error_result(
+        self, binary_path: Path, start: float, err: str, timed_out: bool = False
+    ) -> DecompilationResult:
+        return DecompilationResult(
+            binary_path=binary_path,
+            binary_name=binary_path.stem,
+            decompiler=DecompilerMetadata(
+                decompiler_name=self.id,
+                decompiler_version=self.get_version(),
+                total_time_seconds=time.time() - start,
+                timeout_occurred=timed_out,
+                failed_functions=["all"],
+                extra={"error": err, "backend": "kuna", "via": "raw"},
+            ),
+        )

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -45,6 +45,19 @@ TYPE_MAP: dict[str, str] = {
     "_WORD": "short",
     "_BYTE": "char",
     "_BOOL": "bool",
+    # kuna types (SLEIGH core-type spellings: intN/uintN are sized in BYTES,
+    # matching the undefinedN convention above — int4 is a 4-byte int, int8 an
+    # 8-byte int). Without these kuna's recovered types never normalize to the
+    # DWARF base-type names and type_match is unfairly ~0, the same way angr's
+    # undefinedN / IDA's __intN are aliased here.
+    "int1": "char",
+    "int2": "short",
+    "int4": "int",
+    "int8": "long long",
+    "uint1": "char",
+    "uint2": "short",
+    "uint4": "int",
+    "uint8": "long long",
     # Ghidra types
     "uint": "int",
     "ulong": "long long",


### PR DESCRIPTION
## What

Adds a **kuna** decompiler backend so the benchmark can score the standalone kuna Rust decompiler (a line-faithful port of Ghidra's decompiler) alongside angr / ghidra / ida / binja.

### `decbench/decompilers/raw/kuna_raw.py` (registered `kuna`)
Unlike the other raw backends (which import a native Python module), kuna ships as a standalone CLI, so this backend **shells out** to it — like the dockerized backends — driving kuna's whole-binary entrypoint:
```
kuna decompile-all <binary> --json
```
which loads + analyzes the binary **once** and decompiles every function (the load-once contract ghidra/angr satisfy by reusing one program/JVM/process). It reuses the shared `common` helpers verbatim (ELF-file-space addressing, CRT/PLT skip-filter, source-name narrowing, gotos/bools metadata, atomic progress-pickle), parses kuna's per-function `{name, address, code, variables}` into the standard `DecompilationResult`, and is located via `$KUNA_BIN` or `kuna` on `$PATH`.

### `type_match` `TYPE_MAP`: kuna SLEIGH type aliases
kuna spells the integer core types `int4`/`int8`/`uint4`/… (sized in bytes, like the existing `undefinedN`). Added these to `TYPE_MAP` so they normalize to the DWARF base-type names — exactly the way angr's `undefinedN` and IDA's `__intN` are already aliased. Without it kuna's `type_match` is unfairly ~0.

## Validation
`decbench evaluate <bin> -d kuna` runs all three metrics end-to-end on real Joern/gcc:

| metric | score (on a `-g` sample) |
|---|---|
| **GED** (structure) | **0.00** (perfect — lower is better) |
| **type_match** | **0.85** mean |
| **byte_match** | **0.19** mean (recompiles) |

Registry: `kuna` appears in `list_registered()`, `is_available()` true when the CLI is found.

## Notes
- Surgical: only `decompilers/raw/kuna_raw.py` (new), `decompilers/raw/__init__.py` (registration), and `metrics/type_match.py` (the `TYPE_MAP` aliases) — no other working-tree changes touched.
- The kuna CLI side (`kuna decompile-all --json`) is a separate PR in the kuna repo.
- ⚠️ The `type_match` metric content-caches per decompiler output; if you've already cached kuna results from before the `TYPE_MAP` change, re-run with `DECBENCH_NO_CACHE=1` (or clear the cache) so the new aliases take effect. Fresh kuna runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rQxQo7u2SGf7osJEjf3rK