### PR TITLE
Benchmark fairness overhaul + interactive report

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the Docker build context small: exclude results, stale workspace cruft,
+# VCS, caches, generated reports, and the local Python venv if any.
+results/
+workspace/
+.git/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+node_modules/
+*.html
+*.log
+.venv/
+venv/
+build/
+dist/
+*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,22 @@ DecBench is a benchmarking suite for evaluating decompiler performance. It imple
   `source /home/mahaloz/.virtualenvs/decbench/bin/activate`.
 - Decompiler backends **available and working** on this machine (verified via
   the raw, declib-free interfaces — see Architecture): **angr** (pip),
-  **Ghidra 12.1** AND **Ghidra 12.0** (`/home/mahaloz/bin/ghidra_12.{1,0}`, via
-  pyghidra; export `GHIDRA_INSTALL_DIR` for the unversioned default),
-  **IDA Pro 9.2 idalib** (at `/home/mahaloz/ctf/tools/idapro_9.2`, license
-  present — it works; the older note that only an unusable IDA 8.0 exists is
-  obsolete), and **r2dec** (native radare2 at `/usr/bin`, using the built-in
-  `pdc` pseudo-decompiler since the r2dec plugin can't build without dev
-  headers/sudo). **Binary Ninja is NOT installed** (`binja` coded but
-  unavailable). **RetDec/Reko** are Dockerized (`docker/`, images not pre-built).
-  `decbench list-decompilers` shows availability.
+  **phoenix** (angr driven with the Phoenix structurer — a distinct decompiler;
+  plain `angr` uses angr's default SAILR structurer), **Ghidra 12.1** AND
+  **Ghidra 12.0** (`/home/mahaloz/bin/ghidra_12.{1,0}`, via pyghidra; export
+  `GHIDRA_INSTALL_DIR` for the unversioned default), **IDA Pro 9.2 idalib** (at
+  `/home/mahaloz/ctf/tools/idapro_9.2`), **Binary Ninja 3.1** (install at
+  `/home/mahaloz/ctf/tools/binja/binaryninja`; added to the venv via a
+  `binaryninja.pth` in site-packages; needs a license at
+  `~/.binaryninja/license.dat` — a Commercial/Ultimate license is required for
+  headless use, and it must cover v3.1), and **r2dec** (native radare2 at
+  `/usr/bin`, built-in `pdc`). **RetDec/Reko** are Dockerized (`docker/`).
+  `decbench list-decompilers` shows availability. The 5-decompiler benchmark set
+  is **angr, phoenix, ghidra, ida, binja**.
+- **Phoenix** = `decbench/decompilers/raw/angr_raw.py::RawAngrPhoenixDecompiler`
+  (`structurer = "Phoenix"`). The base `RawAngrDecompiler` has a `structurer`
+  attr (None = SAILR default); set it via angr's `get_structurer_option()`
+  ("SAILR"/"Phoenix"/"DREAM").
 - **Two Ghidra versions** are configured for multi-version benchmarking in
   `~/.config/decbench/decompilers.toml` (`ghidra@12.0` → ghidra_12.0,
   `ghidra@12.1` → ghidra_12.1). Run them as distinct specs: `-d ghidra@12.0 -d
@@ -111,6 +118,40 @@ DECBENCH_WORKERS=40 GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1 \
 #   DECBENCH_DECOMPILE_TIMEOUT (s, default 300), DECBENCH_GED_MAX_NODES (60).
 #   Restart resumes from per-project checkpoints; `... results/sailr_full -- grep`
 #   limits to named projects. Single project: scripts/decompile_one.py.
+
+# FULL run over ALL projects (sailr x86 + cps ARM + malware ARM/PE). Both drivers
+# now gather projects/{sailr,cps,malware}/*.toml (gather_tomls(); cps/disabled/
+# excluded). sailr compiles on the host; cps/malware need the cross/mingw
+# toolchains so they compile INSIDE the slim `decbench-compile` image
+# (Dockerfile.compile — ARM + mingw + decbench's light compile deps; the host has
+# no cross/mingw gcc). Decompilation runs on the HOST for all of them (the raw
+# backends + executor discover ELF *and* PE; PE malware decompiles via
+# ghidra/ida/binja/angr). Steps:
+#   1) host-compile sailr:  python scripts/compile_all.py results/full_run 20
+#   2) docker build -f Dockerfile.compile -t decbench-compile .   (one-time)
+#   3) docker-compile cps+malware INTO the same tree (run as host user, /.dockerenv
+#      satisfies the is_malware guard):
+#      docker run --rm -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace \
+#        -e HOME=/tmp --user "$(id -u):$(id -g)" decbench-compile \
+#        python3 scripts/compile_all.py results/full_run 8 <cps+malware stems...>
+#   4) one decompile+evaluate+report pass over everything (resumes per-project):
+#      DECBENCH_WORKERS=40 DECBENCH_DECOMPILERS=angr,phoenix,ghidra,ida,binja \
+#        GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1 \
+#        python scripts/run_benchmark.py results/full_run
+#   byte_match ABSTAINS (no result, not 0) for ARM/PE on the host (no cross/mingw
+#   recompiler) — GED + type_match carry cps/malware. Overall counts only
+#   functions evaluated on ALL metrics (so abstained byte_match isn't a failure).
+
+# Recompute ONLY byte_match over an existing results tree WITHOUT re-decompiling
+# (uses the stored decompiled/*.c + compiled binaries), then rebuild the report
+# data (merge new byte_match, build Compare samples + Hardest w/ source, compile
+# rates, recompute scoreboard). Used to refresh after a byte_match metric change:
+python scripts/reeval_bytematch.py results/sailr_full 40   # parallel, resumable -> byte_match_new.json
+python scripts/rebuild_function_data.py results/sailr_full # -> function_results.json + scoreboard.toml
+#   NOTE: the on-disk results tree may be a PARTIAL snapshot (some projects have
+#   no decompiled .c); rebuild DROPS byte_match for functions whose artifact is
+#   gone so the column is uniformly the new metric (per-metric denominators
+#   already differ). Re-render: decbench report results/sailr_full/scoreboard.toml
 ```
 
 **Why the run driver isn't just `decbench run`** (key scaling facts): angr's
@@ -195,6 +236,22 @@ functions — no binary copying (`decbench subset function_results.json`).
   ARM→arm-none-eabi, x86→gcc; flags read from the DWARF producer), via
   `decbench/utils/binfmt.py`. Returns a non-scoring result if that toolchain
   isn't installed (don't fake a wrong-arch recompile). Works on ELF and PE.
+  **Two fairness passes (v2, `cache_version="2"`) — investigate before changing:**
+  (1) a **compilability fixup** (`decbench/metrics/fixup.py`) so decompiler
+  output actually builds instead of auto-scoring 0 — it strips illegal tokens
+  (`GLIBC_2.2.5::stderr` symbol-version names), then runs a **gcc-diagnostic-driven
+  self-repair loop** (`LC_ALL=C` for ASCII quotes) that injects ONLY what the
+  compiler reports missing: `typedef`s for pseudo-types (`undefined4`/`code`/`uint`),
+  decls for implicit functions, globals for undeclared ids — never redefining what
+  the decompiler already declared (conflict-withdrawal handles the rare clash).
+  This *maximizes compilation* uniformly for all decompilers (raised compile rate
+  ~16-39%→~44-46% on sailr). (2) **operand normalization** in `_disassemble_bytes`
+  blanks link-time-dependent operands (branch/call targets, `[rip±disp]`) so a
+  function whose only "difference" is an unlinked call displacement isn't
+  penalized. The metric still records `compilable` per function (surfaced as the
+  report's per-decompiler **compile rate**). Net effect on sailr: byte_match mean
+  ~0.05→~0.19 (3-4×). Type recovery is measured separately by `type_match`, so
+  fixing types to compile is fair.
 
 `decbench/utils/binfmt.py` is the shared binary-format helper: detect ELF/PE +
 arch, pick the matching recompiler + capstone arch, read DWARF from ELF *or* PE
@@ -214,22 +271,30 @@ type_match and byte_match use it, so they work on the PE (MinGW) malware targets
   as `function_results.json`
 
 **Results Rendering** (`decbench/rendering/`):
-- `html.py` - Self-contained HTML report, themed after mahaloz.re (terminal
-  aesthetic: black bg, Source Code Pro mono, dashed rules, Unix-path nav, ASCII
-  bars). With function data it embeds JSON + vanilla JS and offers a single
-  **dataset selector** (instead of many toggles) — `full` / `hard` (O2-noinline
-  + large) / `tiny` (~100 funcs **seeded-randomly** sampled across
-  inlined/optimized/unoptimized/large and projects, **at most one per binary**
-  while binaries last; seed via `DECBENCH_TINY_SEED`, default 1337). Selecting
-  one live-recomputes the comparison matrix, per-binary breakdown, and rankings.
-  Hovering a per-binary row shows the function name(s) it contributes.
+- `html.py` - Self-contained **single-page app** with a left **sidebar** that
+  switches views, themed after mahaloz.re (terminal aesthetic: black bg, Source
+  Code Pro mono, dashed rules, ASCII bars). All views are driven client-side from
+  the embedded per-function dataset; the sidebar **dataset selector** (`full` /
+  `hard` / `hard-inlined` / `tiny`) live-recomputes every aggregate. Views:
+  - **Leaderboard** — swebench.com-style ranked table: one row per decompiler,
+    columns = Overall (perfect on all 3 metrics) + each metric's perfect % +
+    Compiles (compile rate); **sortable** by any column.
+  - **Metrics** — explains the three decompilation goals (control-flow structure
+    → GED, types → type_match, recompilation → byte_match), what "perfect" means
+    for each, and a per-decompiler perfect-rate + compile-rate table.
+  - **Compare** — **side-by-side original source vs each decompiler's output** for
+    a curated set of functions (the `tiny` slice), with per-metric scores. Source
+    comes from `decbench/utils/source_extract.py` (DWARF decl_file/line + brace
+    matching). Filterable.
+  - **Hardest** — worst-scoring functions with decompiled code AND source.
+  - **Historical** — pure-SVG per-metric line charts across decompiler versions
+    (e.g. `ghidra@12.0` vs `ghidra@12.1`).
   Preset membership is tagged server-side by `scoring/datasets.py`
-  (`assign_datasets`; "large" = upper tail of the size bell curve, with the
-  `large` label as fallback). Two extra views (built by
-  `scoring/report_extras.py`): **Hardest Functions** (a "hall of shame" of the
-  worst-scoring functions with their decompiled code) and **Historical**
-  (pure-SVG line charts, one per metric, of each decompiler's score across
-  versions/time — driven by multi-version data, e.g. `ghidra@12.0` vs `ghidra@12.1`).
+  (`assign_datasets`; "large" = upper tail of the size bell curve). The
+  code-carrying extras (`samples`, `hardest`, `compile_rates`) are built by
+  `scoring/report_extras.py` (`build_samples`/`build_hardest`/`compute_compile_rates`,
+  wired in `attach_extras` AFTER datasets are assigned). Models in
+  `models/function_data.py` (`SampleEntry`, `compile_rates`).
 
 **Data Models** (`decbench/models/`):
 - Pydantic-based models for projects, decompilation results, metrics, scoreboards, and

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,0 +1,39 @@
+# Slim COMPILE-ONLY image for the cps (ARM) + malware (ARM/PE) targets.
+#
+# Decompilation runs on the host; this image only needs the cross/mingw
+# toolchains + build deps + decbench's light compile-path deps (NOT angr/ghidra/
+# pyjoern/radare2). The repo is MOUNTED at runtime (-v $PWD:/workspace) and
+# decbench is imported via PYTHONPATH, so no `pip install -e .` (which would drag
+# in the heavy decompiler stack). Toolchain/dep list mirrors the proven Dockerfile.
+#
+# Build:  docker build -f Dockerfile.compile -t decbench-compile .
+# Use:    docker run --rm -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace \
+#           decbench-compile python3 scripts/compile_all.py results/full_run 8 <stems...>
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git wget curl unzip ca-certificates \
+    python3 python3-pip python-is-python3 \
+    autoconf automake libtool gettext autopoint rsync bison texinfo gperf \
+    help2man pkg-config meson ninja-build cmake flex file device-tree-compiler \
+    libtool-bin libssl-dev uuid-dev libgnutls28-dev \
+    gcc g++ \
+    gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib \
+    gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+    gcc-mingw-w64 \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m pip install --break-system-packages --no-cache-dir \
+       pydantic toml pyelftools lief pefile rich numpy \
+       capstone diff-match-patch \
+       pyserial future "empy==3.3.4" jsonschema kconfiglib pymavlink pexpect \
+       pyros-genmsg packaging jinja2 pyyaml lxml cerberus \
+    && arm-none-eabi-gcc --version | head -1 \
+    && i686-w64-mingw32-gcc --version | head -1
+
+# Allow running ./configure as root (needed in Docker).
+ENV FORCE_UNSAFE_CONFIGURE=1
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -725,3 +725,71 @@ Verified in-container on a MinGW PE: type_match read the PE-DWARF ground truth
 (`x`, `i`) and scored; byte_match recompiled with MinGW + `-m32 -march=pentiumpro
 -O2` and the disassembly matched (jaccard 1.0). ELF path unchanged; full suite
 103 passed, 2 skipped.
+
+## Byte-match fairness overhaul + report redesign (2026-06-28)
+
+Two workstreams: (a) make the Recompilation Bytematch metric *fair* (it scored
+~0 for everyone), and (b) redesign the HTML report into a swebench-style
+leaderboard with a sidebar, a Metrics explainer, and a side-by-side Compare view.
+
+### Byte-match investigation (root cause)
+Replaying the real metric on stored `sailr_full` decompilations (O0 sample)
+showed two distinct causes, both fixable and both *unfair*:
+- **Most functions never compiled** → auto-scored 0. angr only 38.9% compiled,
+  Ghidra only 16.3%. Failures were systematic: Ghidra emits undefined
+  pseudo-types (`undefined4`/`code`/`uint`), angr emits illegal tokens
+  (`GLIBC_2.2.5::stderr`) and conflicts with the force-included stdlib headers.
+- **Even when compiled, scoring was too punishing**: `_disassemble_bytes`'
+  comment *claimed* it normalized addresses but the code didn't — so unlinked
+  `call`/`jmp` targets and every `[rip±disp]` counted as mismatches.
+
+### Fixes (user chose "maximize compilation")
+- `decbench/metrics/fixup.py` (NEW): token sanitization (strip `NS::`) + minimal
+  includes (stdint/stddef only, so we don't collide with decompiler typedefs) +
+  a **gcc-diagnostic-driven self-repair loop** (`LC_ALL=C` so gcc emits ASCII
+  quotes the regexes can parse — the original miss that made Ghidra *worse*).
+  Injects only what gcc reports missing; withdraws any decl that causes a
+  conflict. Applied uniformly to all decompilers.
+- `byte_match.py`: real `_normalize_operands` (blank branch/call targets +
+  `[rip±disp]`), uses `compile_with_fixup`, records `compilable` per function,
+  cleans the temp object dir, `cache_version="2"`.
+- Result on sailr (24,793 functions w/ surviving artifacts, 21 projects):
+  compile rate **16-39% → ~44-46%**; byte_match mean **0.05 → ~0.19 (3-4×)**;
+  perfect-rate ghidra 0.99%→2.01%, angr 0.62%→0.91%.
+
+### Offline re-eval (no re-decompile)
+- `scripts/reeval_bytematch.py` (NEW): parallel (spawn), resumable per-binary
+  recompute of byte_match from stored `decompiled/*.c` + `compiled/` binaries.
+  Gotcha found: the on-disk results tree is a **partial snapshot** — whole
+  projects (tar, libedit, openssh, ...) have no `.c`/binaries; binaries can have
+  extensions (`psize.aux`) or be shared libs (`libedit.so.0.0.70`).
+- `scripts/rebuild_function_data.py` (NEW): merges new byte_match (DROPS it where
+  the artifact is gone, so the column is uniformly the new metric), builds
+  Compare `samples` + `Hardest` (with source), `compile_rates`, recomputes the
+  scoreboard. Originals backed up to `*.orig.*`.
+
+### Source extraction (Compare view)
+- `decbench/utils/source_extract.py` (NEW): DWARF decl_file/line + brace-matching
+  (string/char/comment aware) to slice one function's original source out of the
+  per-binary `.c`. Definition-vs-call disambiguation requires `{` after `)`.
+
+### Report (`decbench/rendering/html.py`, rewritten)
+- Left **sidebar** SPA (view routing via `location.hash`), dataset selector +
+  stats in the sidebar.
+- **Leaderboard**: swebench-style sortable table (rows=decompilers, cols=Overall
+  + per-metric perfect % + Compiles), recomputes live over the dataset.
+- **Metrics** page explaining the 3 goals (structure/types/recompilation) and the
+  "perfect on all 3 = source recovered" framing → the Overall column.
+- **Compare**: source vs each decompiler side-by-side w/ per-metric scores.
+- Hardest now shows source too; Historical unchanged. All code-derived text is
+  HTML-escaped (XSS-safe). Verified end-to-end in jsdom (no runtime errors) +
+  headless-Chrome screenshots.
+- `models/function_data.py`: `SampleEntry`, `FunctionData.samples`,
+  `FunctionData.compile_rates`. `report_extras.attach_extras` now also builds
+  samples + compile rates (live-run path).
+
+Tests: +`test_byte_match_fixup.py`, +`test_source_extract.py`,
++`test_report_extras.py`; updated the e2e report assertions to the new markup.
+Full suite **120 passed, 2 skipped** (excluding the env-broken Ghidra smoke
+test). ruff/black clean on changed files (html.py gets a per-file E501 ignore —
+it embeds CSS/JS/HTML).

--- a/README.md
+++ b/README.md
@@ -10,9 +10,29 @@ DecBench evaluates decompilers using three core metrics:
 |--------|-----------------|--------------|
 | **Structural Correctness (GED)** | Control flow recovery | Graph Edit Distance between source and decompiled CFGs using [cfgutils](https://github.com/angr/cfgutils) |
 | **Type Correctness** | Variable type recovery | Compares decompiled variable types against DWARF debug info ground truth |
-| **Recompilation Bytematch** | Semantic equivalence | Recompiles decompiled code with gcc, compares assembly via Jaccard similarity |
+| **Recompilation Bytematch** | Recompilable, semantically-equivalent code | Recompiles each decompiled function with the **original toolchain** (matching its format/arch/opt flags) after a compilability **fixup** pass, then diffs the assembly via Jaccard similarity with linker-dependent operands normalized away |
 
-An **Overall** score tracks the percentage of functions where a decompiler achieves a perfect match on *all three* metrics simultaneously.
+An **Overall** score tracks the percentage of functions where a decompiler achieves a perfect match on *all three* metrics simultaneously — i.e. the source was precisely recovered.
+
+### Byte-match fairness (fixup + normalization)
+
+Raw decompiler output rarely recompiles as-is (Ghidra emits pseudo-types like
+`undefined4`/`code`; angr emits illegal `GLIBC_2.2.5::stderr` tokens), so naive
+recompilation scores almost everything 0. To measure *logic* recovery fairly,
+the byte-match metric applies the same two passes to every decompiler:
+
+- **Compilability fixup** (`decbench/metrics/fixup.py`) — a deterministic,
+  algorithmic (no LLM) gcc-diagnostic-driven self-repair loop: it strips illegal
+  tokens, then injects *only* what the compiler reports missing (typedefs for
+  pseudo-types, stubs for undeclared symbols), never redefining what the
+  decompiler already declared. Raised the compile rate from ~16–39% to ~44–46%.
+- **Operand normalization** — branch/call targets and PC-relative (`[rip±x]`,
+  AArch64 `adrp`) displacements are link-time-dependent, so they're blanked
+  before diffing; otherwise an unlinked `call` displacement counts as a mismatch.
+
+Type recovery is scored separately (Type Correctness), so fixing types just to
+compile does not inflate this metric. Each function also records whether it
+recompiled at all, surfaced as the report's per-decompiler **compile rate**.
 
 ## Pipeline
 
@@ -49,6 +69,67 @@ decbench list-decompilers
 decbench list-metrics
 ```
 
+## Generating results
+
+`decbench run` works for a single project, but real benchmark runs use the
+resilient drivers in `scripts/` — they checkpoint per project (so a multi-hour
+run survives crashes) and use the `spawn` multiprocessing context (the default
+`fork` deadlocks workers once angr's threads are live).
+
+```bash
+# 1. Compile every project at every opt level into a results tree.
+GHIDRA_INSTALL_DIR=/path/to/ghidra \
+  python scripts/compile_all.py results/sailr_full 16        # 16 workers
+
+# 2. Decompile + evaluate + write the scoreboard, function data, and report.
+DECBENCH_WORKERS=40 DECBENCH_DECOMPILERS=angr,ghidra \
+  GHIDRA_INSTALL_DIR=/path/to/ghidra \
+  python scripts/run_benchmark.py results/sailr_full
+#   Restart resumes from per-project checkpoints.
+#   `... results/sailr_full -- grep` limits to named projects.
+```
+
+This produces, under `results/sailr_full/`:
+
+- `scoreboard.toml` — machine-readable per-metric + overall scores
+- `function_results.json` — the per-function dataset the HTML report embeds
+  (values, perfect flags, dataset tags, side-by-side **samples** with source,
+  **hardest** functions, per-decompiler **compile rates**)
+- `<opt>/<project>/{compiled,decompiled,evaluated}/` — intermediate artifacts
+
+### Re-scoring byte-match without re-decompiling
+
+Decompilation is the slow part. To re-score **only** byte-match over an existing
+results tree (e.g. after a metric change) — reusing the stored `decompiled/*.c`
+and `compiled/` binaries — run the two offline scripts, then re-render:
+
+```bash
+python scripts/reeval_bytematch.py results/sailr_full 40      # -> byte_match_new.json (parallel, resumable)
+python scripts/rebuild_function_data.py results/sailr_full    # -> refreshed function_results.json + scoreboard.toml
+decbench report results/sailr_full/scoreboard.toml -o results/sailr_full/report.html
+```
+
+## Rendering the site
+
+```bash
+# Render the interactive HTML report next to a scoreboard. If a sibling
+# function_results.json exists, the report is fully interactive.
+decbench report results/sailr_full/scoreboard.toml -o results/sailr_full/report.html
+```
+
+The report is a **self-contained single-page app** (no server, no external
+assets beyond a web font) themed in a terminal aesthetic. A left **sidebar**
+switches between views and holds a **dataset selector** (`full` / `hard` /
+`hard-inlined` / `tiny`) that live-recomputes every score client-side:
+
+| View | What it shows |
+|------|---------------|
+| **Leaderboard** | swebench-style ranked table — one row per decompiler, columns for Overall + each metric's perfect % + compile rate; sortable by any column |
+| **Metrics** | the three decompilation goals, the metric for each, and per-decompiler perfect/compile rates |
+| **Compare** | original source side-by-side with each decompiler's output for a curated set of functions, with per-metric scores |
+| **Hardest** | the worst-scoring functions, with decompiled code and source |
+| **Historical** | per-metric perfect % across decompiler versions (e.g. `ghidra@12.0` vs `ghidra@12.1`) |
+
 ## Project Configuration
 
 Projects are defined via TOML files:
@@ -77,11 +158,12 @@ base_flags = ["-g", "-fno-inline", "-fno-builtin"]
 
 After running the pipeline, DecBench generates:
 
-- **Scoreboard** (`scoreboard.toml`) - Machine-readable results
-- **HTML Report** - Self-contained dark-themed page with rankings per metric and overall
-- **Per-binary TOML files** - Detailed per-function metric values
+- **Scoreboard** (`scoreboard.toml`) — machine-readable per-metric + overall scores
+- **Function data** (`function_results.json`) — per-function dataset embedded by the report
+- **HTML Report** — the interactive single-page site described in [Rendering the site](#rendering-the-site)
+- **Per-binary TOML files** — detailed per-function metric values
 
-Example output:
+`decbench run` also prints a text scoreboard to the terminal, e.g.:
 ```
 ============================================================
   DecBench Scoreboard
@@ -122,13 +204,15 @@ mypy decbench
 ```
 decbench/
   pipeline/         # compile -> decompile -> evaluate orchestration
-  metrics/          # ged.py, type_match.py, byte_match.py
+  metrics/          # ged.py, type_match.py, byte_match.py, fixup.py
   decompilers/      # angr, ghidra, ida plugins
   compilers/        # gcc plugin
   models/           # Pydantic data models
-  scoring/          # aggregation and scoreboard generation
-  rendering/        # HTML report renderer
+  scoring/          # aggregation, scoreboard, datasets, report extras
+  rendering/        # html.py — interactive single-page report
+  utils/            # binfmt.py, source_extract.py, cfg.py
   cli.py            # Click-based CLI
+scripts/            # scalable run drivers + offline byte-match re-eval/rebuild
 ```
 
 ## Dependencies

--- a/decbench/decompilers/raw/angr_raw.py
+++ b/decbench/decompilers/raw/angr_raw.py
@@ -43,6 +43,11 @@ class RawAngrDecompiler(Decompiler):
     name = "angr"
     display_name = "angr"
 
+    # Which structuring algorithm to drive angr with. ``None`` uses angr's
+    # default (currently SAILR). Subclasses set this to "Phoenix"/"DREAM" to
+    # benchmark a specific structurer as its own decompiler (see RawAngrPhoenix).
+    structurer: str | None = None
+
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
@@ -147,16 +152,16 @@ class RawAngrDecompiler(Decompiler):
                 target_funcs = self._enumerate(proj, elf_base, text_range)
 
             target_funcs = common.narrow_to_source(
-                target_funcs, function_names, backend="angr",
+                target_funcs,
+                function_names,
+                backend="angr",
                 binary_name=binary_path.name,
             )
 
             for func_name, file_addr in target_funcs:
                 func_result = None
                 try:
-                    func_result = self._decompile_one(
-                        proj, cfg, func_name, file_addr, elf_base
-                    )
+                    func_result = self._decompile_one(proj, cfg, func_name, file_addr, elf_base)
                 except Exception as e:  # noqa: BLE001
                     _l.debug("angr-raw: failed to decompile %s: %s", func_name, e)
 
@@ -229,9 +234,7 @@ class RawAngrDecompiler(Decompiler):
     def _angr_load_base(proj: Any) -> int:
         """The address angr loaded the main object at (its min mapped vaddr)."""
         try:
-            return int(proj.loader.main_object.mapped_base) or int(
-                proj.loader.main_object.min_addr
-            )
+            return int(proj.loader.main_object.mapped_base) or int(proj.loader.main_object.min_addr)
         except Exception:  # noqa: BLE001
             return 0
 
@@ -254,7 +257,18 @@ class RawAngrDecompiler(Decompiler):
             if func is None:
                 return None
 
-        dec = proj.analyses.Decompiler(func, cfg=cfg.model)
+        dec_kwargs: dict[str, Any] = {"cfg": cfg.model}
+        if self.structurer is not None:
+            # Select a specific structuring algorithm via angr's options system
+            # (value is convert()ed to the structurer class by the option).
+            from angr.analyses.decompiler.decompilation_options import (
+                get_structurer_option,
+            )
+
+            opt = get_structurer_option()
+            if opt is not None:
+                dec_kwargs["options"] = [(opt, self.structurer)]
+        dec = proj.analyses.Decompiler(func, **dec_kwargs)
         codegen = getattr(dec, "codegen", None)
         if codegen is None or not getattr(codegen, "text", None):
             return None
@@ -291,9 +305,7 @@ class RawAngrDecompiler(Decompiler):
         except Exception:  # noqa: BLE001
             return ""
 
-    def _extract_variables(
-        self, codegen: Any, proj: Any, func: Any
-    ) -> list[VariableInfo]:
+    def _extract_variables(self, codegen: Any, proj: Any, func: Any) -> list[VariableInfo]:
         """Pull arguments (ABI order) and stack/local variables.
 
         Arguments come from ``cfunc.arg_list`` (preserving ABI order, so the
@@ -312,11 +324,12 @@ class RawAngrDecompiler(Decompiler):
         # --- Arguments, in ABI/positional order. ---
         arg_list = getattr(cfunc, "arg_list", None) or []
         for position, cvar in enumerate(arg_list):
-            simvar = getattr(cvar, "unified_variable", None) or getattr(
-                cvar, "variable", None
+            simvar = getattr(cvar, "unified_variable", None) or getattr(cvar, "variable", None)
+            name = (
+                getattr(cvar, "name", None)
+                or (getattr(simvar, "name", None) if simvar else None)
+                or ""
             )
-            name = (getattr(cvar, "name", None)
-                    or (getattr(simvar, "name", None) if simvar else None) or "")
             vtype = self._type_str(
                 getattr(cvar, "variable_type", None) or getattr(cvar, "type", None)
             )
@@ -346,9 +359,7 @@ class RawAngrDecompiler(Decompiler):
                     break
             stack_offset = None
             if isinstance(simvar, SimStackVariable):
-                stack_offset = (
-                    int(simvar.offset) if simvar.offset is not None else None
-                )
+                stack_offset = int(simvar.offset) if simvar.offset is not None else None
             size = getattr(simvar, "size", None)
             variables.append(
                 VariableInfo(
@@ -404,3 +415,17 @@ class RawAngrDecompiler(Decompiler):
             line_to_addrs.setdefault(line_no, set()).add(file_addr)
 
         return common.merge_line_addresses(line_to_addrs)
+
+
+@register_decompiler("phoenix")
+class RawAngrPhoenixDecompiler(RawAngrDecompiler):
+    """angr driven with the **Phoenix** structuring algorithm.
+
+    Same native angr pipeline as :class:`RawAngrDecompiler`, but forces the
+    Phoenix structurer instead of angr's default (SAILR), so the two appear as
+    distinct decompilers in the benchmark.
+    """
+
+    name = "phoenix"
+    display_name = "angr (Phoenix)"
+    structurer = "Phoenix"

--- a/decbench/decompilers/raw/binja_raw.py
+++ b/decbench/decompilers/raw/binja_raw.py
@@ -154,7 +154,9 @@ class RawBinjaDecompiler(Decompiler):
                 requested = {n for (n, _a) in functions}
                 enumerated = [(n, a) for (n, a) in enumerated if n in requested]
             enumerated = common.narrow_to_source(
-                enumerated, function_names, backend="binja",
+                enumerated,
+                function_names,
+                backend="binja",
                 binary_name=binary_path.name,
             )
             load_base = self._binja_load_base(bv)
@@ -166,9 +168,7 @@ class RawBinjaDecompiler(Decompiler):
                 func = by_addr.get(binja_addr)
                 if func is not None:
                     try:
-                        func_result = self._decompile_one(
-                            func, func_name, file_addr
-                        )
+                        func_result = self._decompile_one(func, func_name, file_addr)
                     except Exception as e:  # noqa: BLE001
                         _l.debug("binja-raw: failed to decompile %s: %s", func_name, e)
                 if func_result is not None:
@@ -271,30 +271,37 @@ class RawBinjaDecompiler(Decompiler):
 
     @staticmethod
     def _render_c(func: Any) -> str:
-        """Render a function's High Level IL as C-ish pseudocode text.
+        """Render a function as Binary Ninja **pseudo-C** text.
 
-        Binary Ninja exposes a language-representation renderer; we prefer the C
-        view of HLIL and fall back to the plain HLIL string form.
+        Uses the linear-view *language representation* (the "Pseudo C" view),
+        which emits real C-like source — proper signature, braces, ``int32_t``,
+        ``return f(...)`` — so it parses (GED) and compiles (byte_match) like the
+        other decompilers. The raw HLIL form (``func.hlil.lines``: ``rax = ...``,
+        ``u>``, no braces) does NOT, which previously made GED/byte_match score
+        binja near-zero. Falls back to HLIL only if the linear view is
+        unavailable.
         """
         try:
-            from binaryninja import DisassemblyTextLine  # noqa: F401
-            from binaryninja.enums import LanguageRepresentationType  # noqa: F401
+            import binaryninja as bn
+
+            settings = bn.DisassemblySettings()
+            lvo = bn.LinearViewObject.single_function_language_representation(func, settings)
+            cursor = bn.LinearViewCursor(lvo)
+            cursor.seek_to_begin()
+            lines: list[str] = []
+            # Bound the walk so a pathological function can't spin forever.
+            for _ in range(100000):
+                for ln in cursor.lines:
+                    lines.append(str(ln))
+                if not cursor.next():
+                    break
+            text = "\n".join(lines).strip("\n")
+            if text.strip():
+                return text
         except Exception:  # noqa: BLE001
             pass
 
-        # Preferred: the C language representation of HLIL, if available.
-        try:
-            hlil = func.hlil
-            if hlil is not None:
-                lines: list[str] = []
-                for instr in hlil.root.lines if hasattr(hlil, "root") else hlil.lines:
-                    lines.append(str(instr))
-                if lines:
-                    return "\n".join(lines)
-        except Exception:  # noqa: BLE001
-            pass
-
-        # Fallback: stringify HLIL directly.
+        # Fallback: stringify HLIL directly (not valid C, but better than empty).
         try:
             return "\n".join(str(line) for line in func.hlil.lines)
         except Exception:  # noqa: BLE001

--- a/decbench/decompilers/raw/common.py
+++ b/decbench/decompilers/raw/common.py
@@ -38,12 +38,24 @@ _l = logging.getLogger(__name__)
 
 # CRT/compiler-generated functions that are not user code. Copied verbatim
 # from declib_dec so the raw backends discover the same benchmarkable set.
-SKIP_NAMES = frozenset({
-    "_start", "__libc_start_main", "__libc_csu_init", "__libc_csu_fini",
-    "_init", "_fini", "__do_global_dtors_aux", "register_tm_clones",
-    "deregister_tm_clones", "frame_dummy", "__libc_start_call_main",
-    "_dl_relocate_static_pie", "__gmon_start__", "__stack_chk_fail",
-})
+SKIP_NAMES = frozenset(
+    {
+        "_start",
+        "__libc_start_main",
+        "__libc_csu_init",
+        "__libc_csu_fini",
+        "_init",
+        "_fini",
+        "__do_global_dtors_aux",
+        "register_tm_clones",
+        "deregister_tm_clones",
+        "frame_dummy",
+        "__libc_start_call_main",
+        "_dl_relocate_static_pie",
+        "__gmon_start__",
+        "__stack_chk_fail",
+    }
+)
 
 # Name prefixes for thunks/imports that should not be benchmarked.
 SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
@@ -61,11 +73,7 @@ def elf_min_vaddr(binary_path: Path) -> int:
 
         with open(binary_path, "rb") as f:
             elf = ELFFile(f)
-            vaddrs = [
-                seg["p_vaddr"]
-                for seg in elf.iter_segments()
-                if seg["p_type"] == "PT_LOAD"
-            ]
+            vaddrs = [seg["p_vaddr"] for seg in elf.iter_segments() if seg["p_type"] == "PT_LOAD"]
             return min(vaddrs) if vaddrs else 0
     except Exception as e:  # noqa: BLE001
         _l.debug("Failed to read ELF min vaddr for %s: %s", binary_path, e)
@@ -135,25 +143,30 @@ def should_skip_function(
 
 def narrow_to_source(
     target_funcs: list[tuple[str, int]],
-    function_names: set[str] | None,
+    target_addrs: set[int] | None,
     *,
     backend: str,
     binary_name: str,
 ) -> list[tuple[str, int]]:
-    """Optionally restrict to the project's own source functions.
+    """Restrict to the project's own source functions BY ADDRESS.
 
-    Mirrors ``declib_dec.decompile_binary``: if ``function_names`` is given and
-    actually matches some enumerated functions, restrict to that intersection;
-    otherwise (no match — e.g. stripped/renamed binary) fall back to the full
-    list rather than producing an empty result.
+    The decompiler is given a fully-stripped binary (no symbols), so it knows
+    functions only by address; ``target_addrs`` is the set of DWARF low_pc
+    addresses (ELF-file space) for the project's source functions. We keep the
+    enumerated functions whose address is in that set. If nothing matches (an
+    unexpected address-space mismatch) we fall back to the full list rather than
+    silently producing an empty result.
     """
-    if not function_names:
+    if not target_addrs:
         return target_funcs
-    filtered = [(n, a) for (n, a) in target_funcs if n in function_names]
+    filtered = [(n, a) for (n, a) in target_funcs if a in target_addrs]
     if filtered:
         _l.debug(
             "raw/%s: filtered %d/%d functions to source set for %s",
-            backend, len(filtered), len(target_funcs), binary_name,
+            backend,
+            len(filtered),
+            len(target_funcs),
+            binary_name,
         )
         return filtered
     return target_funcs
@@ -223,9 +236,7 @@ def merge_line_addresses(
         addrs = line_to_addrs[line_num]
         if not addrs:
             continue
-        out.append(
-            LineMapping(line_number=int(line_num), addresses=sorted(int(a) for a in addrs))
-        )
+        out.append(LineMapping(line_number=int(line_num), addresses=sorted(int(a) for a in addrs)))
     return out
 
 

--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -9,8 +9,7 @@ Based on the approach from Decomperson (USENIX Security 2022).
 from __future__ import annotations
 
 import logging
-import subprocess
-import tempfile
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,12 +25,108 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Branch/call mnemonics whose operand is a code address. After single-function
+# recompilation that target is an *unlinked* relative displacement (or a
+# different absolute, since we disassemble the original at its real vaddr and the
+# recompiled object at 0), so the printed target is layout/linker-dependent and
+# must be normalized away before diffing — otherwise every call/jump counts as a
+# mismatch even when the control flow is identical.
+_BRANCH_MNEMONICS = frozenset(
+    {
+        "call",
+        "jmp",
+        "loop",
+        "loope",
+        "loopne",
+        "jecxz",
+        "jrcxz",
+        "je",
+        "jne",
+        "jz",
+        "jnz",
+        "jg",
+        "jge",
+        "jl",
+        "jle",
+        "ja",
+        "jae",
+        "jb",
+        "jbe",
+        "jc",
+        "jnc",
+        "js",
+        "jns",
+        "jo",
+        "jno",
+        "jp",
+        "jnp",
+        "jpe",
+        "jpo",
+        "jcxz",
+        # ARM / AArch64 branches.
+        "b",
+        "bl",
+        "blx",
+        "bx",
+        "beq",
+        "bne",
+        "bcs",
+        "bcc",
+        "bmi",
+        "bpl",
+        "bvs",
+        "bvc",
+        "bhi",
+        "bls",
+        "bge",
+        "blt",
+        "bgt",
+        "ble",
+        "cbz",
+        "cbnz",
+    }
+)
+
+# An immediate hex literal, optionally ARM-style ``#``-prefixed (and possibly
+# negative): matches ``0x40``, ``#0x40``, ``#-0x40``.
+_HEX_TOKEN = re.compile(r"#?-?0x[0-9a-fA-F]+")
+# A PC/IP-relative *memory* operand: x86 ``[rip + 0x..]`` / ``[rip - 0x..]`` and
+# AArch64 literal loads ``[pc, #0x..]``. The displacement encodes a data/GOT
+# offset fixed up at link time, so it is layout-dependent and gets a placeholder.
+_PC_REL_MEM = re.compile(r"\[(rip|pc)\s*[+\-,]\s*#?-?0x[0-9a-fA-F]+\]")
+# AArch64 PC-relative *address* computations whose immediate is the (page)
+# target itself — capstone prints e.g. ``adrp x0, #0x400000``.
+_PC_REL_MNEMONICS = frozenset({"adrp", "adr"})
+
+
+def _normalize_operands(mnemonic: str, op_str: str) -> str:
+    """Replace layout/linker-dependent operand values with a stable placeholder.
+
+    Branch/call targets and PC-relative displacements differ between the
+    original (linked, at its real vaddr) and the recompiled single-function
+    object (unlinked, based at 0) even when the instruction is semantically the
+    same. We blank those so the diff measures *real* assembly differences, not
+    relocation noise — the central fairness fix for this metric.
+    """
+    # PC-relative data references: [rip + 0x..] / [pc, #0x..] -> [<base>+X]
+    op_str = _PC_REL_MEM.sub(lambda m: f"[{m.group(1)}+X]", op_str)
+    # Blank the immediate when it IS a link-dependent address: AArch64 adrp/adr
+    # (the immediate is the PC-relative target), or a DIRECT branch/call target
+    # (a bare address, no memory operand). An indirect ``call [rax + 0x20]``
+    # displacement is a base-independent struct/vtable offset — a real difference
+    # we keep — so memory-operand branches are excluded.
+    if mnemonic in _PC_REL_MNEMONICS or (mnemonic in _BRANCH_MNEMONICS and "[" not in op_str):
+        op_str = _HEX_TOKEN.sub("X", op_str)
+    return op_str
+
+
 def _disassemble_bytes(data: bytes, address: int = 0, arch_mode: tuple | None = None) -> list[str]:
     """Disassemble bytes to normalized assembly lines using capstone.
 
     ``arch_mode`` is a (capstone arch, capstone mode) tuple matching the
     binary's architecture (x86-32/64, ARM, ...). Defaults to x86-64.
-    Normalizes addresses and skips nops for stable comparison.
+    Skips nops (alignment padding) and normalizes layout/linker-dependent
+    operands (branch targets, PC-relative displacements) for a fair comparison.
     """
     try:
         import capstone
@@ -47,11 +142,7 @@ def _disassemble_bytes(data: bytes, address: int = 0, arch_mode: tuple | None = 
             if insn.mnemonic == "nop":
                 continue
 
-            # Normalize: use mnemonic + op_str, replacing absolute addresses
-            op_str = insn.op_str
-
-            # Replace absolute addresses with generic placeholders
-            # This makes the comparison more robust to address layout differences
+            op_str = _normalize_operands(insn.mnemonic, insn.op_str)
             line = f"{insn.mnemonic} {op_str}".strip()
             lines.append(line)
 
@@ -125,42 +216,13 @@ def _compile_function(
 ) -> Path | None:
     """Compile a single function's decompiled code to an object file.
 
-    Returns path to the object file, or None if compilation failed.
+    Thin wrapper over :func:`decbench.metrics.fixup.compile_with_fixup` (which
+    maximizes the odds the code builds). Returns the object path or ``None``.
     """
-    if flags is None:
-        flags = ["-O2", "-c"]
+    from decbench.metrics.fixup import compile_with_fixup
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".c", delete=False, prefix=f"decbench_{func_name}_"
-    ) as src_file:
-        # Add minimal headers
-        src_file.write("#include <stdint.h>\n")
-        src_file.write("#include <stddef.h>\n")
-        src_file.write("#include <stdbool.h>\n")
-        src_file.write("#include <stdlib.h>\n")
-        src_file.write("#include <string.h>\n")
-        src_file.write("#include <stdio.h>\n\n")
-        src_file.write(code)
-        src_path = Path(src_file.name)
-
-    obj_path = src_path.with_suffix(".o")
-
-    try:
-        cmd = [compiler, *flags, "-o", str(obj_path), str(src_path)]
-        result = subprocess.run(cmd, capture_output=True, timeout=30)
-
-        if result.returncode != 0:
-            return None
-
-        if not obj_path.exists():
-            return None
-
-        return obj_path
-
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    finally:
-        src_path.unlink(missing_ok=True)
+    result = compile_with_fixup(code, func_name, compiler, flags)
+    return result.obj_path
 
 
 @register_metric("byte_match")
@@ -185,6 +247,11 @@ class ByteMatchMetric(Metric):
 
     requires_source_cfg = False
     requires_decompiled_cfg = False
+
+    # v3: compilability fixup pass (decbench/metrics/fixup.py) + operand
+    # normalization (branch targets, x86 rip- and ARM pc-relative; indirect-branch
+    # displacements preserved).
+    cache_version = "3"
 
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)
@@ -275,22 +342,34 @@ class ByteMatchMetric(Metric):
         flags: list[str],
         arch_mode: tuple | None,
     ) -> MetricValue:
+        import shutil
+
+        from decbench.metrics.fixup import compile_with_fixup
         from decbench.utils import binfmt
 
-        # Compile decompiled code the same way as source (matching toolchain).
-        obj_path = _compile_function(
-            decompiled.decompiled_code,
-            decompiled.name,
-            compiler,
-            flags,
-        )
+        # Compile decompiled code the same way as source (matching toolchain),
+        # running the fixup/self-repair pass so the maximum number of functions
+        # build (otherwise non-compiling code is a flat 0 and dominates).
+        fix = compile_with_fixup(decompiled.decompiled_code, decompiled.name, compiler, flags)
+        obj_path = fix.obj_path
 
         if obj_path is None:
             return MetricValue(
                 value=0.0,
-                metadata={"compilable": False, "error": "Compilation failed"},
+                metadata={
+                    "compilable": False,
+                    "fixup_iterations": fix.iterations,
+                    "error": "Compilation failed",
+                },
             )
 
+        # The fixup pass places the object in its own temp dir; clean the dir.
+        obj_dir = obj_path.parent
+        fixup_meta = {
+            "compilable": True,
+            "fixup_iterations": fix.iterations,
+            "fixup_injected": len(fix.injected),
+        }
         try:
             # Extract recompiled function bytes (.text of the single-function
             # object — ELF or COFF/MinGW).
@@ -299,7 +378,7 @@ class ByteMatchMetric(Metric):
             if recompiled_bytes is None:
                 return MetricValue(
                     value=0.0,
-                    metadata={"compilable": True, "error": "Could not extract recompiled bytes"},
+                    metadata={**fixup_meta, "error": "Could not extract recompiled bytes"},
                 )
 
             # First check exact byte match
@@ -308,7 +387,7 @@ class ByteMatchMetric(Metric):
                     value=1.0,
                     raw_value=True,
                     metadata={
-                        "compilable": True,
+                        **fixup_meta,
                         "exact_match": True,
                         "original_size": len(original_bytes),
                         "recompiled_size": len(recompiled_bytes),
@@ -338,7 +417,7 @@ class ByteMatchMetric(Metric):
                 value=1.0 if similarity == 1.0 else similarity,
                 raw_value=similarity,
                 metadata={
-                    "compilable": True,
+                    **fixup_meta,
                     "exact_match": False,
                     "jaccard_similarity": similarity,
                     "original_size": len(original_bytes),
@@ -349,8 +428,7 @@ class ByteMatchMetric(Metric):
             )
 
         finally:
-            if obj_path:
-                obj_path.unlink(missing_ok=True)
+            shutil.rmtree(obj_dir, ignore_errors=True)
 
     def compute_for_binary(
         self,
@@ -367,6 +445,31 @@ class ByteMatchMetric(Metric):
         errors: list[str] = []
 
         original_binary_path = decompilation.binary_path
+
+        # ABSTAIN (emit no per-function results) when the matching recompile
+        # toolchain isn't installed for this binary's format/arch — e.g. ARM
+        # firmware (cps) or PE malware decompiled on an x86 host without the
+        # cross/mingw gcc. Scoring those 0 would be unfair ("couldn't measure" is
+        # not "wrong"); abstaining drops byte_match for the binary so GED +
+        # type_match carry it (per-metric denominators already differ).
+        if original_binary_path is not None:
+            from decbench.utils import binfmt
+
+            info = binfmt.detect(original_binary_path)
+            if info is not None:
+                recompiler = binfmt.recompiler_for(info)
+                if recompiler is None or not binfmt.tool_available(recompiler):
+                    return MetricResult(
+                        metric_name=self.name,
+                        decompiler_name=decompilation.decompiler.decompiler_name,
+                        binary_name=decompilation.binary_name,
+                        function_results={},
+                        computation_time_seconds=time.time() - start_time,
+                        errors=[
+                            f"abstained: no recompile toolchain ({recompiler}) "
+                            f"for {info.fmt}/{info.arch}"
+                        ],
+                    )
 
         for func_name, func_decomp in decompilation.functions.items():
             try:

--- a/decbench/metrics/fixup.py
+++ b/decbench/metrics/fixup.py
@@ -1,0 +1,280 @@
+"""Compilability fixup for decompiled C (the byte-match preprocessing pass).
+
+Decompiler output rarely compiles as-is: Ghidra emits pseudo-types it never
+defines (``undefined4``, ``code``, ``uint``), angr emits illegal C tokens like
+``GLIBC_2.2.5::stderr`` (symbol-version names) and calls helpers that have no
+declaration. The recompilation byte-match metric scores any non-compiling
+function as 0, so this pass exists to give every decompiler a fair shot at
+recompiling: we *maximize compilation* by repairing the code the same way for
+everyone, then let the (operand-normalized) assembly diff judge correctness.
+
+Strategy — deliberately conflict-safe:
+
+1. **Token sanitization** removes constructs no C compiler accepts (``NS::id``
+   version names) but that are unambiguous in decompiler output.
+2. **Minimal includes** (``stdint``/``stddef`` only) — NOT the full stdlib —
+   so the scaffolding never collides with a decompiler's own ``typedef struct
+   FILE {}`` etc. (forcing ``stdio.h`` was a real cause of redefinition errors).
+3. **gcc-error-driven self-repair**: compile, read the diagnostics, and inject
+   *only* the declarations gcc says are missing (``unknown type name`` →
+   ``typedef``; ``implicit declaration`` → function decl; ``undeclared`` →
+   global). Because we add only what the compiler asks for, we never redefine
+   something the decompiler already declared. Conflicts that we *do* cause
+   (rare) are detected and the offending injected decl is withdrawn.
+
+The cost is some ABI/codegen noise (a synthesized ``long foo();`` may not match
+the real signature), but the metric's operand normalization absorbs the largest
+source of that noise (call/branch targets), and the alternative — scoring 84% of
+Ghidra functions as a flat 0 because they reference ``undefined4`` — is far less
+fair. Applied uniformly to all decompilers, this isolates *logic* recompilation
+from *type recovery* (which ``type_match`` measures separately).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# gcc localizes diagnostics and (by default) quotes identifiers with Unicode
+# curly quotes (' ') — force the C locale so it emits plain ASCII quotes that the
+# repair regexes below can match. (The regexes also accept curly quotes as a
+# fallback, in case a toolchain ignores the locale.)
+_C_LOCALE_ENV = {**os.environ, "LC_ALL": "C", "LANG": "C", "LANGUAGE": "C"}
+_Q = r"['‘’“”]"  # ascii ' or " plus curly variants
+
+# Strip a leading ``Namespace::`` qualifier (e.g. ``GLIBC_2.2.5::stderr`` ->
+# ``stderr``). Decompiled C never uses real C++ scope resolution, so any ``::``
+# is a symbol-version artifact we can safely drop.
+_NS_QUALIFIER = re.compile(r"\b[A-Za-z_][\w.$]*::")
+
+# Decompiler-specific function/type ANNOTATIONS that aren't valid C in the place
+# they appear (Binary Ninja's ``__noreturn``/``__convention("...")``/``__pure``
+# suffixes, IDA/Ghidra ``__cdecl``/``__fastcall``/``__thiscall`` calling-conv
+# keywords, ``__packed``). Dropping them lets the body still compile; they don't
+# affect the recovered logic the byte-match is measuring.
+_ANNOTATIONS = re.compile(
+    r"\b__(?:noreturn|pure|const|packed|noreturn__|hidden|usercall|userpurge"
+    r"|cdecl|stdcall|fastcall|thiscall|vectorcall)\b"
+    r"|\b__convention\s*\([^)]*\)"
+    r'|\b__(?:reg|stack)\s*\("[^"]*"\)'
+)
+
+# Minimal, conflict-safe scaffolding. Only fixed-width int + size types; nothing
+# that defines FILE/struct names a decompiler might also define.
+_MINIMAL_INCLUDES = "#include <stdint.h>\n#include <stddef.h>\n"
+
+# Sensible C type for a Ghidra/IDA/angr pseudo-type, chosen so the *width* (and
+# thus most codegen) matches. Anything unknown falls back to ``long``.
+_TYPE_GUESS: dict[str, str] = {
+    "undefined": "unsigned char",
+    "undefined1": "unsigned char",
+    "undefined2": "unsigned short",
+    "undefined3": "unsigned int",
+    "undefined4": "unsigned int",
+    "undefined5": "unsigned long",
+    "undefined6": "unsigned long",
+    "undefined7": "unsigned long",
+    "undefined8": "unsigned long",
+    "byte": "unsigned char",
+    "uchar": "unsigned char",
+    "sbyte": "signed char",
+    "ushort": "unsigned short",
+    "word": "unsigned short",
+    "uint": "unsigned int",
+    "dword": "unsigned int",
+    "uint3": "unsigned int",
+    "ulong": "unsigned long",
+    "qword": "unsigned long",
+    "uint5": "unsigned long",
+    "uint6": "unsigned long",
+    "uint7": "unsigned long",
+    "ulonglong": "unsigned long long",
+    "longlong": "long long",
+    "code": "void",
+    "pointer": "void *",
+    "__int8": "char",
+    "__int16": "short",
+    "__int32": "int",
+    "__int64": "long long",
+    "__uint8": "unsigned char",
+    "__uint16": "unsigned short",
+    "__uint32": "unsigned int",
+    "__uint64": "unsigned long long",
+    "float10": "long double",
+    "unkbyte10": "long double",
+    "unkuint10": "long double",
+}
+
+_MAX_REPAIR_ITERS = 8
+
+
+def sanitize_tokens(code: str) -> str:
+    """Remove constructs no C compiler accepts but that are unambiguous.
+
+    Currently: strip ``Namespace::`` symbol-version qualifiers (keeping the bare
+    identifier, ``GLIBC_2.2.5::stderr`` -> ``stderr``) and decompiler annotation
+    keywords (``__noreturn``, ``__convention(...)``, ``__cdecl``, ...).
+    """
+    code = _NS_QUALIFIER.sub("", code)
+    code = _ANNOTATIONS.sub("", code)
+    return code
+
+
+def _type_guess(name: str) -> str:
+    """Best-effort concrete C type for an undefined pseudo-type name."""
+    if name in _TYPE_GUESS:
+        return _TYPE_GUESS[name]
+    low = name.lower()
+    if low in _TYPE_GUESS:
+        return _TYPE_GUESS[low]
+    # undefinedN / uintN / intN width hints.
+    m = re.fullmatch(r"u?int(\d+)", low)
+    if m:
+        bits = int(m.group(1))
+        width = "unsigned " if low.startswith("u") else ""
+        if bits <= 8:
+            return f"{width}char"
+        if bits <= 16:
+            return f"{width}short"
+        if bits <= 32:
+            return f"{width}int"
+        return f"{width}long"
+    return "long"
+
+
+@dataclass
+class FixupResult:
+    """Outcome of a fixup compile attempt."""
+
+    obj_path: Path | None
+    source: str
+    compilable: bool
+    iterations: int
+    injected: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+# Diagnostic patterns gcc emits that we know how to repair.
+_RE_UNKNOWN_TYPE = re.compile(rf"unknown type name {_Q}([A-Za-z_]\w*){_Q}")
+_RE_IMPLICIT_FUNC = re.compile(rf"implicit declaration of function {_Q}([A-Za-z_]\w*){_Q}")
+_RE_UNDECLARED = re.compile(rf"{_Q}([A-Za-z_]\w*){_Q} undeclared")
+_RE_NOT_A_FUNC = re.compile(rf"called object {_Q}([A-Za-z_]\w*){_Q}[^\n]*is not a function")
+# A conflict caused by one of OUR injected declarations.
+_RE_CONFLICT = re.compile(
+    r"(?:conflicting types for|redefinition of|redeclared as|previous declaration of) "
+    rf"{_Q}([A-Za-z_]\w*){_Q}"
+)
+
+
+def _build_source(code: str, decls: dict[str, str]) -> str:
+    """Assemble the candidate translation unit: includes + injected decls + code."""
+    inject = "\n".join(decls[k] for k in sorted(decls))
+    return _MINIMAL_INCLUDES + inject + ("\n\n" if inject else "\n") + code
+
+
+def _gcc_compile(
+    src: str, obj_path: Path, compiler: str, flags: list[str]
+) -> subprocess.CompletedProcess:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+        f.write(src)
+        src_path = Path(f.name)
+    try:
+        return subprocess.run(
+            [compiler, *flags, "-o", str(obj_path), str(src_path)],
+            capture_output=True,
+            timeout=30,
+            text=True,
+            env=_C_LOCALE_ENV,
+        )
+    finally:
+        src_path.unlink(missing_ok=True)
+
+
+def compile_with_fixup(
+    code: str,
+    func_name: str,
+    compiler: str = "gcc",
+    flags: list[str] | None = None,
+) -> FixupResult:
+    """Compile decompiled ``code`` to an object file, maximizing the odds it builds.
+
+    Runs token sanitization, then a gcc-diagnostic-driven self-repair loop that
+    injects only the declarations the compiler reports missing. Returns a
+    :class:`FixupResult`; ``obj_path`` is set (and exists) iff compilation
+    eventually succeeded. The caller owns ``obj_path`` and must unlink it.
+    """
+    if flags is None:
+        flags = ["-O2", "-c", "-fno-builtin", "-w"]
+
+    code = sanitize_tokens(code)
+    decls: dict[str, str] = {}
+    # Track which names we injected (so we can withdraw on a conflict we caused).
+    obj_dir = Path(tempfile.mkdtemp(prefix="decbench_bm_"))
+    obj_path = obj_dir / f"{func_name}.o"
+
+    def fail(src: str, iteration: int, error: str) -> FixupResult:
+        # Only the SUCCESS path hands the temp dir to the caller; every failure
+        # must clean it up here or we leak an empty dir per non-compiling func.
+        shutil.rmtree(obj_dir, ignore_errors=True)
+        return FixupResult(None, src, False, iteration, [d for d in decls.values() if d], error)
+
+    last_err = ""
+    for iteration in range(1, _MAX_REPAIR_ITERS + 1):
+        src = _build_source(code, decls)
+        try:
+            proc = _gcc_compile(src, obj_path, compiler, flags)
+        except subprocess.TimeoutExpired:
+            return fail(src, iteration, "timeout")
+        except FileNotFoundError:
+            return fail(src, iteration, "compiler-not-found")
+
+        if proc.returncode == 0 and obj_path.exists():
+            return FixupResult(obj_path, src, True, iteration, [d for d in decls.values() if d])
+
+        last_err = proc.stderr
+        added = False
+
+        # 1) Withdraw any injected decl that caused a conflict, and avoid re-adding.
+        #    Guard on truthiness so an already-blanked (or non-injected) name does
+        #    NOT keep re-firing `added` — otherwise a persistent conflict between
+        #    two decompiler-provided decls burns all _MAX_REPAIR_ITERS gcc runs.
+        for name in _RE_CONFLICT.findall(last_err):
+            if decls.get(name):
+                # Our decl clashed with a decompiler-provided one; drop ours.
+                decls[name] = ""  # blank keeps it "claimed" so we don't re-add
+                added = True
+
+        # 2) unknown type name -> typedef a width-matched concrete type.
+        for name in _RE_UNKNOWN_TYPE.findall(last_err):
+            if name not in decls:
+                decls[name] = f"typedef {_type_guess(name)} {name};"
+                added = True
+
+        # 3) implicit function declaration / called-non-function -> declare a func.
+        for name in set(_RE_IMPLICIT_FUNC.findall(last_err)) | set(
+            _RE_NOT_A_FUNC.findall(last_err)
+        ):
+            decl = f"long {name}();"
+            if decls.get(name) != decl:
+                decls[name] = decl
+                added = True
+
+        # 4) undeclared identifier -> a global (unless we already made it a func).
+        for name in _RE_UNDECLARED.findall(last_err):
+            if name not in decls:
+                decls[name] = f"long {name};"
+                added = True
+
+        if not added:
+            break  # nothing actionable left; give up
+
+    return fail(
+        _build_source(code, decls),
+        iteration,
+        (last_err or "").strip()[-400:] or "unrepairable",
+    )

--- a/decbench/models/function_data.py
+++ b/decbench/models/function_data.py
@@ -25,6 +25,14 @@ class FunctionRecord(BaseModel):
         default_factory=dict,
         description="decompiler -> metric -> whether the value is perfect",
     )
+    decompiled: dict[str, bool] = Field(
+        default_factory=dict,
+        description="decompiler -> whether it successfully produced output for "
+        "this function (False = decompile failed / timed out). The denominator "
+        "for every metric is the set of functions a decompiler decompiled, so "
+        "all metrics share one denominator per decompiler; a missing metric on a "
+        "decompiled function counts as not-perfect.",
+    )
     labels: list[str] = Field(
         default_factory=list,
         description="Labels applied to this function",
@@ -60,11 +68,37 @@ class HardestEntry(BaseModel):
     perfect_value: float = Field(..., description="The value considered perfect")
     size: int | None = Field(default=None, description="Decompiled line count")
     labels: list[str] = Field(default_factory=list)
-    decompiled_code: str | None = Field(
-        default=None, description="Decompiled C for this function"
-    )
+    decompiled_code: str | None = Field(default=None, description="Decompiled C for this function")
     source_code: str | None = Field(
         default=None, description="Best-effort source C for this function"
+    )
+
+
+class SampleEntry(BaseModel):
+    """A curated function shown in the report's side-by-side 'Compare' view.
+
+    Carries the original source next to each decompiler's output (plus per-metric
+    scores) so a reader can eyeball, e.g., Ghidra's recovery against the truth.
+    Bounded server-side to a representative slice (see
+    :func:`decbench.scoring.report_extras.build_samples`) to keep the embedded
+    report small.
+    """
+
+    project: str = Field(...)
+    opt_level: str = Field(...)
+    binary: str = Field(...)
+    function: str = Field(...)
+    size: int | None = Field(default=None, description="Decompiled line count")
+    labels: list[str] = Field(default_factory=list)
+    source_code: str | None = Field(default=None, description="Original source C")
+    decompiled: dict[str, str] = Field(
+        default_factory=dict, description="decompiler id -> decompiled C"
+    )
+    values: dict[str, dict[str, float]] = Field(
+        default_factory=dict, description="decompiler -> metric -> value"
+    )
+    perfects: dict[str, dict[str, bool]] = Field(
+        default_factory=dict, description="decompiler -> metric -> perfect flag"
     )
 
 
@@ -91,16 +125,12 @@ class HistoryPoint(BaseModel):
 
     decompiler: str = Field(..., description="Base decompiler name, e.g. 'ghidra'")
     version: str = Field(..., description="Version label, e.g. '11.3' or '12.1'")
-    date: str | None = Field(
-        default=None, description="ISO date this version is associated with"
-    )
+    date: str | None = Field(default=None, description="ISO date this version is associated with")
     scores: dict[str, float] = Field(
         default_factory=dict,
         description="metric -> perfect percentage at this version",
     )
-    overall: float = Field(
-        default=0.0, description="Overall (perfect on all metrics) percentage"
-    )
+    overall: float = Field(default=0.0, description="Overall (perfect on all metrics) percentage")
 
 
 class BinaryGroup(BaseModel):
@@ -150,6 +180,23 @@ class FunctionData(BaseModel):
     hardest: list[HardestEntry] = Field(
         default_factory=list,
         description="Precomputed 'hardest functions' (worst scores) with code",
+    )
+    samples: list[SampleEntry] = Field(
+        default_factory=list,
+        description="Curated functions with source + per-decompiler output for "
+        "the side-by-side Compare view",
+    )
+    compile_rates: dict[str, float] = Field(
+        default_factory=dict,
+        description="decompiler id -> fraction of functions whose decompilation "
+        "recompiles (byte-match compilability), shown on the Metrics page",
+    )
+    dataset_info: dict = Field(
+        default_factory=dict,
+        description="Dataset overview for the About/Dataset page: total source "
+        "lines of code, per-project LOC, and Joern source-parse failure rates "
+        "(how much of the GED pipeline fails due to our own tooling). Software-"
+        "type categories are derived client-side from per-binary labels.",
     )
     history: list[HistoryPoint] = Field(
         default_factory=list,

--- a/decbench/pipeline/evaluate.py
+++ b/decbench/pipeline/evaluate.py
@@ -35,9 +35,7 @@ def evaluate_decompilation(
 
     # Extract CFGs from decompilation if needed
     decompiled_cfgs = None
-    needs_decomp_cfg = any(
-        MetricRegistry.get(m).requires_decompiled_cfg for m in metrics
-    )
+    needs_decomp_cfg = any(MetricRegistry.get(m).requires_decompiled_cfg for m in metrics)
     if needs_decomp_cfg:
         decompiled_cfgs = extract_cfgs_from_decompilation(decompilation)
 
@@ -132,7 +130,9 @@ def evaluate_project(
                     cfgs = extract_cfgs_from_source(i_path)
                     source_cfgs_by_binary[name] = cfgs
                     if not cfgs:
-                        logger.warning("Source CFG extraction returned empty for %s (%s)", name, i_path)
+                        logger.warning(
+                            "Source CFG extraction returned empty for %s (%s)", name, i_path
+                        )
                     else:
                         logger.debug("Extracted %d CFGs from %s", len(cfgs), name)
                 except Exception as e:
@@ -141,6 +141,15 @@ def evaluate_project(
     else:
         logger.warning("No preprocessed sources for %s/%s", project.name, optimization)
 
+    # A binary's source functions may be defined in ANY of the project's
+    # translation units (multi-.c binaries), and decompiled functions are matched
+    # to source by NAME, so match every binary against the UNION of all the
+    # project's source CFGs rather than only its same-named .i — the per-binary
+    # lookup otherwise lost most GED coverage on multi-source binaries.
+    all_source_cfgs: dict = {}
+    for _cfgs in source_cfgs_by_binary.values():
+        all_source_cfgs.update(_cfgs or {})
+
     if parallel:
         workers = workers or cpu_count()
 
@@ -148,7 +157,7 @@ def evaluate_project(
             futures = {}
 
             for binary_name, dec_results in decompilations.items():
-                source_cfgs = source_cfgs_by_binary.get(binary_name, {})
+                source_cfgs = all_source_cfgs
 
                 for dec_name, decompilation in dec_results.items():
                     future = executor.submit(
@@ -173,7 +182,7 @@ def evaluate_project(
                     results[binary_name][dec_name] = {}
     else:
         for binary_name, dec_results in decompilations.items():
-            source_cfgs = source_cfgs_by_binary.get(binary_name, {})
+            source_cfgs = all_source_cfgs
             results[binary_name] = {}
 
             for dec_name, decompilation in dec_results.items():
@@ -228,9 +237,7 @@ def evaluate_projects(
     metrics: list[str] | None = None,
     parallel: bool = True,
     workers: int | None = None,
-) -> dict[
-    str, dict[OptimizationLevel, dict[str, dict[str, dict[str, MetricResult]]]]
-]:
+) -> dict[str, dict[OptimizationLevel, dict[str, dict[str, dict[str, MetricResult]]]]]:
     """Evaluate multiple projects."""
     if optimization_levels is None:
         optimization_levels = [OptimizationLevel.O2]

--- a/decbench/pipeline/executor.py
+++ b/decbench/pipeline/executor.py
@@ -154,13 +154,13 @@ class PipelineExecutor:
                     if opt in project.compiled_binaries:
                         binaries = project.compiled_binaries[opt]
                         if len(binaries) > self.config.binary_limit:
-                            project.compiled_binaries[opt] = binaries[:self.config.binary_limit]
-                            print(f"Limited to {self.config.binary_limit} binaries for {project.name}/{opt.value}")
+                            project.compiled_binaries[opt] = binaries[: self.config.binary_limit]
+                            print(
+                                f"Limited to {self.config.binary_limit} binaries for {project.name}/{opt.value}"
+                            )
                     if opt in project.preprocessed_sources:
                         # Keep only sources matching the limited binaries
-                        limited_names = {
-                            b.stem for b in project.compiled_binaries.get(opt, [])
-                        }
+                        limited_names = {b.stem for b in project.compiled_binaries.get(opt, [])}
                         project.preprocessed_sources[opt] = {
                             name: path
                             for name, path in project.preprocessed_sources[opt].items()
@@ -170,6 +170,7 @@ class PipelineExecutor:
         # Apply binary sampling if set (deterministic random selection)
         if self.config.binary_sample is not None:
             import random
+
             for project in projects:
                 for opt in self.config.optimization_levels:
                     if opt in project.compiled_binaries:
@@ -179,11 +180,11 @@ class PipelineExecutor:
                             sampled = sorted(rng.sample(binaries, self.config.binary_sample))
                             project.compiled_binaries[opt] = sampled
                             names = [b.stem for b in sampled]
-                            print(f"Sampled {self.config.binary_sample} binaries for {project.name}/{opt.value}: {names}")
+                            print(
+                                f"Sampled {self.config.binary_sample} binaries for {project.name}/{opt.value}: {names}"
+                            )
                     if opt in project.preprocessed_sources:
-                        sampled_names = {
-                            b.stem for b in project.compiled_binaries.get(opt, [])
-                        }
+                        sampled_names = {b.stem for b in project.compiled_binaries.get(opt, [])}
                         project.preprocessed_sources[opt] = {
                             name: path
                             for name, path in project.preprocessed_sources[opt].items()
@@ -287,9 +288,7 @@ class PipelineExecutor:
         except (OSError, struct.error):
             return False
 
-    def _discover_existing_binaries(
-        self, projects: list[Project], output_dir: Path
-    ) -> None:
+    def _discover_existing_binaries(self, projects: list[Project], output_dir: Path) -> None:
         """Populate project.compiled_binaries from previously compiled output.
 
         Scans ``<output_dir>/<opt>/<project>/compiled/`` for ELF executables
@@ -298,36 +297,35 @@ class PipelineExecutor:
         """
         for project in projects:
             for opt in self.config.optimization_levels:
-                compiled_dir = (
-                    output_dir / opt.value / project.name / "compiled"
-                )
+                compiled_dir = output_dir / opt.value / project.name / "compiled"
                 if not compiled_dir.is_dir():
-                    print(
-                        f"Warning: compiled directory not found: {compiled_dir}"
-                    )
+                    print(f"Warning: compiled directory not found: {compiled_dir}")
                     continue
 
-                # Discover ELF binaries
+                # Discover ELF executables AND PE binaries (the malware targets
+                # are MinGW PE .exe/.dll; without the PE check they'd never be
+                # decompiled). cps ARM firmware is ELF, so it's covered already.
+                from decbench.utils import binfmt
+
                 binaries: list[Path] = []
                 for entry in sorted(compiled_dir.iterdir()):
-                    if entry.is_file() and self._is_elf_executable(entry):
+                    if not entry.is_file() or entry.is_symlink():
+                        continue
+                    if self._is_elf_executable(entry):
+                        binaries.append(entry)
+                        continue
+                    info = binfmt.detect(entry)
+                    if info is not None and info.fmt == "pe":
                         binaries.append(entry)
 
                 if binaries:
                     project.compiled_binaries[opt] = binaries
-                    print(
-                        f"Discovered {len(binaries)} binaries for "
-                        f"{project.name}/{opt.value}"
-                    )
+                    print(f"Discovered {len(binaries)} binaries for " f"{project.name}/{opt.value}")
                 else:
-                    print(
-                        f"Warning: no ELF binaries found in {compiled_dir}"
-                    )
+                    print(f"Warning: no ELF binaries found in {compiled_dir}")
 
                 # Discover preprocessed .i sources
-                i_files = {
-                    f.stem: f for f in sorted(compiled_dir.glob("*.i"))
-                }
+                i_files = {f.stem: f for f in sorted(compiled_dir.glob("*.i"))}
                 if i_files:
                     project.preprocessed_sources[opt] = i_files
                     print(

--- a/decbench/rendering/html.py
+++ b/decbench/rendering/html.py
@@ -1,11 +1,23 @@
 """HTML report renderer for DecBench results.
 
-Re-skinned to the mahaloz.re terminal aesthetic (pure-black bg, Source Code Pro
-monospace, dashed rules, Unix-path nav, dash-prefixed lists, ASCII-ish bars).
-All existing interactivity is preserved verbatim — label chips + per-binary
-toggles live-recompute the comparison matrix, per-binary breakdown, ranking
-tables, and stats. Two new views are added: a "Hardest Functions" hall of shame
-and a "Historical" view of per-metric line charts rendered as inline SVG in JS.
+Single-page app with a left **sidebar** that switches between views, themed in
+the mahaloz.re terminal aesthetic (pure-black bg, Source Code Pro mono, dashed
+rules, ASCII bars). Views:
+
+* **Leaderboard** — a swebench.com-style ranked table: one row per decompiler,
+  one column per metric (perfect %) plus an Overall column; sortable; recomputes
+  live over the selected dataset.
+* **Metrics** — explains the three decompilation goals (control-flow structure,
+  types, recompilation) and the metric used for each, with each decompiler's
+  perfect rate + compile rate.
+* **Compare** — side-by-side original source vs each decompiler's output for a
+  curated set of functions, with per-metric scores.
+* **Hardest** — the worst-scoring functions (decompiled + source).
+* **Historical** — per-metric perfect % across decompiler versions (SVG).
+
+Everything below the leaderboard is driven client-side from the embedded
+per-function dataset, so the dataset selector recomputes all aggregates without a
+server round-trip.
 """
 
 from __future__ import annotations
@@ -23,6 +35,23 @@ METRIC_DISPLAY_NAMES = {
     "byte_match": "Recompilation Bytematch",
 }
 
+# Short column labels for the leaderboard table.
+METRIC_SHORT_NAMES = {
+    "ged": "Structure",
+    "type_match": "Types",
+    "byte_match": "Recompile",
+}
+
+# Preferred display order: the three decompilation goals (structure, types,
+# recompilation). Unknown metrics are appended in their given order.
+_METRIC_ORDER = ["ged", "type_match", "byte_match"]
+
+
+def _ordered_metrics(metrics: list[str]) -> list[str]:
+    known = [m for m in _METRIC_ORDER if m in metrics]
+    extra = [m for m in metrics if m not in _METRIC_ORDER]
+    return known + extra
+
 
 def render_html_report(
     scoreboard: Scoreboard,
@@ -30,14 +59,6 @@ def render_html_report(
     function_data: FunctionData | None = None,
 ) -> None:
     """Render a self-contained HTML report from scoreboard data.
-
-    Generates sections for:
-    1. Overall - functions perfect on ALL metrics
-    2. Each individual metric
-
-    When ``function_data`` is provided, the report additionally embeds the
-    per-function dataset and interactive client-side filtering controls, plus
-    the Hardest Functions and Historical views.
 
     Args:
         scoreboard: The scoreboard to render.
@@ -52,38 +73,45 @@ def render_html_report(
 
 def _build_html(scoreboard: Scoreboard, function_data: FunctionData | None) -> str:
     """Build the complete HTML string."""
-    metric_sections = ""
-    for metric_name in scoreboard.metrics:
-        metric_sections += _build_metric_section(scoreboard, metric_name)
-
-    overall_section = _build_overall_section(scoreboard)
-
-    if function_data is None:
-        banner = (
-            '<div class="banner" id="no-data-banner">'
-            "[ note ] interactive filtering unavailable: per-function data "
-            "(function_results.json) not found."
-            "</div>"
-        )
-        interactive_sections = ""
-        hardest_section = ""
-        history_section = ""
-        script = ""
-        nav = _build_nav(has_extras=False)
-    else:
-        banner = ""
-        interactive_sections = (
-            _build_filters_section(function_data)
-            + _build_comparison_matrix_section(function_data)
-            + _build_per_binary_section(function_data)
-        )
-        hardest_section = _build_hardest_section(function_data)
-        history_section = _build_history_section(function_data)
-        script = _build_script(function_data)
-        nav = _build_nav(has_extras=True)
-
+    has_data = function_data is not None
     date_str = scoreboard.generated_at.strftime("%Y-%m-%d")
     time_str = scoreboard.generated_at.strftime("%H:%M")
+
+    nav_items = [
+        ("leaderboard", "leaderboard", True),
+        ("metrics", "metrics", True),
+        ("dataset", "dataset", has_data),
+        ("compare", "compare", has_data),
+        ("hardest", "hardest", has_data),
+        ("history", "historical", has_data),
+    ]
+    nav = ""
+    for view, label, enabled in nav_items:
+        if not enabled:
+            continue
+        nav += (
+            f'<a class="nav-item" data-view="{view}" href="#{view}">'
+            f'<span class="nav-bullet">&gt;</span> {html_escape(label)}</a>'
+        )
+
+    dataset_selector = _build_dataset_selector(function_data) if has_data else ""
+
+    leaderboard = _build_leaderboard_section(scoreboard, function_data)
+    metrics_view = _build_metrics_section(scoreboard, function_data)
+    dataset_view = _build_dataset_overview_section(function_data) if has_data else ""
+    compare_view = _build_compare_section(function_data) if has_data else ""
+    hardest_view = _build_hardest_section(function_data) if has_data else ""
+    history_view = _build_history_section(function_data) if has_data else ""
+
+    banner = ""
+    if not has_data:
+        banner = (
+            '<div class="banner">[ note ] interactive views unavailable: '
+            "per-function data (function_results.json) not found next to the "
+            "scoreboard.</div>"
+        )
+
+    script = _build_script(function_data) if has_data else ""
 
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -99,66 +127,73 @@ def _build_html(scoreboard: Scoreboard, function_data: FunctionData | None) -> s
     </style>
 </head>
 <body>
-    <div class="container">
-        <header>
-            <div class="prompt">$ decbench report --scoreboard {html_escape(scoreboard.name)}</div>
-            <h1>{html_escape(scoreboard.name)}</h1>
-            <div class="subtitle">
-                [ {date_str} {time_str} ]
-                &middot; projects: {html_escape(', '.join(scoreboard.projects_evaluated) or '-')}
-                &middot; opt: {html_escape(', '.join(scoreboard.optimization_levels) or '-')}
+    <div class="layout">
+        <aside class="sidebar">
+            <div class="brand">
+                <div class="brand-prompt">$ decbench</div>
+                <div class="brand-title">DecBench</div>
+                <div class="brand-sub">decompiler benchmark</div>
             </div>
-            {nav}
-        </header>
+            <nav class="nav">{nav}</nav>
+            {dataset_selector}
+            <div class="side-stats">
+                <div class="side-stat"><span class="side-num" data-stat="functions">{scoreboard.total_functions:,}</span> functions</div>
+                <div class="side-stat"><span class="side-num" data-stat="binaries">{scoreboard.total_binaries:,}</span> binaries</div>
+                <div class="side-stat"><span class="side-num">{len(scoreboard.decompilers)}</span> decompilers</div>
+                <div class="side-stat"><span class="side-num">{len(scoreboard.metrics)}</span> metrics</div>
+            </div>
+            <div class="side-foot">[ {date_str} {time_str} ]</div>
+        </aside>
 
-        <div class="rule"></div>
-
-        {banner}
-
-        <div class="stats">
-            <span class="stat"><span class="stat-value" data-stat="functions">{scoreboard.total_functions:,}</span> functions</span>
-            <span class="sep">&middot;</span>
-            <span class="stat"><span class="stat-value" data-stat="binaries">{scoreboard.total_binaries:,}</span> binaries</span>
-            <span class="sep">&middot;</span>
-            <span class="stat"><span class="stat-value">{len(scoreboard.decompilers)}</span> decompilers</span>
-            <span class="sep">&middot;</span>
-            <span class="stat"><span class="stat-value">{len(scoreboard.metrics)}</span> metrics</span>
-        </div>
-
-        {interactive_sections}
-        {overall_section}
-        {metric_sections}
-        {hardest_section}
-        {history_section}
-
-        <div class="rule"></div>
-        <footer>
-            DecBench v{html_escape(str(scoreboard.version))} &mdash; decompiler benchmarking suite
-            &middot; [ {date_str} ]
-        </footer>
+        <main class="main">
+            {banner}
+            {leaderboard}
+            {metrics_view}
+            {dataset_view}
+            {compare_view}
+            {hardest_view}
+            {history_view}
+            <div class="rule"></div>
+            <footer>
+                DecBench v{html_escape(str(scoreboard.version))} &mdash; decompiler benchmarking suite
+                &middot; projects: {html_escape(', '.join(scoreboard.projects_evaluated) or '-')}
+            </footer>
+        </main>
     </div>
     {script}
 </body>
 </html>"""
 
 
-def _build_nav(has_extras: bool) -> str:
-    """Build the Unix-path style nav bar."""
-    links = [
-        ('#overall', '/decbench'),
-        ('#metrics', '/metrics'),
-    ]
-    if has_extras:
-        links.append(('#hardest', '/hardest'))
-        links.append(('#history', '/history'))
-    inner = " ".join(
-        f'<a href="{href}">{html_escape(label)}</a>' for href, label in links
-    )
-    return f'<nav class="nav">{inner}</nav>'
+def _build_dataset_selector(function_data: FunctionData) -> str:
+    """Sidebar dataset selector (full / hard / hard-inlined / tiny)."""
+    presets = function_data.dataset_presets or []
+    if not presets:
+        return ""
+    buttons = ""
+    for i, preset in enumerate(presets):
+        active = " active" if i == 0 else ""
+        buttons += (
+            f'<button class="ds-btn{active}" data-dataset="{html_escape(preset.name)}" '
+            f'title="{html_escape(preset.description)}">{html_escape(preset.label)}</button>'
+        )
+    return f"""
+        <div class="side-section">
+            <div class="side-label">dataset</div>
+            <div class="ds-controls">{buttons}</div>
+            <div class="ds-desc" id="dataset-desc"></div>
+            <div class="counter" id="function-counter"></div>
+            <div class="ds-controls" style="margin-top:0.6rem;">
+                <button class="ds-btn" id="normalize-btn"
+                        title="Only count functions that EVERY decompiler decompiled successfully (apples-to-apples).">
+                    normalize failures
+                </button>
+            </div>
+        </div>"""
 
 
 def _build_css() -> str:
-    """Return the full terminal-aesthetic stylesheet."""
+    """Return the full terminal-aesthetic stylesheet (sidebar layout)."""
     return """        :root {
             --bg: #000;
             --code-bg: #141414;
@@ -169,6 +204,7 @@ def _build_css() -> str:
             --green: #6ab04c;
             --amber: #d4a72c;
             --red: #c0504d;
+            --sidebar-w: 230px;
         }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         html { background: var(--bg); }
@@ -178,177 +214,183 @@ def _build_css() -> str:
             color: var(--text);
             line-height: 1.5;
             font-size: 15px;
-            padding: 2rem 1rem 3rem;
         }
-        .container { width: 90%; max-width: 850px; margin: 0 auto; }
-        a {
-            color: var(--text);
-            text-decoration: none;
-            border-bottom: 1px dotted var(--border-color);
+        a { color: var(--text); text-decoration: none; }
+        .layout { display: flex; align-items: flex-start; min-height: 100vh; }
+
+        /* ---- Sidebar ---- */
+        .sidebar {
+            width: var(--sidebar-w);
+            min-width: var(--sidebar-w);
+            position: sticky;
+            top: 0;
+            align-self: flex-start;
+            height: 100vh;
+            overflow-y: auto;
+            border-right: dashed 1px var(--border-color);
+            padding: 1.4rem 1rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.1rem;
         }
-        a:hover { color: #000; background: var(--text); border-bottom-color: transparent; }
-        .rule {
-            border: none;
-            border-top: dashed 1px var(--border-color);
-            margin: 1.4rem 0;
-            height: 0;
+        .brand-prompt { color: var(--text-muted); font-size: 0.8em; }
+        .brand-title { font-size: 1.35rem; font-weight: 700; letter-spacing: 0.02em; }
+        .brand-sub { color: var(--text-muted); font-size: 0.78em; }
+        .nav { display: flex; flex-direction: column; gap: 0.15rem; }
+        .nav-item {
+            padding: 0.25rem 0.4rem;
+            font-size: 0.92em;
+            border: dashed 1px transparent;
         }
-        header { margin-bottom: 0.4rem; }
-        .prompt { color: var(--text-muted); font-size: 0.85em; margin-bottom: 0.4rem; }
-        h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.4rem; }
-        .subtitle { color: var(--text-muted); font-size: 0.85em; margin-bottom: 0.6rem; }
-        .nav { font-size: 0.9em; }
-        .nav a { margin-right: 0.6rem; border-bottom: none; }
-        .nav a:hover { color: #000; background: var(--text); }
+        .nav-bullet { color: var(--text-muted); }
+        .nav-item:hover { color: #000; background: var(--text); }
+        .nav-item.active {
+            border-color: var(--border-color);
+            color: var(--green);
+        }
+        .nav-item.active .nav-bullet { color: var(--green); }
+        .side-section { border-top: dashed 1px rgba(219,219,219,0.25); padding-top: 0.9rem; }
+        .side-label { color: var(--text-muted); font-size: 0.78em; margin-bottom: 0.4rem; }
+        .ds-controls { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+        .ds-desc { color: var(--text-muted); font-size: 0.74em; margin-top: 0.4rem; line-height: 1.35; }
+        .side-stats { border-top: dashed 1px rgba(219,219,219,0.25); padding-top: 0.9rem; font-size: 0.85em; }
+        .side-stat { color: var(--text-muted); padding: 0.05rem 0; }
+        .side-num { color: var(--text); font-weight: 700; }
+        .side-foot { color: var(--text-muted); font-size: 0.78em; margin-top: auto; }
+
+        /* ---- Main ---- */
+        .main {
+            flex: 1;
+            min-width: 0;
+            max-width: 1100px;
+            padding: 1.8rem 2rem 3rem;
+        }
+        .view { display: none; }
+        .view.active { display: block; }
+        .rule { border: none; border-top: dashed 1px var(--border-color); margin: 1.4rem 0; }
         .banner {
-            border: dashed 1px var(--amber);
-            color: var(--amber);
-            padding: 0.6rem 0.9rem;
-            margin: 1rem 0;
-            font-size: 0.9em;
+            border: dashed 1px var(--amber); color: var(--amber);
+            padding: 0.6rem 0.9rem; margin: 0 0 1rem; font-size: 0.9em;
         }
-        .stats { font-size: 0.95em; margin: 0.6rem 0 0.4rem; }
-        .stats .sep { color: var(--text-muted); margin: 0 0.3rem; }
-        .stat-value { font-weight: 700; }
-        .section { margin: 1.6rem 0; }
-        .section h2 {
-            font-size: 1.05rem;
-            font-weight: 700;
-            margin-bottom: 0.2rem;
-        }
-        .section h2:before { content: "## "; color: var(--text-muted); }
-        .section .desc {
-            color: var(--text-muted);
-            font-size: 0.85em;
-            margin-bottom: 0.8rem;
-        }
-        .section.overall h2 { color: var(--green); }
+        h2.view-title { font-size: 1.3rem; font-weight: 700; margin-bottom: 0.2rem; }
+        h2.view-title:before { content: "## "; color: var(--text-muted); }
+        .view-desc { color: var(--text-muted); font-size: 0.88em; margin-bottom: 1.1rem; max-width: 70ch; }
+        h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
+        h3.sub:before { content: "> "; color: var(--text-muted); }
+
+        /* ---- Tables ---- */
         table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
         th, td {
-            text-align: left;
-            padding: 0.35rem 0.7rem 0.35rem 0;
-            border-bottom: dashed 1px rgba(219, 219, 219, 0.25);
+            text-align: left; padding: 0.45rem 0.8rem 0.45rem 0;
+            border-bottom: dashed 1px rgba(219, 219, 219, 0.22);
             vertical-align: middle;
         }
         th {
-            color: var(--text-muted);
-            font-weight: 600;
-            font-size: 0.85em;
-            border-bottom: dashed 1px var(--border-color);
+            color: var(--text-muted); font-weight: 600; font-size: 0.82em;
+            border-bottom: dashed 1px var(--border-color); white-space: nowrap;
         }
+        th.sortable { cursor: pointer; user-select: none; }
+        th.sortable:hover { color: var(--text); }
+        th .arrow { color: var(--green); }
         tr:last-child td { border-bottom: none; }
-        .binrow { cursor: help; }
-        .binrow:hover td { background: rgba(219, 219, 219, 0.08); }
-        .rank { color: var(--text-muted); width: 3.5em; }
-        .bar-ascii {
-            color: var(--text-muted);
-            white-space: pre;
-            letter-spacing: -0.02em;
-        }
-        .pct { font-weight: 700; text-align: right; white-space: nowrap; }
+        .lb-rank { color: var(--text-muted); width: 2.6em; }
+        .lb-name { font-weight: 700; font-size: 1.02em; }
+        .lb-name .ver { color: var(--text-muted); font-weight: 400; font-size: 0.85em; }
+        td.metric-cell { white-space: nowrap; }
+        .cell-pct { font-weight: 700; }
+        .cell-count { color: var(--text-muted); font-size: 0.82em; }
+        .bar-ascii { color: var(--text-muted); white-space: pre; letter-spacing: -0.02em; }
         .pct-high { color: var(--green); }
         .pct-mid { color: var(--amber); }
         .pct-low { color: var(--red); }
-        .counts { color: var(--text-muted); font-size: 0.85em; text-align: right; }
-        .chips { margin-bottom: 0.6rem; }
-        .chip {
-            display: inline-block;
-            border: dashed 1px var(--border-color);
-            padding: 0.1rem 0.5rem;
-            margin: 0 0.3rem 0.3rem 0;
-            font-size: 0.85em;
-            cursor: pointer;
-            user-select: none;
-        }
-        .chip:hover { color: #000; background: var(--text); }
-        .chip input { cursor: pointer; vertical-align: middle; margin-right: 0.3rem; }
-        details { margin: 0.6rem 0; }
-        details summary {
-            cursor: pointer;
-            color: var(--text-muted);
-            font-size: 0.85em;
-            margin-bottom: 0.4rem;
-        }
-        .binary-list label {
-            display: block;
-            font-size: 0.85em;
-            padding: 0.05rem 0;
-        }
-        .binary-list label:before { content: "- "; color: var(--text-muted); }
-        .controls {
-            display: flex;
-            align-items: center;
-            gap: 0.8rem;
-            margin: 0.6rem 0;
-            flex-wrap: wrap;
-            font-size: 0.9em;
-        }
+        .binrow:hover td { background: rgba(219, 219, 219, 0.06); }
+        .col-overall { border-left: dashed 1px rgba(219,219,219,0.25); }
+        .cat-btn.active { color: #000; background: var(--green); border-style: solid; font-weight: 700; }
+        tr.cat-hl td { background: rgba(106, 176, 76, 0.16); }
+
+        /* ---- Buttons / inputs ---- */
         button, select, input[type=text] {
-            background: var(--bg);
-            border: dashed 1px var(--border-color);
-            color: var(--text);
-            padding: 0.25rem 0.7rem;
-            cursor: pointer;
-            font-family: inherit;
-            font-size: 0.9em;
+            background: var(--bg); border: dashed 1px var(--border-color);
+            color: var(--text); padding: 0.25rem 0.6rem; cursor: pointer;
+            font-family: inherit; font-size: 0.88em;
         }
         button:hover, select:hover { color: #000; background: var(--text); }
-        .ds-btn { margin: 0 0.3rem 0.3rem 0; }
-        .ds-btn.active {
-            color: #000; background: var(--text);
-            border-style: solid; font-weight: 700;
+        .ds-btn { padding: 0.15rem 0.5rem; font-size: 0.82em; }
+        .ds-btn.active { color: #000; background: var(--text); border-style: solid; font-weight: 700; }
+        .controls { display: flex; align-items: center; gap: 0.7rem; margin: 0.8rem 0; flex-wrap: wrap; font-size: 0.9em; }
+        .controls label { color: var(--text-muted); }
+        .counter { color: var(--text-muted); font-size: 0.82em; }
+
+        /* ---- Metrics cards ---- */
+        .goal {
+            border: dashed 1px rgba(219,219,219,0.4);
+            padding: 0.9rem 1.1rem; margin: 0.9rem 0;
         }
-        .counter { color: var(--text-muted); font-size: 0.9em; }
-        .ul-dash { list-style: none; padding: 0; }
-        .ul-dash li { padding: 0.1rem 0; }
-        .ul-dash li:before { content: "- "; color: var(--text-muted); }
+        .goal-head { font-weight: 700; font-size: 1.02em; margin-bottom: 0.2rem; }
+        .goal-head .num { color: var(--green); margin-right: 0.4rem; }
+        .goal-metric { color: var(--amber); font-size: 0.82em; margin-bottom: 0.5rem; }
+        .goal-body { color: var(--text); font-size: 0.88em; max-width: 75ch; }
+        .goal-body .perfect { color: var(--text-muted); }
+        .formula { color: var(--text-muted); font-size: 0.82em; margin-top: 0.5rem; }
+        .recovered {
+            border: dashed 1px var(--green); color: var(--green);
+            padding: 0.7rem 1rem; margin: 1.2rem 0; font-size: 0.9em;
+        }
+
+        /* ---- Code blocks / compare ---- */
         pre {
-            background: var(--code-bg);
-            border: 0.1em solid var(--code-border);
-            box-shadow: inset 0 0 0.4em rgba(0, 0, 0, 0.8);
-            padding: 0.7rem 0.9rem;
-            overflow-x: auto;
-            margin: 0.5rem 0;
-            font-size: 0.85em;
-            line-height: 1.45;
+            background: var(--code-bg); border: 0.1em solid var(--code-border);
+            box-shadow: inset 0 0 0.4em rgba(0,0,0,0.8);
+            padding: 0.7rem 0.9rem; overflow: auto; margin: 0.4rem 0;
+            font-size: 0.8em; line-height: 1.45; max-height: 560px;
         }
-        pre code {
-            font-family: Consolas, "Source Code Pro", monospace;
-            color: var(--text);
-            white-space: pre;
+        pre code { font-family: Consolas, "Source Code Pro", monospace; color: var(--text); white-space: pre; }
+        .code-label { color: var(--text-muted); font-size: 0.8em; margin: 0.6rem 0 0.1rem; }
+        .cmp-grid { display: grid; gap: 0.8rem; margin-top: 0.6rem; }
+        .cmp-col { min-width: 0; }
+        .cmp-col h4 {
+            font-size: 0.9em; font-weight: 700; margin-bottom: 0.2rem;
+            border-bottom: dashed 1px var(--border-color); padding-bottom: 0.2rem;
         }
-        .code-label {
-            color: var(--text-muted);
-            font-size: 0.8em;
-            margin: 0.6rem 0 0.1rem;
-        }
-        /* Hardest functions */
-        .hard-entry {
-            border: dashed 1px rgba(219, 219, 219, 0.4);
-            padding: 0.7rem 0.9rem;
-            margin: 0.9rem 0;
-        }
-        .hard-head { font-size: 0.92em; margin-bottom: 0.2rem; }
+        .cmp-col.src h4 { color: var(--green); }
+        .cmp-scores { font-size: 0.78em; color: var(--text-muted); margin: 0.2rem 0; }
+        .cmp-scores .sc { margin-right: 0.7rem; }
+        .cmp-meta { color: var(--text-muted); font-size: 0.82em; margin-bottom: 0.4rem; }
+
+        /* ---- Hardest ---- */
+        .hard-entry { border: dashed 1px rgba(219,219,219,0.4); padding: 0.7rem 0.9rem; margin: 0.9rem 0; }
+        .hard-head { font-size: 0.95em; margin-bottom: 0.2rem; }
         .hard-head .fn { font-weight: 700; }
         .hard-meta { color: var(--text-muted); font-size: 0.82em; margin-bottom: 0.3rem; }
         .hard-meta .tag { margin-right: 0.6rem; }
         .hard-meta .score-bad { color: var(--red); }
-        /* Historical charts */
+
+        /* ---- Charts ---- */
         .chart-block { margin: 1.2rem 0; }
         .chart-block h3 { font-size: 0.95em; font-weight: 600; margin-bottom: 0.3rem; }
         .chart-block h3:before { content: "> "; color: var(--text-muted); }
         svg { display: block; max-width: 100%; }
         .legend { font-size: 0.82em; color: var(--text-muted); margin-top: 0.3rem; }
         .legend .item { margin-right: 1rem; white-space: nowrap; }
-        .legend .swatch {
-            display: inline-block; width: 1.4em; height: 0.5em;
-            vertical-align: middle; margin-right: 0.3rem;
-        }
-        footer { color: var(--text-muted); font-size: 0.85em; }"""
+        .legend .swatch { display: inline-block; width: 1.4em; height: 0.5em; vertical-align: middle; margin-right: 0.3rem; }
+        footer { color: var(--text-muted); font-size: 0.82em; margin-top: 1.5rem; }
+
+        @media (max-width: 820px) {
+            .layout { flex-direction: column; }
+            .sidebar { width: 100%; min-width: 0; height: auto; position: static;
+                       border-right: none; border-bottom: dashed 1px var(--border-color); }
+            .main { padding: 1.2rem 1rem 3rem; }
+            .nav { flex-direction: row; flex-wrap: wrap; }
+            .side-foot { margin-top: 0.5rem; }
+        }"""
+
+
+# --------------------------------------------------------------------------
+# Static section scaffolds (filled/recomputed by JS when data is present).
+# --------------------------------------------------------------------------
 
 
 def _ascii_bar(pct: float, width: int = 12) -> str:
-    """Build an ASCII ``[####----]`` bar for a percentage."""
     p = max(0.0, min(pct, 100.0))
     filled = int(round((p / 100.0) * width))
     filled = max(0, min(filled, width))
@@ -358,226 +400,275 @@ def _ascii_bar(pct: float, width: int = 12) -> str:
 def _pct_class(pct: float) -> str:
     if pct >= 50:
         return "high"
-    elif pct >= 20:
+    if pct >= 20:
         return "mid"
     return "low"
 
 
-def _build_ranking_table(
-    rankings: list[tuple[str, float]],
-    scoreboard: Scoreboard,
-    metric_name: str | None = None,
-) -> str:
-    """Build an HTML table for rankings."""
-    rows = ""
-    metric_attr = metric_name if metric_name is not None else "__overall__"
-    for rank, (dec_name, pct) in enumerate(rankings, 1):
-        cls = _pct_class(pct)
-
-        # Get count info if available
-        count_str = ""
-        if metric_name and dec_name in scoreboard.decompiler_scores:
-            ms = scoreboard.decompiler_scores[dec_name].metric_scores.get(metric_name)
-            if ms:
-                count_str = f"{ms.perfect_count}/{ms.total_count}"
-        elif metric_name is None and dec_name in scoreboard.decompiler_scores:
-            ds = scoreboard.decompiler_scores[dec_name]
-            count_str = f"{ds.overall_perfect_count}/{ds.overall_total_count}"
-
-        esc_dec = html_escape(dec_name)
-        bar = _ascii_bar(pct)
-        rows += f"""
-        <tr data-ranking-row="{html_escape(metric_attr)}" data-decompiler="{esc_dec}">
-            <td class="rank">#{rank}</td>
-            <td>{esc_dec}</td>
-            <td class="bar-ascii" data-bar="1">{bar}</td>
-            <td class="pct pct-{cls}" data-pct="1">{pct:.1f}%</td>
-            <td class="counts" data-count="1">{count_str}</td>
-        </tr>"""
+def _build_leaderboard_section(scoreboard: Scoreboard, function_data: FunctionData | None) -> str:
+    """The swebench-style leaderboard. JS rebuilds it; we render a static
+    fallback from the scoreboard so a no-JS / no-data view still works."""
+    active = " active"  # leaderboard is the default view
+    intro = (
+        "ranked by Overall &mdash; the share of functions a decompiler recovers "
+        "<em>perfectly on all three metrics</em>. click a column to sort."
+    )
+    if function_data is None:
+        # Static table straight from the scoreboard.
+        table = _static_leaderboard_table(scoreboard)
+        return f"""
+    <section class="view{active}" id="view-leaderboard" data-view="leaderboard">
+        <h2 class="view-title">leaderboard</h2>
+        <p class="view-desc">{intro}</p>
+        {table}
+    </section>"""
 
     return f"""
-    <table>
-        <thead>
-            <tr>
-                <th>rank</th>
-                <th>decompiler</th>
-                <th>progress</th>
-                <th>perfect %</th>
-                <th>count</th>
-            </tr>
-        </thead>
-        <tbody>{rows}
-        </tbody>
-    </table>"""
+    <section class="view{active}" id="view-leaderboard" data-view="leaderboard">
+        <h2 class="view-title">leaderboard</h2>
+        <p class="view-desc">{intro}</p>
+        <table id="leaderboard-table">
+            <thead><tr></tr></thead>
+            <tbody></tbody>
+        </table>
+    </section>"""
 
 
-def _build_overall_section(scoreboard: Scoreboard) -> str:
+def _static_leaderboard_table(scoreboard: Scoreboard) -> str:
+    """No-JS fallback leaderboard from the scoreboard object."""
     rankings = scoreboard.get_overall_rankings()
-    if not rankings:
-        return ""
-
-    table = _build_ranking_table(rankings, scoreboard)
-    return f"""
-    <div class="section overall" id="overall">
-        <h2>Overall &mdash; perfect on all metrics</h2>
-        <p class="desc">
-            functions where the decompiler achieves a 100% match on
-            all three metrics (GED, type, bytematch).
-        </p>
-        {table}
-    </div>"""
-
-
-def _build_metric_section(scoreboard: Scoreboard, metric_name: str) -> str:
-    rankings = scoreboard.get_metric_rankings(metric_name)
-    if not rankings:
-        return ""
-
-    display_name = METRIC_DISPLAY_NAMES.get(metric_name, metric_name)
-    table = _build_ranking_table(rankings, scoreboard, metric_name)
-
-    # Anchor the first metric section so /metrics nav lands somewhere.
-    anchor = ' id="metrics"' if metric_name == scoreboard.metrics[0] else ""
-    return f"""
-    <div class="section"{anchor}>
-        <h2>{html_escape(display_name)}</h2>
-        {table}
-    </div>"""
-
-
-def _build_filters_section(function_data: FunctionData) -> str:
-    """Build the single dataset selector (full / hard / hard-inlined / tiny).
-
-    Replaces the old label-chip + per-binary toggle soup: the report now offers
-    one choice — which curated dataset to view — and everything below recomputes
-    over it. Presets come from ``function_data.dataset_presets`` (tagged by
-    :mod:`decbench.scoring.datasets`).
-    """
-    presets = function_data.dataset_presets or []
-    buttons = ""
-    for i, preset in enumerate(presets):
-        active = " active" if i == 0 else ""
-        buttons += (
-            f'<button class="ds-btn{active}" data-dataset="{html_escape(preset.name)}">'
-            f"{html_escape(preset.label)}</button>"
+    headers = "<th>#</th><th>decompiler</th><th>Overall</th>"
+    for m in _ordered_metrics(scoreboard.metrics):
+        headers += f"<th>{html_escape(METRIC_SHORT_NAMES.get(m, m))}</th>"
+    rows = ""
+    for rank, (dec, overall_pct) in enumerate(rankings, 1):
+        ds = scoreboard.decompiler_scores.get(dec)
+        cells = (
+            f'<td class="metric-cell col-overall"><span class="cell-pct pct-{_pct_class(overall_pct)}">'
+            f"{overall_pct:.1f}%</span></td>"
         )
+        for m in _ordered_metrics(scoreboard.metrics):
+            ms = ds.metric_scores.get(m) if ds else None
+            p = ms.perfect_percentage if ms else 0.0
+            cells += (
+                f'<td class="metric-cell"><span class="cell-pct pct-{_pct_class(p)}">'
+                f"{p:.1f}%</span></td>"
+            )
+        rows += (
+            f'<tr class="binrow"><td class="lb-rank">#{rank}</td>'
+            f'<td class="lb-name">{html_escape(dec)}</td>{cells}</tr>'
+        )
+    return f"<table><thead><tr>{headers}</tr></thead><tbody>{rows}</tbody></table>"
 
-    if not presets:
-        # Backward-compat: data without presets -> nothing to select; the JS
-        # treats everything as active.
-        return """
-    <div class="section" id="filters">
-        <h2>dataset</h2>
-        <p class="desc">showing all functions (no dataset presets in this data).</p>
-        <span class="counter" id="function-counter"></span>
-    </div>"""
+
+def _build_metrics_section(scoreboard: Scoreboard, function_data: FunctionData | None) -> str:
+    """The Metrics explainer: three goals, their metrics, perfect rates."""
+    goals = [
+        (
+            "1",
+            "Control-flow structure correctness",
+            "Structural Correctness (GED)",
+            "Does the decompiled code branch and loop the same way the source "
+            "does? We compare the control-flow graphs of the source and the "
+            "decompilation with a Graph Edit Distance (GED) &mdash; the number of "
+            "node/edge insertions, deletions, and substitutions needed to turn "
+            "one CFG into the other.",
+            "perfect = GED of 0 (graph-isomorphic control flow).",
+        ),
+        (
+            "2",
+            "Type correctness",
+            "Type Correctness",
+            "Did the decompiler recover the right variable and argument types? "
+            "We match the decompiled variables against DWARF ground truth "
+            "(arguments by ABI position, stack variables by calibrated offset, "
+            "the rest by name) and score the fraction recovered correctly.",
+            "perfect = 1.0 (every recoverable variable typed correctly).",
+        ),
+        (
+            "3",
+            "Recompilation correctness",
+            "Recompilation Bytematch",
+            "Does the decompiled code recompile to the same machine code? We run "
+            "a uniform compilability fixup (define decompiler pseudo-types, strip "
+            "illegal symbol-version tokens, declare missing symbols) so every "
+            "decompiler gets a fair shot at building, recompile each function with "
+            "the original toolchain, and compare the resulting assembly &mdash; "
+            "normalizing link-time-dependent operands (call/jump targets, "
+            "PC-relative offsets) so only real differences count.",
+            "perfect = 1.0 (recompiled assembly matches the original).",
+        ),
+    ]
+    cards = ""
+    for num, title, metric_disp, body, perfect in goals:
+        cards += f"""
+        <div class="goal">
+            <div class="goal-head"><span class="num">[{num}]</span>{html_escape(title)}</div>
+            <div class="goal-metric">metric: {html_escape(metric_disp)}</div>
+            <div class="goal-body">{body} <span class="perfect">{html_escape(perfect)}</span></div>
+        </div>"""
+
+    perfect_table = (
+        '<table id="metrics-perfect-table"><thead><tr></tr></thead><tbody></tbody></table>'
+        if function_data is not None
+        else _static_metrics_table(scoreboard)
+    )
 
     return f"""
-    <div class="section" id="filters">
-        <h2>dataset</h2>
-        <p class="desc">
-            pick one curated view; every score below recomputes over it.
+    <section class="view" id="view-metrics" data-view="metrics">
+        <h2 class="view-title">metrics</h2>
+        <p class="view-desc">
+            Decompilation has three goals; DecBench measures each with one metric
+            and reports how often a decompiler gets it <em>perfect</em>.
         </p>
-        <div class="controls" id="dataset-controls">{buttons}</div>
-        <div class="desc" id="dataset-desc"></div>
-        <span class="counter" id="function-counter"></span>
-    </div>"""
-
-
-def _build_comparison_matrix_section(function_data: FunctionData) -> str:
-    """Build the metric x decompiler comparison matrix (filled by JS)."""
-    return """
-    <div class="section" id="comparison-matrix">
-        <h2>comparison matrix</h2>
-        <table>
-            <thead>
-                <tr><th>metric</th></tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>"""
-
-
-def _build_per_binary_section(function_data: FunctionData) -> str:
-    """Build the per-binary breakdown with a metric selector (filled by JS)."""
-    return """
-    <div class="section" id="per-binary-breakdown">
-        <h2>per-binary breakdown</h2>
-        <p class="desc">hover a binary row to see the function name(s) it
-        contributes to the current dataset.</p>
-        <div class="controls">
-            <label class="counter" for="breakdown-metric">metric:</label>
-            <select id="breakdown-metric"></select>
+        {cards}
+        <div class="recovered">
+            [ = ] When a function is perfect on <strong>all three</strong> metrics,
+            the decompiler has precisely recovered the original source: same control
+            flow, same types, and code that recompiles to the same bytes. That is the
+            Overall column on the leaderboard.
         </div>
-        <table>
-            <thead>
-                <tr><th>binary</th></tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>"""
+        <h3 class="sub">how often each decompiler is perfect</h3>
+        <p class="view-desc" id="metrics-table-note">over the selected dataset.</p>
+        {perfect_table}
+    </section>"""
+
+
+def _static_metrics_table(scoreboard: Scoreboard) -> str:
+    headers = "<th>decompiler</th>"
+    for m in _ordered_metrics(scoreboard.metrics):
+        headers += f"<th>{html_escape(METRIC_SHORT_NAMES.get(m, m))}</th>"
+    headers += "<th>Overall</th>"
+    rows = ""
+    for dec in scoreboard.decompilers:
+        ds = scoreboard.decompiler_scores.get(dec)
+        cells = ""
+        for m in _ordered_metrics(scoreboard.metrics):
+            ms = ds.metric_scores.get(m) if ds else None
+            p = ms.perfect_percentage if ms else 0.0
+            cells += f'<td><span class="cell-pct pct-{_pct_class(p)}">{p:.1f}%</span></td>'
+        op = ds.overall_perfect_percentage if ds else 0.0
+        cells += f'<td><span class="cell-pct pct-{_pct_class(op)}">{op:.1f}%</span></td>'
+        rows += f'<tr><td class="lb-name">{html_escape(dec)}</td>{cells}</tr>'
+    return f"<table><thead><tr>{headers}</tr></thead><tbody>{rows}</tbody></table>"
+
+
+def _build_dataset_overview_section(function_data: FunctionData) -> str:
+    """The Dataset/About page: software types, projects, total LOC, Joern health.
+
+    Rendered client-side from the embedded dataset (categories from per-binary
+    labels) + ``dataset_info`` (LOC, Joern parse failures).
+    """
+    return """
+    <section class="view" id="view-dataset" data-view="dataset">
+        <h2 class="view-title">dataset</h2>
+        <p class="view-desc">
+            The benchmark corpus: the kinds of software it covers, every project,
+            its size, and how much of the GED pipeline is lost to our own tooling
+            (Joern source-parse failures) rather than to the decompilers.
+        </p>
+        <h3 class="sub">software types</h3>
+        <p class="view-desc">click a type to highlight the projects it covers (a
+            project can span several).</p>
+        <div class="controls" id="category-controls"></div>
+        <h3 class="sub">summary</h3>
+        <div id="dataset-summary" class="goal"></div>
+        <h3 class="sub">pipeline health (our own tooling)</h3>
+        <p class="view-desc">
+            GED depends on Joern parsing both the source and the decompiler output.
+            When Joern fails on the <strong>source</strong>, that's our tooling — those
+            functions are excluded from GED for every decompiler (never counted against
+            them). When Joern fails on a single decompiler's <strong>output</strong>,
+            that's reported here (per decompiler), not folded into the headline score.
+        </p>
+        <div id="joern-source" class="goal"></div>
+        <table id="joern-output-table"><thead><tr></tr></thead><tbody></tbody></table>
+        <h3 class="sub">projects</h3>
+        <table id="dataset-projects"><thead><tr></tr></thead><tbody></tbody></table>
+    </section>"""
+
+
+def _build_compare_section(function_data: FunctionData) -> str:
+    """Side-by-side source vs decompiler output, picked from curated samples."""
+    if not function_data.samples:
+        return """
+    <section class="view" id="view-compare" data-view="compare">
+        <h2 class="view-title">compare</h2>
+        <p class="view-desc">no sample functions were attached to this report.</p>
+    </section>"""
+    return """
+    <section class="view" id="view-compare" data-view="compare">
+        <h2 class="view-title">compare</h2>
+        <p class="view-desc">
+            original source next to each decompiler's output for a curated set of
+            functions, with this function's per-metric scores. pick one below.
+        </p>
+        <div class="controls">
+            <label for="cmp-filter">filter:</label>
+            <input type="text" id="cmp-filter" placeholder="function / project / binary" size="28">
+            <label for="cmp-select">function:</label>
+            <select id="cmp-select"></select>
+            <span class="counter" id="cmp-counter"></span>
+        </div>
+        <div id="compare-body"></div>
+    </section>"""
 
 
 def _build_hardest_section(function_data: FunctionData) -> str:
-    """Build the Hardest Functions 'hall of shame' (filtered client-side)."""
     if not function_data.hardest:
         return """
-    <div class="section" id="hardest">
-        <h2>hardest functions &mdash; hall of shame</h2>
-        <p class="desc">
-            no hardest-function data was attached to this report.
-        </p>
-    </div>"""
-
+    <section class="view" id="view-hardest" data-view="hardest">
+        <h2 class="view-title">hardest functions</h2>
+        <p class="view-desc">no hardest-function data was attached to this report.</p>
+    </section>"""
     return """
-    <div class="section" id="hardest">
-        <h2>hardest functions &mdash; hall of shame</h2>
-        <p class="desc">
+    <section class="view" id="view-hardest" data-view="hardest">
+        <h2 class="view-title">hardest functions &mdash; hall of shame</h2>
+        <p class="view-desc">
             the functions decompilers struggled with most (farthest from the
-            metric's perfect value), with their decompiled output.
+            metric's perfect value), with decompiled output and original source.
         </p>
         <div class="controls">
-            <label class="counter" for="hard-metric">metric:</label>
+            <label for="hard-metric">metric:</label>
             <select id="hard-metric"><option value="__all__">all</option></select>
-            <label class="counter" for="hard-dec">decompiler:</label>
+            <label for="hard-dec">decompiler:</label>
             <select id="hard-dec"><option value="__all__">all</option></select>
             <span class="counter" id="hard-counter"></span>
         </div>
         <div id="hardest-list"></div>
-    </div>"""
+    </section>"""
 
 
 def _build_history_section(function_data: FunctionData) -> str:
-    """Build the Historical view container (charts drawn by JS)."""
     if not function_data.history:
         return """
-    <div class="section" id="history">
-        <h2>historical</h2>
-        <p class="desc">
-            this view shows how each decompiler's metric scores change across
-            versions. it appears once &ge;2 versions have been benchmarked.
+    <section class="view" id="view-history" data-view="history">
+        <h2 class="view-title">historical</h2>
+        <p class="view-desc">
+            shows how each decompiler's metric scores change across versions.
+            appears once &ge;2 versions have been benchmarked
+            (e.g. ghidra@12.0 vs ghidra@12.1).
         </p>
-    </div>"""
-
+    </section>"""
     return """
-    <div class="section" id="history">
-        <h2>historical</h2>
-        <p class="desc">
+    <section class="view" id="view-history" data-view="history">
+        <h2 class="view-title">historical</h2>
+        <p class="view-desc">
             per-metric perfect % across decompiler versions (x = version order,
             y = perfect %, one line per decompiler).
         </p>
         <div id="history-charts"></div>
-    </div>"""
+    </section>"""
 
 
 def _build_script(function_data: FunctionData) -> str:
-    """Build the inline <script> that powers interactive recomputation."""
-    # Escape "<" to avoid breaking out of the <script> element.
-    data_json = json.dumps(function_data.model_dump(mode="json")).replace(
-        "<", "\\u003c"
-    )
+    """Inline JS: view routing + live recomputation + compare/hardest/history."""
+    data_json = json.dumps(function_data.model_dump(mode="json")).replace("<", "\\u003c")
+    js = _JS_TEMPLATE
+    return js.replace("__DATA__", data_json)
 
-    js = """
+
+_JS_TEMPLATE = """
     <script>
     const DATA = __DATA__;
     const METRIC_NAMES = {
@@ -585,36 +676,45 @@ def _build_script(function_data: FunctionData) -> str:
         "type_match": "Type Correctness",
         "byte_match": "Recompilation Bytematch"
     };
+    const METRIC_SHORT = {"ged": "Structure", "type_match": "Types", "byte_match": "Recompile"};
+    // Display metrics in goal order (structure -> types -> recompile), with any
+    // extra/unknown metrics appended.
+    const METRIC_ORDER = ["ged", "type_match", "byte_match"];
+    function orderedMetrics() {
+        const known = METRIC_ORDER.filter(m => DATA.metrics.indexOf(m) >= 0);
+        const extra = DATA.metrics.filter(m => METRIC_ORDER.indexOf(m) < 0);
+        return known.concat(extra);
+    }
     const PRESETS = DATA.dataset_presets || [];
     const state = {
-        dataset: PRESETS.length ? PRESETS[0].name : null
+        dataset: PRESETS.length ? PRESETS[0].name : null,
+        view: "leaderboard",
+        sortKey: "__overall__",
+        sortDir: -1,
+        normalize: false
     };
 
-    function binaryKey(g) {
-        return g.project + "/" + g.opt_level + "/" + g.binary;
+    function binaryKey(g) { return g.project + "/" + g.opt_level + "/" + g.binary; }
+    // Did decompiler d produce output for this function? (back-compat: infer from
+    // metric presence if older data lacks the `decompiled` map.)
+    function decompiledBy(func, d) {
+        const dd = func.decompiled;
+        if (dd && (d in dd)) return dd[d];
+        return !!func.perfects[d];
     }
-
-    // A function is active iff it belongs to the selected dataset preset. With
-    // no presets (older data) everything is active.
+    function allDecompiled(func) {
+        for (const d of DATA.decompilers) if (!decompiledBy(func, d)) return false;
+        return true;
+    }
     function isActive(group, func) {
+        if (state.normalize && !allDecompiled(func)) return false;
         if (!state.dataset) return true;
-        const ds = func.datasets || [];
-        return ds.indexOf(state.dataset) >= 0;
+        return (func.datasets || []).indexOf(state.dataset) >= 0;
     }
-
     function groupHasActive(group) {
-        for (const func of group.functions) {
-            if (isActive(group, func)) return true;
-        }
-        return false;
+        return group.functions.some(f => isActive(group, f));
     }
-
-    function pctClass(pct) {
-        if (pct >= 50) return "high";
-        if (pct >= 20) return "mid";
-        return "low";
-    }
-
+    function pctClass(p) { return p >= 50 ? "high" : (p >= 20 ? "mid" : "low"); }
     function asciiBar(pct, width) {
         width = width || 12;
         let p = Math.max(0, Math.min(pct, 100));
@@ -622,195 +722,322 @@ def _build_script(function_data: FunctionData) -> str:
         filled = Math.max(0, Math.min(filled, width));
         return "[" + "#".repeat(filled) + "-".repeat(width - filled) + "]";
     }
+    function escapeHtml(s) {
+        return (s == null ? "" : String(s))
+            .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    }
+    function pct(cell) { return cell.total > 0 ? (cell.perfect / cell.total) * 100 : 0; }
 
-    // Recompute per (decompiler, metric) perfect counts plus Overall over
-    // active functions only, mirroring scoring/scoreboard.py semantics.
+    // GED's source CFG is decompiler-independent: a function's source parsed iff
+    // SOME decompiler obtained a GED value for it. Joern failing on the SOURCE is
+    // our own tooling's fault, so those functions are excluded from GED for every
+    // decompiler (not counted against anyone). Joern failing on a single
+    // decompiler's OUTPUT (source parsed, but that decompiler has no GED value)
+    // still counts as a GED miss for it AND is reported as a per-decompiler
+    // tooling stat on the Dataset page.
+    function hasGed(func, d) {
+        const v = func.values[d];
+        return !!(v && ("ged" in v));
+    }
+    function sourceParsed(func) {
+        if (DATA.metrics.indexOf("ged") < 0) return true;
+        for (const d of DATA.decompilers) if (hasGed(func, d)) return true;
+        return false;
+    }
+
+    // ---- Recompute aggregates over the active dataset ----
     function recompute() {
-        const decs = DATA.decompilers;
-        const metrics = DATA.metrics;
-
-        // dec -> metric -> {perfect, total}
-        const perMetric = {};
-        // dec -> {perfect, total}
-        const overall = {};
+        const decs = DATA.decompilers, metrics = DATA.metrics;
+        const perMetric = {}, overall = {}, errors = {}, joernOutFail = {};
         for (const d of decs) {
             perMetric[d] = {};
             for (const m of metrics) perMetric[d][m] = {perfect: 0, total: 0};
             overall[d] = {perfect: 0, total: 0};
+            errors[d] = {errored: 0, scope: 0};  // scope = functions d attempted
+            joernOutFail[d] = {failed: 0, scope: 0};  // Joern failed on d's output
         }
-
-        // binKey -> dec -> metric -> {perfect, total}
-        const perBinary = {};
-        let activeFunctions = 0;
-        let totalFunctions = 0;
-
+        let activeFunctions = 0, totalFunctions = 0, activeBins = 0;
         for (const group of DATA.groups) {
-            const bk = binaryKey(group);
-            perBinary[bk] = {};
-            for (const d of decs) {
-                perBinary[bk][d] = {};
-                for (const m of metrics) {
-                    perBinary[bk][d][m] = {perfect: 0, total: 0};
-                }
-                perBinary[bk][d].__overall__ = {perfect: 0, total: 0};
-            }
-
+            let groupActive = false;
             for (const func of group.functions) {
                 totalFunctions += 1;
                 if (!isActive(group, func)) continue;
-                activeFunctions += 1;
-
+                activeFunctions += 1; groupActive = true;
+                const srcOk = sourceParsed(func);
                 for (const d of decs) {
-                    const fperf = func.perfects[d];
-                    if (!fperf) continue;
-
+                    // Errors: a function is "in scope" for d if d attempted it
+                    // (present in the decompiled map); errored if it didn't
+                    // produce output (failed / timed out).
+                    const dd = func.decompiled || {};
+                    if (d in dd) {
+                        errors[d].scope += 1;
+                        if (!dd[d]) errors[d].errored += 1;
+                    }
+                    // DENOMINATOR = functions d decompiled (one denominator for
+                    // every metric). A metric not computed on a decompiled
+                    // function counts as not-perfect (it still counts in total) —
+                    // EXCEPT GED excludes functions where our source parser (Joern)
+                    // failed on the source, since that's not the decompiler's fault.
+                    if (!decompiledBy(func, d)) continue;
+                    const fperf = func.perfects[d] || {};
                     for (const m of metrics) {
-                        if (!(m in fperf)) continue;
+                        if (m === "ged" && !srcOk) continue;  // source-parse fail: exclude
                         perMetric[d][m].total += 1;
-                        perBinary[bk][d][m].total += 1;
-                        if (fperf[m]) {
-                            perMetric[d][m].perfect += 1;
-                            perBinary[bk][d][m].perfect += 1;
-                        }
+                        if (fperf[m]) perMetric[d][m].perfect += 1;
                     }
-
-                    // Overall: perfect on EVERY metric in DATA.metrics that
-                    // appears in perfects[d], AND all DATA.metrics present.
-                    let hasAll = true;
-                    let allPerfect = true;
-                    for (const m of metrics) {
-                        if (!(m in fperf)) { hasAll = false; break; }
-                        if (!fperf[m]) allPerfect = false;
+                    // Per-decompiler Joern-on-output failure (source parsed but
+                    // Joern couldn't parse THIS decompiler's output) — a tooling
+                    // diagnostic surfaced on the Dataset page, not a score.
+                    if (srcOk) {
+                        joernOutFail[d].scope += 1;
+                        if (!hasGed(func, d)) joernOutFail[d].failed += 1;
                     }
-                    overall[d].total += 1;
-                    perBinary[bk][d].__overall__.total += 1;
-                    if (hasAll && allPerfect) {
-                        overall[d].perfect += 1;
-                        perBinary[bk][d].__overall__.perfect += 1;
+                    // Overall (perfect on ALL metrics) needs GED, so it too
+                    // excludes source-parse failures from its denominator.
+                    if (srcOk) {
+                        overall[d].total += 1;
+                        let allPerfect = true;
+                        for (const m of metrics) { if (!fperf[m]) { allPerfect = false; break; } }
+                        if (allPerfect) overall[d].perfect += 1;
                     }
                 }
             }
+            if (groupActive) activeBins += 1;
         }
-
-        return {perMetric, overall, perBinary, activeFunctions, totalFunctions};
+        return {perMetric, overall, errors, joernOutFail, activeFunctions, totalFunctions, activeBins};
     }
 
-    function pct(cell) {
-        return cell.total > 0 ? (cell.perfect / cell.total) * 100 : 0;
-    }
-
-    function cellHtml(cell) {
+    // ---- Leaderboard (swebench-style sortable table) ----
+    function cellPctHtml(cell) {
         const p = pct(cell);
-        const cls = pctClass(p);
-        return '<span class="bar-ascii">' + asciiBar(p, 10) + '</span> ' +
-            '<span class="pct-' + cls + '">' +
-            p.toFixed(1) + '% (' + cell.perfect + '/' + cell.total + ')</span>';
+        return '<span class="bar-ascii">' + asciiBar(p, 8) + '</span> ' +
+            '<span class="cell-pct pct-' + pctClass(p) + '">' + p.toFixed(1) + '%</span> ' +
+            '<span class="cell-count">(' + cell.perfect + '/' + cell.total + ')</span>';
+    }
+    // Errors: lower is better, so the color scale is inverted vs metrics.
+    function errPctClass(p) { return p < 2 ? "high" : (p < 10 ? "mid" : "low"); }
+    function errRate(cell) { return cell.scope > 0 ? (cell.errored / cell.scope) * 100 : 0; }
+    function errorCellHtml(cell) {
+        const p = errRate(cell);
+        return '<span class="cell-pct pct-' + errPctClass(p) + '">' + p.toFixed(1) + '%</span> ' +
+            '<span class="cell-count">(' + cell.errored + '/' + cell.scope + ')</span>';
+    }
+    function sortValue(d, key, result) {
+        if (key === "__name__") return d;
+        if (key === "__errors__") return errRate(result.errors[d]);
+        const cell = key === "__overall__" ? result.overall[d] : result.perMetric[d][key];
+        return pct(cell);
+    }
+    function buildLeaderboard(result) {
+        const tbl = document.getElementById("leaderboard-table");
+        if (!tbl) return;
+        const decs = DATA.decompilers.slice(), metrics = orderedMetrics();
+        // Header. "Errors" = how often the decompiler failed/timed out on a
+        // function it was asked to decompile (lower is better).
+        const cols = [["__name__", "decompiler"], ["__overall__", "Overall"]];
+        for (const m of metrics) cols.push([m, METRIC_SHORT[m] || m]);
+        cols.push(["__errors__", "Errors"]);
+        let head = "<th>#</th>";
+        for (const [key, label] of cols) {
+            const arrow = state.sortKey === key ? (state.sortDir < 0 ? " ▼" : " ▲") : "";
+            const cls = "sortable" + (key === "__overall__" ? " col-overall" : "");
+            head += '<th class="' + cls + '" data-sort="' + key + '">' +
+                escapeHtml(label) + '<span class="arrow">' + arrow + '</span></th>';
+        }
+        tbl.querySelector("thead tr").innerHTML = head;
+        // Sort.
+        decs.sort((a, b) => {
+            let va = sortValue(a, state.sortKey, result), vb = sortValue(b, state.sortKey, result);
+            if (typeof va === "string") return state.sortDir * va.localeCompare(vb);
+            return state.sortDir * (va - vb);
+        });
+        // Rows.
+        let body = "";
+        decs.forEach((d, i) => {
+            const ver = DATA.decompiler_versions && DATA.decompiler_versions[d];
+            const tip = ver ? (d + " — version " + ver) : d;
+            let row = '<tr class="binrow"><td class="lb-rank">#' + (i + 1) + '</td>' +
+                '<td class="lb-name" title="' + escapeHtml(tip) + '">' + escapeHtml(d) + '</td>';
+            row += '<td class="metric-cell col-overall">' + cellPctHtml(result.overall[d]) + '</td>';
+            for (const m of metrics) row += '<td class="metric-cell">' + cellPctHtml(result.perMetric[d][m]) + '</td>';
+            row += '<td class="metric-cell">' + errorCellHtml(result.errors[d]) + '</td>';
+            row += '</tr>';
+            body += row;
+        });
+        tbl.querySelector("tbody").innerHTML = body;
+        tbl.querySelectorAll("th.sortable").forEach(th => {
+            th.addEventListener("click", () => {
+                const key = th.getAttribute("data-sort");
+                if (state.sortKey === key) state.sortDir *= -1;
+                else { state.sortKey = key; state.sortDir = (key === "__name__") ? 1 : -1; }
+                buildLeaderboard(lastResult);
+            });
+        });
     }
 
-    function buildMatrix(result) {
-        const decs = DATA.decompilers;
-        const metrics = DATA.metrics;
-        const tbl = document.querySelector("#comparison-matrix table");
-        const thead = tbl.querySelector("thead tr");
-        thead.innerHTML = "<th>metric</th>";
+    // ---- Metrics perfect-rate table ----
+    function buildMetricsTable(result) {
+        const tbl = document.getElementById("metrics-perfect-table");
+        if (!tbl) return;
+        const decs = DATA.decompilers, metrics = orderedMetrics();
+        let head = "<th>decompiler</th>";
+        for (const m of metrics) head += "<th>" + escapeHtml(METRIC_SHORT[m] || m) + "</th>";
+        head += '<th class="col-overall">Overall</th><th>Errors</th>';
+        tbl.querySelector("thead tr").innerHTML = head;
+        let body = "";
         for (const d of decs) {
-            const th = document.createElement("th");
-            th.textContent = d;
-            thead.appendChild(th);
+            const ver = DATA.decompiler_versions && DATA.decompiler_versions[d];
+            const tip = ver ? (d + " — version " + ver) : d;
+            let row = '<tr><td class="lb-name" title="' + escapeHtml(tip) + '">' + escapeHtml(d) + '</td>';
+            for (const m of metrics) row += '<td class="metric-cell">' + cellPctHtml(result.perMetric[d][m]) + '</td>';
+            row += '<td class="metric-cell col-overall">' + cellPctHtml(result.overall[d]) + '</td>';
+            row += '<td class="metric-cell">' + errorCellHtml(result.errors[d]) + '</td>';
+            row += '</tr>';
+            body += row;
         }
-        const tbody = tbl.querySelector("tbody");
-        tbody.innerHTML = "";
-        const rows = metrics.slice();
-        rows.push("__overall__");
-        for (const m of rows) {
-            const tr = document.createElement("tr");
-            const label = m === "__overall__"
-                ? "Overall" : (METRIC_NAMES[m] || m);
-            const tdName = document.createElement("td");
-            tdName.textContent = label;
-            tr.appendChild(tdName);
-            for (const d of decs) {
-                const td = document.createElement("td");
-                const cell = m === "__overall__"
-                    ? result.overall[d] : result.perMetric[d][m];
-                td.innerHTML = cellHtml(cell);
-                tr.appendChild(td);
-            }
-            tbody.appendChild(tr);
-        }
+        tbl.querySelector("tbody").innerHTML = body;
     }
 
-    function buildPerBinary(result) {
-        const decs = DATA.decompilers;
-        const sel = document.getElementById("breakdown-metric");
-        const metric = sel.value || "__overall__";
-        const tbl = document.querySelector("#per-binary-breakdown table");
-        const thead = tbl.querySelector("thead tr");
-        thead.innerHTML = "<th>binary</th>";
-        for (const d of decs) {
-            const th = document.createElement("th");
-            th.textContent = d;
-            thead.appendChild(th);
+    // ---- Dataset / About page (static; describes the whole corpus) ----
+    const CATEGORY_LABELS = {
+        "parser": ["parsing", "text-processing", "compression", "archiving"],
+        "webserver": ["server", "daemon"],
+        "cryptography": ["crypto", "security"],
+        "malware": ["malware"],
+        "firmware": ["cps"]
+    };
+    function projectStats() {
+        const m = {};
+        for (const g of DATA.groups) {
+            let p = m[g.project];
+            if (!p) p = m[g.project] = {labels: new Set(), binaries: new Set(), functions: 0};
+            (g.labels || []).forEach(l => p.labels.add(l));
+            p.binaries.add(g.binary);
+            p.functions += g.functions.length;
         }
-        const tbody = tbl.querySelector("tbody");
-        tbody.innerHTML = "";
-        for (const group of DATA.groups) {
-            const bk = binaryKey(group);
-            if (!groupHasActive(group)) continue;
-            const tr = document.createElement("tr");
-            // Tooltip: the function name(s) this binary contributes to the
-            // current dataset (for `tiny` that is exactly one function).
-            const fns = [];
-            for (const func of group.functions) {
-                if (isActive(group, func)) fns.push(func.function);
-            }
-            const MAX_TIP = 25;
-            let tip = fns.slice(0, MAX_TIP).join(", ");
-            if (fns.length > MAX_TIP) tip += ", (+" + (fns.length - MAX_TIP) + " more)";
-            tr.title = (fns.length === 1)
-                ? ("function: " + fns[0])
-                : (fns.length + " functions: " + tip);
-            tr.className = "binrow";
-            const tdName = document.createElement("td");
-            tdName.textContent = bk;
-            tr.appendChild(tdName);
-            for (const d of decs) {
-                const td = document.createElement("td");
-                const cell = result.perBinary[bk][d][metric];
-                td.innerHTML = cellHtml(cell);
-                tr.appendChild(td);
-            }
-            tbody.appendChild(tr);
-        }
+        return m;
     }
-
-    function updateRankingTables(result) {
-        const decs = DATA.decompilers;
-        const metrics = DATA.metrics;
-        const targets = metrics.slice();
-        targets.push("__overall__");
-        for (const m of targets) {
-            for (const d of decs) {
-                const row = document.querySelector(
-                    'tr[data-ranking-row="' + m + '"][data-decompiler="' +
-                    d + '"]');
-                if (!row) continue;
-                const cell = m === "__overall__"
-                    ? result.overall[d] : result.perMetric[d][m];
-                const p = pct(cell);
-                const cls = pctClass(p);
-                const bar = row.querySelector('[data-bar]');
-                if (bar) {
-                    bar.textContent = asciiBar(p, 12);
+    function categoriesOf(labelSet) {
+        const cats = [];
+        for (const cat in CATEGORY_LABELS) {
+            if (CATEGORY_LABELS[cat].some(l => labelSet.has(l))) cats.push(cat);
+        }
+        return cats;
+    }
+    function buildDataset() {
+        const di = DATA.dataset_info || {};
+        const loc = di.loc_by_project || {};
+        const stats = projectStats();
+        const proj = Object.keys(stats).sort().map(n => ({
+            name: n, cats: categoriesOf(stats[n].labels), loc: loc[n] || 0,
+            binaries: stats[n].binaries.size, functions: stats[n].functions
+        }));
+        // Category highlight buttons.
+        const cc = document.getElementById("category-controls");
+        const ORDER = ["parser", "webserver", "cryptography", "malware", "firmware"];
+        if (cc) {
+            cc.innerHTML = ORDER.map(cat => {
+                const cnt = proj.filter(p => p.cats.indexOf(cat) >= 0).length;
+                return '<button class="ds-btn cat-btn" data-cat="' + cat + '">' +
+                    cat + ' (' + cnt + ')</button>';
+            }).join("");
+            cc.querySelectorAll(".cat-btn").forEach(b => b.addEventListener("click", () => {
+                const cat = b.getAttribute("data-cat");
+                const turnOn = !b.classList.contains("active");
+                cc.querySelectorAll(".cat-btn").forEach(x => x.classList.remove("active"));
+                document.querySelectorAll("#dataset-projects tbody tr")
+                    .forEach(tr => tr.classList.remove("cat-hl"));
+                if (turnOn) {
+                    b.classList.add("active");
+                    document.querySelectorAll('#dataset-projects tbody tr[data-cats~="' + cat + '"]')
+                        .forEach(tr => tr.classList.add("cat-hl"));
                 }
-                const pctEl = row.querySelector('[data-pct]');
-                if (pctEl) {
-                    pctEl.className = "pct pct-" + cls;
-                    pctEl.textContent = p.toFixed(1) + "%";
-                }
-                const cnt = row.querySelector('[data-count]');
-                if (cnt) cnt.textContent = cell.perfect + "/" + cell.total;
+            }));
+        }
+        // Summary.
+        const totalLoc = di.total_loc || 0;
+        const totalFuncs = proj.reduce((a, p) => a + p.functions, 0);
+        const totalBins = proj.reduce((a, p) => a + p.binaries, 0);
+        const j = di.joern || {};
+        const builds = DATA.groups.length;  // binary × opt-level instances
+        const sum = document.getElementById("dataset-summary");
+        if (sum) {
+            sum.innerHTML = '<div class="goal-body">' +
+                '<div><span class="num" style="color:var(--green)">' + proj.length +
+                '</span> projects &middot; <strong>' + totalBins.toLocaleString() +
+                '</strong> unique binaries &middot; <strong>' + builds.toLocaleString() +
+                '</strong> builds (across opt levels) &middot; <strong>' + totalFuncs.toLocaleString() +
+                '</strong> function instances</div>' +
+                '<div><strong>' + totalLoc.toLocaleString() +
+                '</strong> total source lines of code (project .c files)</div>' +
+                '</div>';
+        }
+        // Pipeline health: source-side GED loss, measured from the run itself —
+        // a benchmark function has NO source CFG iff no decompiler ever got a GED
+        // value for it (source CFGs are decompiler-independent). This is the real
+        // share of functions GED can't score because OUR source front-end (Joern)
+        // failed or was too slow on the source.
+        let srcTotal = 0, srcLost = 0;
+        for (const g of DATA.groups) for (const f of g.functions) {
+            if (!DATA.decompilers.some(d => decompiledBy(f, d))) continue;
+            srcTotal += 1;
+            if (!sourceParsed(f)) srcLost += 1;
+        }
+        const srcPct = srcTotal ? (100 * srcLost / srcTotal) : 0;
+        const js = document.getElementById("joern-source");
+        if (js) {
+            js.innerHTML = '<div class="goal-body"><div class="perfect">' +
+                'No source CFG (GED unmeasurable — our source front-end failed/timed out): ' +
+                '<strong>' + srcPct.toFixed(1) + '%</strong> of benchmark functions (' +
+                srcLost.toLocaleString() + '/' + srcTotal.toLocaleString() +
+                '). These are excluded from GED for every decompiler.</div>' +
+                (j.files_sampled ? ('<div class="view-desc" style="margin-top:0.3rem;">' +
+                    'Direct re-parse spot-check: ' + j.files_failed + '/' + j.files_sampled +
+                    ' sampled source files outright failed' +
+                    (j.files_timed_out ? (' (' + j.files_timed_out +
+                    ' more too slow to finish — the dominant real-world failure mode)') : '') +
+                    '.</div>') : '') +
+                '</div>';
+        }
+        // Pipeline health: Joern failures on each decompiler's OUTPUT (corpus-wide).
+        const jof = {};
+        DATA.decompilers.forEach(d => jof[d] = {failed: 0, scope: 0});
+        for (const g of DATA.groups) for (const f of g.functions) {
+            if (!sourceParsed(f)) continue;
+            for (const d of DATA.decompilers) {
+                if (!decompiledBy(f, d)) continue;
+                jof[d].scope += 1;
+                if (!hasGed(f, d)) jof[d].failed += 1;
             }
+        }
+        const jt = document.getElementById("joern-output-table");
+        if (jt) {
+            jt.querySelector("thead tr").innerHTML =
+                "<th>decompiler</th><th>Joern failed on output</th>";
+            jt.querySelector("tbody").innerHTML = DATA.decompilers.slice().sort((a, b) =>
+                (jof[a].scope ? jof[a].failed / jof[a].scope : 0) -
+                (jof[b].scope ? jof[b].failed / jof[b].scope : 0)
+            ).map(d => {
+                const s = jof[d], p = s.scope ? (100 * s.failed / s.scope) : 0;
+                return '<tr><td class="lb-name">' + escapeHtml(d) + '</td>' +
+                    '<td class="metric-cell"><span class="cell-pct pct-' + errPctClass(p) + '">' +
+                    p.toFixed(1) + '%</span> <span class="cell-count">(' + s.failed + '/' +
+                    s.scope + ')</span></td></tr>';
+            }).join("");
+        }
+        // Projects table (sorted by LOC desc).
+        const tbl = document.getElementById("dataset-projects");
+        if (tbl) {
+            tbl.querySelector("thead tr").innerHTML =
+                "<th>project</th><th>types</th><th>LOC</th><th>binaries</th><th>functions</th>";
+            tbl.querySelector("tbody").innerHTML = proj.sort((a, b) => b.loc - a.loc).map(p =>
+                '<tr data-cats="' + p.cats.join(" ") + '">' +
+                '<td class="lb-name">' + escapeHtml(p.name) + '</td>' +
+                '<td class="cell-count">' + (p.cats.join(", ") || "—") + '</td>' +
+                '<td>' + (p.loc ? p.loc.toLocaleString() : "—") + '</td>' +
+                '<td>' + p.binaries + '</td>' +
+                '<td>' + p.functions.toLocaleString() + '</td></tr>'
+            ).join("");
         }
     }
 
@@ -818,36 +1045,91 @@ def _build_script(function_data: FunctionData) -> str:
         const fnEl = document.querySelector('[data-stat="functions"]');
         if (fnEl) fnEl.textContent = result.activeFunctions.toLocaleString();
         const binEl = document.querySelector('[data-stat="binaries"]');
-        if (binEl) {
-            let active = 0;
-            for (const group of DATA.groups) {
-                if (groupHasActive(group)) active += 1;
-            }
-            binEl.textContent = active.toLocaleString();
-        }
-    }
-
-    function refresh() {
-        const result = recompute();
-        buildMatrix(result);
-        buildPerBinary(result);
-        updateRankingTables(result);
-        updateStats(result);
+        if (binEl) binEl.textContent = result.activeBins.toLocaleString();
         const counter = document.getElementById("function-counter");
         if (counter) {
-            const dsName = state.dataset ? ("[" + state.dataset + "] ") : "";
-            counter.textContent = dsName + "showing " + result.activeFunctions +
-                " / " + result.totalFunctions + " functions";
+            const ds = state.dataset ? ("[" + state.dataset + "] ") : "";
+            counter.textContent = ds + result.activeFunctions + " / " + result.totalFunctions + " fns";
         }
     }
 
-    // ---- Hardest Functions view -----------------------------------------
-    function escapeHtml(s) {
-        return (s == null ? "" : String(s))
-            .replace(/&/g, "&amp;").replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;");
+    let lastResult = null;
+    function refresh() {
+        lastResult = recompute();
+        buildLeaderboard(lastResult);
+        buildMetricsTable(lastResult);
+        updateStats(lastResult);
     }
 
+    // ---- Compare view ----
+    function sampleLabel(s) {
+        return s.project + "/" + s.opt_level + "/" + s.binary + " :: " + s.function;
+    }
+    function renderCompare() {
+        const sel = document.getElementById("cmp-select");
+        const body = document.getElementById("compare-body");
+        if (!sel || !body) return;
+        const idx = parseInt(sel.value, 10);
+        const samples = DATA.samples || [];
+        const s = samples[idx];
+        if (!s) { body.innerHTML = '<p class="view-desc">no sample selected.</p>'; return; }
+        const decs = Object.keys(s.decompiled || {});
+        const cols = (s.source_code ? 1 : 0) + decs.length;
+        let html = '<div class="cmp-meta">' + escapeHtml(s.project) + '/' +
+            escapeHtml(s.opt_level) + '/' + escapeHtml(s.binary) +
+            ' &middot; ' + escapeHtml(s.function) +
+            (s.size != null ? (' &middot; ' + s.size + ' lines') : '') +
+            (s.labels && s.labels.length ? (' &middot; ' + escapeHtml(s.labels.join(", "))) : '') +
+            '</div>';
+        html += '<div class="cmp-grid" style="grid-template-columns:repeat(' +
+            Math.max(1, cols) + ',minmax(0,1fr));">';
+        if (s.source_code) {
+            html += '<div class="cmp-col src"><h4>source (ground truth)</h4>' +
+                '<pre><code>' + escapeHtml(s.source_code) + '</code></pre></div>';
+        }
+        for (const d of decs) {
+            const vals = (s.values && s.values[d]) || {};
+            const perf = (s.perfects && s.perfects[d]) || {};
+            let scores = "";
+            for (const m of DATA.metrics) {
+                if (!(m in vals)) continue;
+                const ok = perf[m] ? "pct-high" : "pct-low";
+                scores += '<span class="sc ' + ok + '">' + (METRIC_SHORT[m] || m) +
+                    ' ' + Number(vals[m]).toFixed(2) + '</span>';
+            }
+            html += '<div class="cmp-col"><h4>' + escapeHtml(d) + '</h4>' +
+                '<div class="cmp-scores">' + (scores || '&mdash;') + '</div>' +
+                '<pre><code>' + escapeHtml(s.decompiled[d]) + '</code></pre></div>';
+        }
+        html += '</div>';
+        body.innerHTML = html;
+    }
+    function populateCompare() {
+        const sel = document.getElementById("cmp-select");
+        const filter = document.getElementById("cmp-filter");
+        const counter = document.getElementById("cmp-counter");
+        if (!sel) return;
+        const samples = DATA.samples || [];
+        function fill() {
+            const q = (filter && filter.value || "").toLowerCase();
+            sel.innerHTML = "";
+            let shown = 0;
+            samples.forEach((s, i) => {
+                const label = sampleLabel(s);
+                if (q && label.toLowerCase().indexOf(q) < 0) return;
+                const o = document.createElement("option");
+                o.value = i; o.textContent = label;
+                sel.appendChild(o); shown += 1;
+            });
+            if (counter) counter.textContent = shown + " / " + samples.length + " samples";
+            renderCompare();
+        }
+        sel.addEventListener("change", renderCompare);
+        if (filter) filter.addEventListener("input", fill);
+        fill();
+    }
+
+    // ---- Hardest view ----
     function renderHardest() {
         const list = document.getElementById("hardest-list");
         if (!list) return;
@@ -856,9 +1138,7 @@ def _build_script(function_data: FunctionData) -> str:
         const dSel = document.getElementById("hard-dec");
         const mFilter = mSel ? mSel.value : "__all__";
         const dFilter = dSel ? dSel.value : "__all__";
-
-        let shown = 0;
-        let html = "";
+        let shown = 0, html = "";
         for (const e of entries) {
             if (mFilter !== "__all__" && e.metric !== mFilter) continue;
             if (dFilter !== "__all__" && e.decompiler !== dFilter) continue;
@@ -866,194 +1146,101 @@ def _build_script(function_data: FunctionData) -> str:
             const metricLabel = METRIC_NAMES[e.metric] || e.metric;
             const sizeStr = (e.size != null) ? (e.size + " lines") : "? lines";
             html += '<div class="hard-entry">';
-            html += '<div class="hard-head"><span class="fn">' +
-                escapeHtml(e.function) + '</span> &middot; ' +
-                escapeHtml(e.decompiler) + ' &middot; ' +
+            html += '<div class="hard-head"><span class="fn">' + escapeHtml(e.function) +
+                '</span> &middot; ' + escapeHtml(e.decompiler) + ' &middot; ' +
                 escapeHtml(metricLabel) + '</div>';
-            html += '<div class="hard-meta">' +
-                '<span class="tag">' + escapeHtml(e.project) + '/' +
+            html += '<div class="hard-meta"><span class="tag">' + escapeHtml(e.project) + '/' +
                 escapeHtml(e.opt_level) + '/' + escapeHtml(e.binary) + '</span>' +
-                '<span class="tag score-bad">score ' +
-                Number(e.value).toFixed(3) + ' (perfect ' +
-                Number(e.perfect_value).toFixed(3) + ')</span>' +
-                '<span class="tag">' + escapeHtml(sizeStr) + '</span>' +
-                '</div>';
+                '<span class="tag score-bad">score ' + Number(e.value).toFixed(3) +
+                ' (perfect ' + Number(e.perfect_value).toFixed(3) + ')</span>' +
+                '<span class="tag">' + escapeHtml(sizeStr) + '</span></div>';
+            const cols = (e.decompiled_code ? 1 : 0) + (e.source_code ? 1 : 0);
+            html += '<div class="cmp-grid" style="grid-template-columns:repeat(' +
+                Math.max(1, cols) + ',minmax(0,1fr));">';
             if (e.decompiled_code) {
-                html += '<div class="code-label">decompiled:</div>';
-                html += '<pre><code>' + escapeHtml(e.decompiled_code) +
-                    '</code></pre>';
+                html += '<div class="cmp-col"><h4>' + escapeHtml(e.decompiler) +
+                    '</h4><pre><code>' + escapeHtml(e.decompiled_code) + '</code></pre></div>';
             }
             if (e.source_code) {
-                html += '<div class="code-label">source:</div>';
-                html += '<pre><code>' + escapeHtml(e.source_code) +
-                    '</code></pre>';
+                html += '<div class="cmp-col src"><h4>source</h4><pre><code>' +
+                    escapeHtml(e.source_code) + '</code></pre></div>';
             }
-            html += '</div>';
+            html += '</div></div>';
         }
-        if (shown === 0) {
-            html = '<p class="desc">no entries match the current filter.</p>';
-        }
+        if (shown === 0) html = '<p class="view-desc">no entries match the current filter.</p>';
         list.innerHTML = html;
         const counter = document.getElementById("hard-counter");
-        if (counter) {
-            counter.textContent = "showing " + shown + " / " +
-                entries.length + " entries";
-        }
+        if (counter) counter.textContent = "showing " + shown + " / " + entries.length;
     }
-
     function initHardest() {
         const entries = DATA.hardest || [];
         if (!entries.length) return;
-        const mSel = document.getElementById("hard-metric");
-        const dSel = document.getElementById("hard-dec");
+        const mSel = document.getElementById("hard-metric"), dSel = document.getElementById("hard-dec");
         if (!mSel || !dSel) return;
-        const metrics = [];
-        const decs = [];
+        const metrics = [], decs = [];
         for (const e of entries) {
             if (metrics.indexOf(e.metric) < 0) metrics.push(e.metric);
             if (decs.indexOf(e.decompiler) < 0) decs.push(e.decompiler);
         }
-        metrics.sort();
-        decs.sort();
+        metrics.sort(); decs.sort();
         for (const m of metrics) {
             const o = document.createElement("option");
-            o.value = m;
-            o.textContent = METRIC_NAMES[m] || m;
-            mSel.appendChild(o);
+            o.value = m; o.textContent = METRIC_NAMES[m] || m; mSel.appendChild(o);
         }
         for (const d of decs) {
             const o = document.createElement("option");
-            o.value = d;
-            o.textContent = d;
-            dSel.appendChild(o);
+            o.value = d; o.textContent = d; dSel.appendChild(o);
         }
         mSel.addEventListener("change", renderHardest);
         dSel.addEventListener("change", renderHardest);
         renderHardest();
     }
 
-    // ---- Historical view (inline SVG line charts) -----------------------
-    const CHART_COLORS = [
-        "#6ab04c", "#4a90d9", "#d4a72c", "#c0504d", "#9b59b6",
-        "#1abc9c", "#e67e22", "#7f8c8d", "#e84393", "#00cec9"
-    ];
-
-    function baseName(dec) {
-        // Strip a "@version" suffix for grouping by base decompiler name.
-        const at = dec.indexOf("@");
-        return at >= 0 ? dec.substring(0, at) : dec;
-    }
-
+    // ---- Historical (SVG) ----
+    const CHART_COLORS = ["#6ab04c","#4a90d9","#d4a72c","#c0504d","#9b59b6","#1abc9c","#e67e22","#7f8c8d","#e84393","#00cec9"];
+    function baseName(dec) { const a = dec.indexOf("@"); return a >= 0 ? dec.substring(0, a) : dec; }
     function svgEl(tag, attrs) {
-        const NS = "http://www.w3.org/2000/svg";
-        const el = document.createElementNS(NS, tag);
+        const el = document.createElementNS("http://www.w3.org/2000/svg", tag);
         for (const k in attrs) el.setAttribute(k, attrs[k]);
         return el;
     }
-
-    // Build one chart: metricKey is a metric name or "__overall__".
     function buildChart(container, metricKey, title) {
         const history = DATA.history || [];
-        // Ordered list of distinct versions (x-axis), in first-seen order.
         const versions = [];
-        for (const h of history) {
-            if (versions.indexOf(h.version) < 0) versions.push(h.version);
-        }
-        // dec base name -> {version -> value}
+        for (const h of history) if (versions.indexOf(h.version) < 0) versions.push(h.version);
         const lines = {};
         for (const h of history) {
             const bn = baseName(h.decompiler);
-            let val;
-            if (metricKey === "__overall__") val = h.overall;
-            else val = (h.scores && (metricKey in h.scores)) ?
-                h.scores[metricKey] : null;
+            let val = metricKey === "__overall__" ? h.overall :
+                (h.scores && (metricKey in h.scores) ? h.scores[metricKey] : null);
             if (val == null) continue;
             if (!lines[bn]) lines[bn] = {};
             lines[bn][h.version] = val;
         }
         const decNames = Object.keys(lines).sort();
         if (!decNames.length || versions.length < 1) return;
-
         const block = document.createElement("div");
         block.className = "chart-block";
-        const h3 = document.createElement("h3");
-        h3.textContent = title;
-        block.appendChild(h3);
-
-        const W = 760, H = 280;
-        const padL = 46, padR = 16, padT = 14, padB = 40;
-        const plotW = W - padL - padR;
-        const plotH = H - padT - padB;
-        const svg = svgEl("svg", {
-            viewBox: "0 0 " + W + " " + H, width: W, height: H,
-            role: "img"
-        });
-
-        function xFor(i) {
-            if (versions.length === 1) return padL + plotW / 2;
-            return padL + (plotW * i) / (versions.length - 1);
-        }
-        function yFor(v) {
-            return padT + plotH - (plotH * Math.max(0, Math.min(v, 100)) / 100);
-        }
-
-        // Gridlines + y-axis labels (0..100 step 25).
+        const h3 = document.createElement("h3"); h3.textContent = title; block.appendChild(h3);
+        const W = 760, H = 280, padL = 46, padR = 16, padT = 14, padB = 40;
+        const plotW = W - padL - padR, plotH = H - padT - padB;
+        const svg = svgEl("svg", {viewBox: "0 0 " + W + " " + H, width: W, height: H, role: "img"});
+        const xFor = i => versions.length === 1 ? padL + plotW / 2 : padL + (plotW * i) / (versions.length - 1);
+        const yFor = v => padT + plotH - (plotH * Math.max(0, Math.min(v, 100)) / 100);
         for (let g = 0; g <= 100; g += 25) {
             const y = yFor(g);
-            svg.appendChild(svgEl("line", {
-                x1: padL, y1: y, x2: W - padR, y2: y,
-                stroke: "#333", "stroke-width": 1,
-                "stroke-dasharray": "3 3"
-            }));
-            const lbl = svgEl("text", {
-                x: padL - 6, y: y + 4, "text-anchor": "end",
-                fill: "#8a8a8a", "font-size": 11,
-                "font-family": "Source Code Pro, monospace"
-            });
-            lbl.textContent = g + "%";
-            svg.appendChild(lbl);
+            svg.appendChild(svgEl("line", {x1: padL, y1: y, x2: W - padR, y2: y, stroke: "#333", "stroke-width": 1, "stroke-dasharray": "3 3"}));
+            const lbl = svgEl("text", {x: padL - 6, y: y + 4, "text-anchor": "end", fill: "#8a8a8a", "font-size": 11, "font-family": "Source Code Pro, monospace"});
+            lbl.textContent = g + "%"; svg.appendChild(lbl);
         }
-
-        // Axes.
-        svg.appendChild(svgEl("line", {
-            x1: padL, y1: padT, x2: padL, y2: padT + plotH,
-            stroke: "#666", "stroke-width": 1
-        }));
-        svg.appendChild(svgEl("line", {
-            x1: padL, y1: padT + plotH, x2: W - padR, y2: padT + plotH,
-            stroke: "#666", "stroke-width": 1
-        }));
-
-        // X-axis version labels.
+        svg.appendChild(svgEl("line", {x1: padL, y1: padT, x2: padL, y2: padT + plotH, stroke: "#666", "stroke-width": 1}));
+        svg.appendChild(svgEl("line", {x1: padL, y1: padT + plotH, x2: W - padR, y2: padT + plotH, stroke: "#666", "stroke-width": 1}));
         for (let i = 0; i < versions.length; i++) {
-            const t = svgEl("text", {
-                x: xFor(i), y: padT + plotH + 18, "text-anchor": "middle",
-                fill: "#8a8a8a", "font-size": 11,
-                "font-family": "Source Code Pro, monospace"
-            });
-            t.textContent = versions[i];
-            svg.appendChild(t);
+            const t = svgEl("text", {x: xFor(i), y: padT + plotH + 18, "text-anchor": "middle", fill: "#8a8a8a", "font-size": 11, "font-family": "Source Code Pro, monospace"});
+            t.textContent = versions[i]; svg.appendChild(t);
         }
-        // Axis titles.
-        const yTitle = svgEl("text", {
-            x: 12, y: padT + plotH / 2, fill: "#8a8a8a", "font-size": 11,
-            "text-anchor": "middle",
-            "font-family": "Source Code Pro, monospace",
-            transform: "rotate(-90 12 " + (padT + plotH / 2) + ")"
-        });
-        yTitle.textContent = "perfect %";
-        svg.appendChild(yTitle);
-        const xTitle = svgEl("text", {
-            x: padL + plotW / 2, y: H - 4, fill: "#8a8a8a", "font-size": 11,
-            "text-anchor": "middle",
-            "font-family": "Source Code Pro, monospace"
-        });
-        xTitle.textContent = "version";
-        svg.appendChild(xTitle);
-
-        // Polylines per decompiler.
         const colorByDec = {};
-        decNames.forEach(function (dn, idx) {
+        decNames.forEach((dn, idx) => {
             const color = CHART_COLORS[idx % CHART_COLORS.length];
             colorByDec[dn] = color;
             const pts = [];
@@ -1062,100 +1249,83 @@ def _build_script(function_data: FunctionData) -> str:
                 if (v == null) continue;
                 const x = xFor(i), y = yFor(v);
                 pts.push(x + "," + y);
-                svg.appendChild(svgEl("circle", {
-                    cx: x, cy: y, r: 3, fill: color
-                }));
+                svg.appendChild(svgEl("circle", {cx: x, cy: y, r: 3, fill: color}));
             }
-            if (pts.length >= 2) {
-                svg.appendChild(svgEl("polyline", {
-                    points: pts.join(" "), fill: "none",
-                    stroke: color, "stroke-width": 2
-                }));
-            }
+            if (pts.length >= 2) svg.appendChild(svgEl("polyline", {points: pts.join(" "), fill: "none", stroke: color, "stroke-width": 2}));
         });
-
         block.appendChild(svg);
-
-        // Legend.
-        const legend = document.createElement("div");
-        legend.className = "legend";
+        const legend = document.createElement("div"); legend.className = "legend";
         for (const dn of decNames) {
-            const span = document.createElement("span");
-            span.className = "item";
-            const sw = document.createElement("span");
-            sw.className = "swatch";
-            sw.style.background = colorByDec[dn];
-            span.appendChild(sw);
-            span.appendChild(document.createTextNode(dn));
-            legend.appendChild(span);
+            const span = document.createElement("span"); span.className = "item";
+            const sw = document.createElement("span"); sw.className = "swatch"; sw.style.background = colorByDec[dn];
+            span.appendChild(sw); span.appendChild(document.createTextNode(dn)); legend.appendChild(span);
         }
-        block.appendChild(legend);
-
-        container.appendChild(block);
+        block.appendChild(legend); container.appendChild(block);
     }
-
     function initHistory() {
         const container = document.getElementById("history-charts");
-        if (!container) return;
-        const history = DATA.history || [];
-        if (!history.length) return;
-        // One chart per metric, plus an overall chart.
-        const metrics = DATA.metrics || [];
-        for (const m of metrics) {
-            buildChart(container, m, METRIC_NAMES[m] || m);
-        }
+        if (!container || !(DATA.history || []).length) return;
+        for (const m of (DATA.metrics || [])) buildChart(container, m, METRIC_NAMES[m] || m);
         buildChart(container, "__overall__", "Overall (perfect on all metrics)");
     }
 
-    function init() {
-        // Metric selector options.
-        const sel = document.getElementById("breakdown-metric");
-        for (const m of DATA.metrics) {
-            const opt = document.createElement("option");
-            opt.value = m;
-            opt.textContent = METRIC_NAMES[m] || m;
-            sel.appendChild(opt);
-        }
-        const overallOpt = document.createElement("option");
-        overallOpt.value = "__overall__";
-        overallOpt.textContent = "Overall";
-        sel.appendChild(overallOpt);
-        sel.addEventListener("change", refresh);
-
-        initDatasetSelector();
-
-        refresh();
-        initHardest();
-        initHistory();
+    // ---- View routing ----
+    function showView(name) {
+        state.view = name;
+        document.querySelectorAll(".view").forEach(v => {
+            v.classList.toggle("active", v.getAttribute("data-view") === name);
+        });
+        document.querySelectorAll(".nav-item").forEach(a => {
+            a.classList.toggle("active", a.getAttribute("data-view") === name);
+        });
+    }
+    function initNav() {
+        document.querySelectorAll(".nav-item").forEach(a => {
+            a.addEventListener("click", e => {
+                e.preventDefault();
+                showView(a.getAttribute("data-view"));
+            });
+        });
+        const initial = (location.hash || "").replace("#", "");
+        const valid = Array.from(document.querySelectorAll(".view")).map(v => v.getAttribute("data-view"));
+        showView(valid.indexOf(initial) >= 0 ? initial : "leaderboard");
     }
 
     function setDatasetDesc() {
         const el = document.getElementById("dataset-desc");
         if (!el) return;
-        const p = PRESETS.filter(function (x) { return x.name === state.dataset; })[0];
+        const p = PRESETS.filter(x => x.name === state.dataset)[0];
         el.textContent = p ? p.description : "";
     }
-
-    // Wire the single dataset selector (full / hard / hard-inlined / tiny).
     function initDatasetSelector() {
-        const btns = document.querySelectorAll(".ds-btn");
-        btns.forEach(function (b) {
-            b.addEventListener("click", function () {
-                state.dataset = b.getAttribute("data-dataset");
-                btns.forEach(function (x) { x.classList.remove("active"); });
-                b.classList.add("active");
-                setDatasetDesc();
-                refresh();
-            });
-        });
+        // Only the preset buttons carry data-dataset (the normalize toggle does not).
+        const btns = document.querySelectorAll(".ds-btn[data-dataset]");
+        btns.forEach(b => b.addEventListener("click", () => {
+            state.dataset = b.getAttribute("data-dataset");
+            btns.forEach(x => x.classList.remove("active"));
+            b.classList.add("active");
+            setDatasetDesc();
+            refresh();
+        }));
         setDatasetDesc();
+        // "normalize failures": restrict to functions every decompiler decompiled.
+        const nb = document.getElementById("normalize-btn");
+        if (nb) nb.addEventListener("click", () => {
+            state.normalize = !state.normalize;
+            nb.classList.toggle("active", state.normalize);
+            refresh();
+        });
     }
 
-    if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", init);
-    } else {
-        init();
+    function init() {
+        initNav();
+        initDatasetSelector();
+        refresh();
+        buildDataset();
+        populateCompare();
+        initHardest();
+        initHistory();
     }
+    if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);
+    else init();
     </script>"""
-
-    return js.replace("__DATA__", data_json)

--- a/decbench/scoring/function_data_builder.py
+++ b/decbench/scoring/function_data_builder.py
@@ -54,6 +54,28 @@ def _line_count_for(
     return None
 
 
+def _dec_results_for(
+    decompile_results,
+    project_name: str,
+    opt_level: OptimizationLevel,
+    binary_name: str,
+) -> dict:
+    """Return ``{decompiler: DecompilationResult}`` for one binary (or {})."""
+    if not decompile_results:
+        return {}
+    opt_results = decompile_results.get(project_name) or {}
+    binary_results = opt_results.get(opt_level)
+    if binary_results is None:
+        ov = opt_level.value if hasattr(opt_level, "value") else str(opt_level)
+        for k, v in opt_results.items():
+            if (k.value if hasattr(k, "value") else str(k)) == ov:
+                binary_results = v
+                break
+    if not binary_results:
+        return {}
+    return binary_results.get(binary_name) or {}
+
+
 def build_function_data(
     evaluation_results: dict[
         str,
@@ -87,6 +109,7 @@ def build_function_data(
     decompilers_seen: set[str] = set()
     metrics_seen: set[str] = set()
     perfect_values: dict[str, float] = {}
+    decompiler_versions: dict[str, str] = {}
     groups: list[BinaryGroup] = []
 
     for project_name, opt_results in evaluation_results.items():
@@ -118,6 +141,36 @@ def build_function_data(
                             record.perfects.setdefault(dec_name, {})[metric_name] = (
                                 value.value == perfect_value
                             )
+
+                # --- Decompile success/failure universe --------------------
+                # Record, per (function, decompiler), whether the decompiler
+                # actually produced output. The universe is every name any
+                # decompiler decompiled (plus explicit failures); a decompiler
+                # that didn't produce a universe function "errored" on it (failed
+                # or timed out). This makes a decompiler's metric denominator =
+                # the set it decompiled — one denominator across all metrics — and
+                # powers the Errors column + the normalize-failures view.
+                dec_map = _dec_results_for(decompile_results, project_name, opt_level, binary_name)
+                allfail_decs: set[str] = set()
+                for dec_name, dr in dec_map.items():
+                    decompilers_seen.add(dec_name)
+                    ver = getattr(dr.decompiler, "decompiler_version", None)
+                    if ver:
+                        decompiler_versions[dec_name] = str(ver)
+                    ff = list(getattr(dr.decompiler, "failed_functions", []) or [])
+                    if ff == ["all"]:
+                        allfail_decs.add(dec_name)
+                    names = list(dr.functions.keys()) + [f for f in ff if f != "all"]
+                    for fn in names:
+                        if fn not in records:
+                            records[fn] = FunctionRecord(function=fn)
+                            func_order.append(fn)
+                for fn in func_order:
+                    rec = records[fn]
+                    for dec_name, dr in dec_map.items():
+                        ok = (dec_name not in allfail_decs) and (fn in dr.functions)
+                        # a computed metric implies the function was decompiled
+                        rec.decompiled[dec_name] = bool(ok or dec_name in rec.values)
 
                 if project is not None:
                     bin_labels = binary_labels_for(project.config, opt_value, binary_name)
@@ -151,6 +204,7 @@ def build_function_data(
     return FunctionData(
         schema_version=2,
         decompilers=sorted(decompilers_seen),
+        decompiler_versions=decompiler_versions,
         metrics=sorted(metrics_seen),
         perfect_values=perfect_values,
         groups=groups,

--- a/decbench/scoring/report_extras.py
+++ b/decbench/scoring/report_extras.py
@@ -86,6 +86,57 @@ def _lookup_decompiled(
         return None
 
 
+def _lookup_binary_path(
+    decompile_results: Any,
+    project: str,
+    opt_level: Any,
+    binary: str,
+) -> Any:
+    """Best-effort path to the original binary for a (project, opt, binary)."""
+    if not decompile_results:
+        return None
+    try:
+        opt_results = decompile_results.get(project) or {}
+        binary_results = opt_results.get(opt_level)
+        if binary_results is None:
+            ov = _opt_value(opt_level)
+            for key, val in opt_results.items():
+                if _opt_value(key) == ov:
+                    binary_results = val
+                    break
+        if not binary_results:
+            return None
+        dec_results = binary_results.get(binary) or {}
+        for dec_result in dec_results.values():
+            bp = getattr(dec_result, "binary_path", None)
+            if bp is not None:
+                return bp
+    except Exception:
+        return None
+    return None
+
+
+def _lookup_source(
+    decompile_results: Any,
+    project: str,
+    opt_level: Any,
+    binary: str,
+    func_name: str,
+) -> str | None:
+    """Best-effort original source text for one function (for side-by-side view)."""
+    bp = _lookup_binary_path(decompile_results, project, opt_level, binary)
+    if bp is None:
+        return None
+    try:
+        from pathlib import Path
+
+        from decbench.utils.source_extract import function_source
+
+        return function_source(Path(bp), func_name)
+    except Exception:
+        return None
+
+
 def _lookup_line_count(
     decompile_results: Any,
     project: str,
@@ -160,9 +211,7 @@ def build_hardest(
                 for dec_name, metric_results in (dec_results or {}).items():
                     for metric_name, result in (metric_results or {}).items():
                         if metric_name not in perfect_cache:
-                            perfect_cache[metric_name] = _perfect_value_for(
-                                metric_name
-                            )
+                            perfect_cache[metric_name] = _perfect_value_for(metric_name)
                         perfect = perfect_cache[metric_name]
                         fr = getattr(result, "function_results", None) or {}
                         for func_name, mv in fr.items():
@@ -227,12 +276,102 @@ def build_hardest(
                     size=size,
                     labels=[],
                     decompiled_code=code,
-                    source_code=None,
+                    source_code=_lookup_source(
+                        decompile_results,
+                        c["project"],
+                        c["opt_key"],
+                        c["binary"],
+                        c["function"],
+                    ),
                 )
             )
             kept += 1
 
     return entries
+
+
+def build_samples(
+    function_data: FunctionData,
+    decompile_results: Any,
+    max_samples: int = 140,
+) -> list[Any]:
+    """Curated side-by-side samples (source + each decompiler's output).
+
+    Prefers the ``tiny`` representative slice (so it spans projects/opt levels at
+    one function per binary); falls back to any function with decompiled code.
+    Requires datasets to be assigned first (see :func:`attach_extras`).
+    """
+    from decbench.models.function_data import SampleEntry
+
+    samples: list[SampleEntry] = []
+    groups = function_data.groups
+
+    def opt_key_for(group_opt: str) -> Any:
+        return group_opt  # _lookup_* tolerate string opt keys via _opt_value
+
+    candidates = [(g, f) for g in groups for f in g.functions if "tiny" in (f.datasets or [])]
+    if not candidates:
+        candidates = [(g, f) for g in groups for f in g.functions]
+
+    for g, f in candidates:
+        if len(samples) >= max_samples:
+            break
+        decompiled: dict[str, str] = {}
+        for dec in function_data.decompilers:
+            code = _lookup_decompiled(
+                decompile_results,
+                g.project,
+                opt_key_for(g.opt_level),
+                g.binary,
+                dec,
+                f.function,
+            )
+            if code:
+                decompiled[dec] = code
+        if not decompiled:
+            continue
+        source = _lookup_source(
+            decompile_results, g.project, opt_key_for(g.opt_level), g.binary, f.function
+        )
+        samples.append(
+            SampleEntry(
+                project=g.project,
+                opt_level=g.opt_level,
+                binary=g.binary,
+                function=f.function,
+                size=f.size,
+                labels=f.labels,
+                source_code=source,
+                decompiled=decompiled,
+                values=f.values,
+                perfects=f.perfects,
+            )
+        )
+    return samples
+
+
+def compute_compile_rates(evaluation_results: Any) -> dict[str, float]:
+    """decompiler -> fraction of byte_match functions whose code recompiled.
+
+    Reads the ``compilable`` flag the byte_match metric records per function.
+    """
+    comp: dict[str, int] = {}
+    tot: dict[str, int] = {}
+    for _project, opt_results in (evaluation_results or {}).items():
+        for _opt, binary_results in (opt_results or {}).items():
+            for _binary, dec_results in (binary_results or {}).items():
+                for dec_name, metric_results in (dec_results or {}).items():
+                    bm = (metric_results or {}).get("byte_match")
+                    if bm is None:
+                        continue
+                    for mv in getattr(bm, "function_results", {}).values():
+                        meta = getattr(mv, "metadata", None) or {}
+                        if "compilable" not in meta:
+                            continue
+                        tot[dec_name] = tot.get(dec_name, 0) + 1
+                        if meta.get("compilable"):
+                            comp[dec_name] = comp.get(dec_name, 0) + 1
+    return {d: comp.get(d, 0) / n for d, n in tot.items() if n}
 
 
 def build_history(
@@ -267,10 +406,7 @@ def build_history(
                         decompiler=str(decompiler),
                         version=str(version),
                         date=item.get("date"),
-                        scores={
-                            str(k): float(v)
-                            for k, v in (item.get("scores") or {}).items()
-                        },
+                        scores={str(k): float(v) for k, v in (item.get("scores") or {}).items()},
                         overall=float(item.get("overall", 0.0) or 0.0),
                     )
                 )
@@ -331,11 +467,24 @@ def attach_extras(
 
     # Tag each function with its dataset presets (full/hard/hard-inlined/tiny)
     # so the report shows a single dataset selector instead of many toggles.
+    # Must run BEFORE build_samples (which prefers the `tiny` slice).
     try:
         from decbench.scoring.datasets import assign_datasets
 
         assign_datasets(function_data)
     except Exception:
         pass
+
+    # Side-by-side Compare samples (original source vs each decompiler's output).
+    try:
+        function_data.samples = build_samples(function_data, decompile_results)
+    except Exception:
+        function_data.samples = []
+
+    # Per-decompiler recompilation (compilability) rate for the Metrics page.
+    try:
+        function_data.compile_rates = compute_compile_rates(evaluation_results)
+    except Exception:
+        function_data.compile_rates = {}
 
     return function_data

--- a/decbench/scoring/scoreboard.py
+++ b/decbench/scoring/scoreboard.py
@@ -60,18 +60,21 @@ def build_scoreboard(
             )
             dec_score.metric_scores[metric_name] = ms
 
-        # Compute Overall: functions that are perfect on ALL metrics
+        # Compute Overall: functions perfect on ALL metrics, counted ONLY over
+        # functions that were evaluated on every metric. A function missing a
+        # metric (e.g. byte_match abstained for ARM/PE) is EXCLUDED from Overall
+        # rather than counted as a failure — "couldn't measure" != "wrong".
         per_func = aggregated.per_function.get(dec_name, {})
         all_metric_names = aggregated.metrics
 
         overall_perfect = 0
-        overall_total = len(per_func)
+        overall_total = 0
 
         for metric_perfects in per_func.values():
-            all_perfect = all(
-                metric_perfects.get(m, False) for m in all_metric_names
-            )
-            if all_perfect:
+            if not all(m in metric_perfects for m in all_metric_names):
+                continue
+            overall_total += 1
+            if all(metric_perfects[m] for m in all_metric_names):
                 overall_perfect += 1
 
         dec_score.overall_perfect_count = overall_perfect

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-import shutil
+import re
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,11 +16,59 @@ if TYPE_CHECKING:
     from decbench.models.decompilation import DecompilationResult
 
 
+_LINE_MARKER = re.compile(r'^#\s+\d+\s+"([^"]*)"')
+
+
+def _is_system_header(path: str) -> bool:
+    """True if a preprocessor line-marker file is a system/toolchain header.
+
+    Covers glibc (/usr/include), gcc internals (/usr/lib/gcc), the cross/mingw
+    toolchains (also under /usr/...), and the preprocessor's synthetic files
+    (<built-in>, <command-line>, stdc-predef.h).
+    """
+    return (
+        not path
+        or path.startswith("<")
+        or path.startswith("/usr/")
+        or "/usr/lib/gcc" in path
+        or path.endswith("stdc-predef.h")
+    )
+
+
+def strip_system_headers(preprocessed: str) -> str:
+    """Drop inlined system-header code from a preprocessed (.i) translation unit.
+
+    A ``.i`` file is the project source with EVERY ``#include`` expanded inline,
+    so it is dominated (80-98%) by glibc/toolchain headers. Joern then either
+    times out parsing megabytes of headers or drowns the project's own functions
+    in thousands of header inlines — which is why GED "source-parse failures"
+    were really header-bloat timeouts, not real failures.
+
+    Using the ``# <line> "<file>"`` markers gcc emits, we keep only lines that
+    came from the project's own files. ``#ifdef`` selection and macro expansion
+    have ALREADY been done by the real compiler, so the result is exactly the
+    code that was compiled (the right ifdef branches) — fair and small.
+    """
+    keep: list[str] = []
+    in_system = True  # before the first marker
+    for line in preprocessed.splitlines():
+        m = _LINE_MARKER.match(line)
+        if m is not None:
+            in_system = _is_system_header(m.group(1))
+            continue  # drop the marker line itself
+        if not in_system:
+            keep.append(line)
+    return "\n".join(keep) + "\n"
+
+
 def extract_cfgs_from_source(source_path: Path) -> dict[str, DiGraph]:
     """Extract CFGs from a C source file using pyjoern.
 
     Args:
-        source_path: Path to C source file (.c or .i)
+        source_path: Path to C source file (.c or .i). For ``.i`` files the
+            inlined system headers are stripped first (see
+            :func:`strip_system_headers`) so Joern parses only the project's own
+            (already-preprocessed, correctly-ifdef'd) code — fast and complete.
 
     Returns:
         Dictionary mapping function names to CFG DiGraphs
@@ -29,18 +77,20 @@ def extract_cfgs_from_source(source_path: Path) -> dict[str, DiGraph]:
         from pyjoern import parse_source
     except ImportError:
         raise ImportError(
-            "pyjoern is required for CFG extraction. "
-            "Install with: pip install pyjoern"
+            "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
         )
 
     cfgs = {}
-    # Joern doesn't recognize .i files; copy to .c temp file if needed
-    temp_c_path = None
-    parse_path = source_path
+    # Always parse via a UNIQUE temp .c: Joern names its workspace after the input
+    # file's basename, so parsing the same filename concurrently (e.g. the same
+    # function file across opt levels) would collide. A unique temp name avoids
+    # that. For .i we also strip the inlined system headers first.
+    temp_c_path = Path(tempfile.mktemp(suffix=".c"))
     if source_path.suffix == ".i":
-        temp_c_path = Path(tempfile.mktemp(suffix=".c"))
-        shutil.copy2(source_path, temp_c_path)
-        parse_path = temp_c_path
+        temp_c_path.write_text(strip_system_headers(source_path.read_text(errors="replace")))
+    else:
+        temp_c_path.write_text(source_path.read_text(errors="replace"))
+    parse_path = temp_c_path
 
     try:
         # parse_source returns dict[str, Function] or dict[tuple[str,str], Function]
@@ -81,8 +131,7 @@ def extract_cfgs_from_decompilation(
         from pyjoern import parse_source
     except ImportError:
         raise ImportError(
-            "pyjoern is required for CFG extraction. "
-            "Install with: pip install pyjoern"
+            "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
         )
 
     cfgs = {}

--- a/decbench/utils/source_extract.py
+++ b/decbench/utils/source_extract.py
@@ -1,0 +1,221 @@
+"""Best-effort extraction of a single function's *source* text.
+
+Powers the report's "Compare samples" view (original source next to each
+decompiler's output) and fills in :attr:`HardestEntry.source_code`. There is no
+perfect way to slice a C function out of a translation unit without a full
+parser, so this is heuristic but conservative:
+
+1. Read the function's ``decl_file`` / ``decl_line`` from the binary's DWARF
+   (when present) to know *which* source file and roughly *where*.
+2. Find the matching original ``.c`` next to the binary (the compile stage keeps
+   per-binary sources in ``compiled/``), then locate the function *definition*
+   (not a call/prototype) and brace-match its body.
+
+Returns ``None`` whenever anything is uncertain rather than guessing wrong.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def _dwarf_decl(binary_path: Path) -> dict[str, tuple[str, int]]:
+    """Map function name -> (decl_file basename, decl_line) from DWARF.
+
+    Empty dict when DWARF is missing/unreadable (callers then search all
+    sibling sources without a line hint).
+    """
+    out: dict[str, tuple[str, int]] = {}
+    try:
+        from elftools.elf.elffile import ELFFile
+    except Exception:  # noqa: BLE001
+        return out
+    try:
+        with open(binary_path, "rb") as f:
+            elf = ELFFile(f)
+            if not elf.has_dwarf_info():
+                return out
+            dw = elf.get_dwarf_info()
+            for cu in dw.iter_CUs():
+                lp = dw.line_program_for_CU(cu)
+                # DW_AT_decl_file indexing differs by DWARF version: pre-v5 is
+                # 1-based (entry 0 is unused), v5 is 0-based (entry 0 is the
+                # primary source). Prepend a placeholder only for pre-v5 so the
+                # index lines up either way.
+                version = 4
+                if lp is not None:
+                    version = lp.header.get("version", cu.header.get("version", 4))
+                files: list = [] if version >= 5 else [None]
+                if lp is not None:
+                    for fe in lp["file_entry"]:
+                        nm = fe.name
+                        files.append(nm.decode() if isinstance(nm, bytes) else nm)
+                for die in cu.iter_DIEs():
+                    if die.tag != "DW_TAG_subprogram":
+                        continue
+                    attrs = die.attributes
+                    if "DW_AT_name" not in attrs or "DW_AT_low_pc" not in attrs:
+                        continue
+                    nm = attrs["DW_AT_name"].value
+                    name = nm.decode() if isinstance(nm, bytes) else nm
+                    fi = attrs.get("DW_AT_decl_file")
+                    ln = attrs.get("DW_AT_decl_line")
+                    fname = None
+                    if fi is not None and 0 <= fi.value < len(files):
+                        fname = files[fi.value]
+                    line = int(ln.value) if ln is not None else 0
+                    out[name] = (os.path.basename(fname) if fname else "", line)
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def _match_braces(text: str, open_idx: int) -> int | None:
+    """Index just past the ``}`` matching the ``{`` at ``open_idx`` (string/char
+    and comment aware). ``None`` if unbalanced."""
+    depth = 0
+    i = open_idx
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            i = n if j < 0 else j
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            i = n if j < 0 else j + 2
+            continue
+        if c in ("'", '"'):
+            quote = c
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    break
+                i += 1
+            i += 1
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _match_paren(text: str, open_idx: int) -> int | None:
+    """Index of the ``)`` matching the ``(`` at ``open_idx`` (depth-counted).
+
+    Needed because a function's parameter list can itself contain parentheses
+    (function-pointer params, casts, ``__attribute__((...))``), so the *first*
+    ``)`` is not the end of the signature. ``None`` if unbalanced.
+    """
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return None
+
+
+def extract_from_text(text: str, func_name: str, decl_line: int = 0) -> str | None:
+    """Extract ``func_name``'s definition from C ``text`` via brace matching.
+
+    When ``decl_line`` (1-based) is given, prefer the candidate nearest it.
+    Returns the signature + body, or ``None`` if no definition is found.
+    """
+    pat = re.compile(r"(^|[^\w])" + re.escape(func_name) + r"\s*\(")
+    lines = text.splitlines(keepends=True)
+    # Precompute byte offset of each line start for decl_line proximity.
+    offsets = []
+    acc = 0
+    for ln in lines:
+        offsets.append(acc)
+        acc += len(ln)
+
+    # (proximity, signature_start_offset, body_end_offset)
+    candidates: list[tuple[int, int, int]] = []
+    for m in pat.finditer(text):
+        paren = text.index("(", m.start())
+        close = _match_paren(text, paren)
+        if close is None:
+            continue
+        # The next non-space char after ')' must be '{' for a definition.
+        j = close + 1
+        while j < len(text) and text[j] in " \t\r\n":
+            j += 1
+        if j >= len(text) or text[j] != "{":
+            continue  # prototype, call, or K&R — skip the simple case
+        # Reject if this looks like a call inside another body: require the
+        # token before the name (ignoring the return type) to start a logical
+        # line — i.e. the line's first non-space isn't itself a statement.
+        line_no = text.count("\n", 0, m.start())  # 0-based
+        # Find start of the signature: walk back to the line that begins the
+        # return type (previous blank line or '}' / ';').
+        sig_start = text.rfind("\n", 0, m.start())
+        # extend upward over the return-type line(s)
+        k = line_no
+        while k > 0:
+            prev = lines[k - 1].strip()
+            if prev == "" or prev.endswith(("}", ";", "*/", "{")) or prev.startswith(("#", "//")):
+                break
+            k -= 1
+        sig_start = offsets[k]
+        end = _match_braces(text, j)
+        if end is None:
+            continue
+        prox = abs((line_no + 1) - decl_line) if decl_line else 0
+        candidates.append((prox, sig_start, end))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: (c[0], c[1]))
+    _, start, end = candidates[0]
+    snippet = text[start:end].strip("\n")
+    return snippet or None
+
+
+def function_source(binary_path: Path, func_name: str) -> str | None:
+    """Best-effort source text for ``func_name`` defined in ``binary_path``.
+
+    Looks for the original ``.c`` sources kept next to the binary (the compile
+    stage writes them into ``compiled/``), guided by DWARF when available.
+    """
+    decl = _dwarf_decl(binary_path)
+    decl_file, decl_line = decl.get(func_name, ("", 0))
+
+    search_dir = binary_path.parent
+    sources = sorted(p for p in search_dir.glob("*.c") if p.is_file())
+    if not sources:
+        return None
+
+    # Prefer the DWARF-named file, then any file containing the name.
+    ordered: list[Path] = []
+    if decl_file:
+        for p in sources:
+            if p.name == decl_file or p.stem == os.path.splitext(decl_file)[0]:
+                ordered.append(p)
+    ordered += [p for p in sources if p not in ordered]
+
+    for p in ordered:
+        try:
+            text = p.read_text(errors="replace")
+        except Exception:  # noqa: BLE001
+            continue
+        if func_name not in text:
+            continue
+        line_hint = decl_line if (decl_file and p.name == decl_file) else 0
+        snippet = extract_from_text(text, func_name, line_hint)
+        if snippet:
+            return snippet
+    return None

--- a/projects/cps/betaflight.toml
+++ b/projects/cps/betaflight.toml
@@ -30,12 +30,12 @@ pre_make_cmds = []
 # the STM32F405 target, untouched, so the ELF is ARM.
 # IMPORTANT: if a future image swaps the arm gcc, update GCC_REQUIRED_VERSION to
 # that compiler's `arm-none-eabi-gcc -dumpversion` (here: 13.2.1).
-make_cmd = 'make TARGET=STM32F405 GCC_REQUIRED_VERSION=13.2.1 EXTRA_FLAGS="$CFLAGS -Wno-error"'
+make_cmd = 'make TARGET=STM32F405 DEBUG=GDB GCC_REQUIRED_VERSION=13.2.1 EXTRA_FLAGS="$CFLAGS -Wno-error"'
 
 labels = ["cps", "drone", "flight-controller", "avionics", "bare-metal", "cortex-m4", "stm32f4"]
 
 [compilation]
 optimization_levels = ["O0", "O2", "O2-noinline"]
-base_flags = ["-g", "-fno-builtin", "-save-temps=obj"]
+base_flags = ["-g", "-fno-builtin", "-save-temps=obj", "-fno-lto"]
 c_compiler = "arm-none-eabi-gcc"
 target_arch = "arm"  # only collect the ARM hardware binaries (drop host tools)

--- a/projects/cps/chibios.toml
+++ b/projects/cps/chibios.toml
@@ -24,7 +24,7 @@ pre_make_cmds = []
 # the ELF stays ARM. make_cmd cds into the demo dir (build runs there); the ELF
 # (build/ch.elf) and .i files (build/obj/*.i) land under source_dir=".".
 # Verified: ELF 32-bit ARM, with debug_info, not stripped; 74 .i files.
-make_cmd = 'cd demos/STM32/RT-STM32F407-DISCOVERY && make USE_OPT="$CFLAGS"'
+make_cmd = 'cd demos/STM32/RT-STM32F407-DISCOVERY && make USE_LTO=no USE_OPT="$CFLAGS -ggdb3"'
 
 labels = ["cps", "rtos", "real-time-kernel", "bare-metal", "cortex-m4", "stm32f407"]
 

--- a/projects/cps/cleanflight.toml
+++ b/projects/cps/cleanflight.toml
@@ -36,7 +36,7 @@ pre_make_cmds = ["mkdir -p tools/shim && ln -sf \"$(command -v python3)\" tools/
 # DALRCF405 target, untouched, so the ELF is ARM.
 # IMPORTANT: if a future image swaps the arm gcc, update GCC_REQUIRED_VERSION to
 # that compiler's `arm-none-eabi-gcc -dumpversion` (here: 13.2.1).
-make_cmd = 'PATH="$PWD/tools/shim:$PATH" make TARGET=DALRCF405 GCC_REQUIRED_VERSION=13.2.1 EXTRA_FLAGS="$CFLAGS -Wno-error -fcommon"'
+make_cmd = 'PATH="$PWD/tools/shim:$PATH" make TARGET=DALRCF405 DEBUG=GDB GCC_REQUIRED_VERSION=13.2.1 EXTRA_FLAGS="$CFLAGS -Wno-error -fcommon"'
 
 labels = ["cps", "drone", "flight-controller", "avionics", "bare-metal", "cortex-m4", "stm32f4"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,15 @@ target-version = ["py310"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+# The HTML renderer embeds CSS/JS/HTML as template strings, where the 100-col
+# Python rule produces awkward breaks in foreign-language lines (and unbreakable
+# URLs). Logic-affecting rules still apply; only line length is relaxed here.
+"decbench/rendering/html.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/scripts/compile_all.py
+++ b/scripts/compile_all.py
@@ -27,7 +27,20 @@ from decbench.pipeline.compile import compile_project
 # with downloads done but never extracted).
 _MP = multiprocessing.get_context("spawn")
 
-PROJECTS_DIR = Path("projects/sailr")
+# All benchmark project dirs (top-level *.toml only; cps/disabled/ is excluded
+# since glob is non-recursive). sailr is x86 (host-compilable); cps (ARM) and
+# malware (ARM/PE) need the cross/mingw toolchains, so those are compiled inside
+# the decbench-cps-toolchain Docker image. Restrict with the trailing `only` args.
+PROJECT_DIRS = [Path("projects/sailr"), Path("projects/cps"), Path("projects/malware")]
+
+
+def gather_tomls() -> list[Path]:
+    out: list[Path] = []
+    for d in PROJECT_DIRS:
+        out.extend(sorted(d.glob("*.toml")))
+    return sorted(out, key=lambda p: p.stem)
+
+
 OPT_LEVELS = [
     OptimizationLevel.O0,
     OptimizationLevel.O2,
@@ -107,7 +120,7 @@ def main() -> int:
     only = set(sys.argv[3:])  # optional: restrict to these project stems
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    tomls = sorted(PROJECTS_DIR.glob("*.toml"))
+    tomls = gather_tomls()
     if only:
         tomls = [t for t in tomls if t.stem in only]
 
@@ -154,9 +167,7 @@ def main() -> int:
         else:
             broken.append(proj)
 
-    print(
-        f"\nFully OK ({len(fully_ok)}): {', '.join(fully_ok)}", flush=True
-    )
+    print(f"\nFully OK ({len(fully_ok)}): {', '.join(fully_ok)}", flush=True)
     print(f"Partial ({len(partial)}): {', '.join(partial)}", flush=True)
     print(f"BROKEN ({len(broken)}): {', '.join(broken)}", flush=True)
 

--- a/scripts/compute_dataset_info.py
+++ b/scripts/compute_dataset_info.py
@@ -1,0 +1,151 @@
+"""Compute the report's Dataset/About-page info and store it in function_results.json.
+
+Produces:
+- total_loc + per-project LOC: line counts of the projects' own source (.c files
+  the compile stage kept under compiled/; counted once per project from O0 so opt
+  levels aren't triple-counted).
+- joern: source-parse failure rate — how often Joern (the GED front-end) fails to
+  parse a source file, i.e. how much of the GED pipeline is lost to our own
+  tooling rather than the decompilers. Measured on a stratified SAMPLE of real
+  source .i files (preprocessed units; conftest/autoconf noise excluded).
+
+Software-type categories (parser/webserver/cryptography/malware/firmware) are
+derived client-side from per-binary labels, so they aren't stored here.
+
+Usage:  python scripts/compute_dataset_info.py results/full_run [joern_sample_per_project]
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from decbench.models.function_data import FunctionData
+
+OPT_FOR_LOC = "O0"  # source is identical across opt levels; count once
+SKIP_C = ("conftest.c",)  # autoconf probe noise
+
+
+def count_loc(root: Path) -> tuple[int, dict[str, int]]:
+    """Total + per-project source LOC (lines of compiled/*.c, deduped per name)."""
+    by_project: dict[str, int] = {}
+    base = root / OPT_FOR_LOC
+    if not base.is_dir():
+        return 0, {}
+    for proj in sorted(p for p in base.iterdir() if p.is_dir()):
+        comp = proj / "compiled"
+        if not comp.is_dir():
+            continue
+        total = 0
+        for c in comp.glob("*.c"):
+            if c.name in SKIP_C or c.name.startswith("a-conftest"):
+                continue
+            try:
+                total += sum(1 for _ in c.open("rb"))
+            except OSError:
+                continue
+        if total:
+            by_project[proj.name] = total
+    return sum(by_project.values()), by_project
+
+
+def sample_i_files(root: Path, per_project: int) -> list[Path]:
+    """A stratified sample of real source .i files (exclude autoconf probes)."""
+    out: list[Path] = []
+    base = root / OPT_FOR_LOC
+    for proj in sorted(p for p in base.iterdir() if p.is_dir()):
+        comp = proj / "compiled"
+        if not comp.is_dir():
+            continue
+        cand = sorted(
+            f for f in comp.glob("*.i") if "conftest" not in f.name and not f.name.startswith("a-")
+        )
+        # spread across the project's units rather than taking the first N
+        if len(cand) > per_project:
+            step = len(cand) / per_project
+            cand = [cand[int(i * step)] for i in range(per_project)]
+        out.extend(cand)
+    return out
+
+
+def _parse_one(ip: Path) -> tuple[bool, int]:
+    """Return (failed, n_functions) for one source file (Joern parse)."""
+    from decbench.utils.cfg import extract_cfgs_from_source
+
+    try:
+        cfgs = extract_cfgs_from_source(ip) or {}
+    except Exception:  # noqa: BLE001
+        return True, 0
+    return (not cfgs), len(cfgs)
+
+
+def joern_failures(samples: list[Path], workers: int = 8, deadline_s: int = 420) -> dict:
+    """Parse each sampled .i with Joern (parallel); count files yielding no CFGs.
+
+    Each Joern run is a subprocess (GIL-free). Bounded by an overall deadline:
+    files that don't finish in time (some preprocessed units are huge and very
+    slow, distinct from a parse *failure* which errors out fast) are reported as
+    "timed_out" and excluded from the failure rate, so a few slow/hung JVMs can't
+    stall the whole measurement.
+    """
+    import concurrent.futures as cf
+
+    completed = failed = funcs = 0
+    with cf.ThreadPoolExecutor(max_workers=workers) as pool:
+        futs = [pool.submit(_parse_one, ip) for ip in samples]
+        try:
+            for fut in cf.as_completed(futs, timeout=deadline_s):
+                completed += 1
+                fail, n = fut.result()
+                if fail:
+                    failed += 1
+                else:
+                    funcs += n
+        except cf.TimeoutError:
+            pass
+        for f in futs:
+            f.cancel()
+        pool.shutdown(wait=False, cancel_futures=True)
+    return {
+        "files_sampled": completed,
+        "files_failed": failed,
+        "files_timed_out": len(samples) - completed,
+        "file_fail_pct": (100.0 * failed / completed) if completed else 0.0,
+        "functions_extracted": funcs,
+    }
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/full_run")
+    per_project = int(sys.argv[2]) if len(sys.argv) > 2 else 4
+
+    fd = FunctionData.from_json(root / "function_results.json")
+
+    total_loc, loc_by_project = count_loc(root)
+    print(f"[dataset] total LOC: {total_loc:,} across {len(loc_by_project)} projects", flush=True)
+
+    samples = sample_i_files(root, per_project)
+    print(f"[dataset] Joern parse sample: {len(samples)} source files...", flush=True)
+    joern = joern_failures(samples)
+    print(
+        f"[dataset] Joern: {joern['files_failed']}/{joern['files_sampled']} files "
+        f"failed to parse ({joern['file_fail_pct']:.1f}%), "
+        f"{joern['functions_extracted']} functions extracted",
+        flush=True,
+    )
+
+    fd.dataset_info = {
+        "total_loc": total_loc,
+        "loc_by_project": loc_by_project,
+        "joern": joern,
+    }
+    fd.to_json(root / "function_results.json")
+    print("[dataset] wrote dataset_info into function_results.json", flush=True)
+    # Hard-exit so any still-running (slow/hung) Joern worker threads can't block
+    # the interpreter from exiting on the thread join.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decompile_one.py
+++ b/scripts/decompile_one.py
@@ -27,13 +27,15 @@ from decbench.pipeline.decompile import decompile_binary
 
 def main() -> int:
     binary, dec_name, out_dir, pkl_out = sys.argv[1:5]
-    names: set[str] | None = None
+    # The binary handed to us is a STRIPPED copy (no symbols), so the filter is a
+    # JSON list of target ADDRESSES (DWARF low_pc), not names.
+    target_addrs: set[int] | None = None
     if len(sys.argv) > 5 and sys.argv[5] not in ("", "NONE"):
         try:
             loaded = json.loads(Path(sys.argv[5]).read_text())
-            names = set(loaded) or None
+            target_addrs = {int(a) for a in loaded} or None
         except Exception:
-            names = None
+            target_addrs = None
     # Write partial progress straight to the output pickle, so if the
     # orchestrator kills this process on timeout, the functions completed so far
     # are still recoverable. The final write below replaces it atomically.
@@ -41,7 +43,7 @@ def main() -> int:
         Path(binary),
         dec_name,
         Path(out_dir),
-        function_names=names,
+        function_names=target_addrs,
         progress_path=Path(pkl_out),
     )
     Path(pkl_out).write_bytes(pickle.dumps(result))

--- a/scripts/finalize_full_run.sh
+++ b/scripts/finalize_full_run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Auto-finalize the full_run benchmark after the cps-debug decompile completes:
+#   1) wait for the cps-debug decompile (betaflight/chibios/cleanflight) to finish
+#   2) full resume run_benchmark over all 41 projects -> function_results.json +
+#      scoreboard (host eval; ARM/PE byte_match abstains)
+#   3) Docker reeval byte_match for the ARM/PE projects (cps + PE malware) in the
+#      cross-toolchain image so they recompile instead of abstaining
+#   4) rebuild --add-only: fold the ARM/PE byte_match in (keep host x86 values)
+#   5) render the final report
+set -uo pipefail
+cd /home/mahaloz/github/decbench
+source /home/mahaloz/.virtualenvs/decbench/bin/activate
+
+CPS_LOG="$1"          # path to the cps-debug decompile task output
+export KUNA_BIN=/home/mahaloz/github/kuna/decompiler/target/release/kuna
+export GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1
+export DECBENCH_DECOMPILERS=angr,phoenix,ghidra,ida,binja,kuna
+export DECBENCH_DECOMPILE_TIMEOUT=300
+export DECBENCH_WORKERS=40
+
+# ARM (cps) + PE (malware) projects whose byte_match abstains on the host.
+ARMPE="betaflight chibios cleanflight crazyflie freertos libopencm3 nuttx riot-os u-boot dexter minipig mydoom x0r-usb"
+
+echo "[finalize] waiting for cps-debug decompile to finish ($CPS_LOG)..."
+until grep -q "RUN_DRIVER_DONE" "$CPS_LOG" 2>/dev/null; do sleep 20; done
+echo "[finalize] cps-debug decompile done."
+
+echo "[finalize] step 2/5: full resume over all 41 projects..."
+python scripts/run_benchmark.py results/full_run >results/finalize_resume.log 2>&1
+echo "[finalize] resume done."
+
+echo "[finalize] step 3/5: Docker byte_match reeval for ARM/PE projects..."
+docker run --rm -v "$(pwd)":/workspace -w /workspace -e PYTHONPATH=/workspace \
+  -e HOME=/tmp --user "$(id -u):$(id -g)" decbench-compile bash -lc \
+  "pip install --quiet --break-system-packages capstone diff-match-patch >/dev/null 2>&1; \
+   python3 scripts/reeval_bytematch.py results/full_run 40 $ARMPE" \
+  >results/finalize_reeval.log 2>&1
+echo "[finalize] Docker reeval done -> $(tail -1 results/finalize_reeval.log)"
+
+echo "[finalize] step 4/5: rebuild --add-only (merge ARM/PE byte_match)..."
+python scripts/rebuild_function_data.py results/full_run --add-only >results/finalize_rebuild.log 2>&1
+tail -8 results/finalize_rebuild.log
+
+echo "[finalize] step 5/5: render report..."
+python -m decbench.cli report results/full_run/scoreboard.toml -o results/full_run/report.html \
+  >results/finalize_render.log 2>&1
+echo "[finalize] FINALIZE_DONE -> results/full_run/report.html"

--- a/scripts/ged_finalize.sh
+++ b/scripts/ged_finalize.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Wait for reeval_ged to finish, then merge GED + rebuild + render.
+set -uo pipefail
+cd /home/mahaloz/github/decbench
+source /home/mahaloz/.virtualenvs/decbench/bin/activate
+echo "[ged-final] waiting for reeval_ged..."
+until grep -q "\[ged\] wrote" results/reeval_ged.log 2>/dev/null; do sleep 30; done
+echo "[ged-final] reeval done: $(grep '\[ged\] wrote' results/reeval_ged.log | tail -1)"
+python scripts/rebuild_function_data.py results/full_run --ged >results/ged_rebuild.log 2>&1
+grep -E "merged GED|ged:|functions," results/ged_rebuild.log | tail -8
+python -m decbench.cli report results/full_run/scoreboard.toml -o results/full_run/report.html >results/ged_render.log 2>&1
+echo "[ged-final] GED_FINALIZE_DONE"

--- a/scripts/overnight_run.sh
+++ b/scripts/overnight_run.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Full overnight re-run with the fairness fixes:
+#   - decompilers get a STRIPPED binary (no DWARF, no symbols); eval uses the
+#     unstripped DWARF copy (run_benchmark strips + address-filters + relabels).
+#   - GED source CFGs use header-stripped .i (decbench.utils.cfg) + union across
+#     the project's translation units.
+# Steps: fresh re-decompile+eval (resumable) -> Docker byte_match for ARM/PE ->
+# merge -> render.
+set -uo pipefail
+cd /home/mahaloz/github/decbench
+source /home/mahaloz/.virtualenvs/decbench/bin/activate
+export KUNA_BIN=/home/mahaloz/github/kuna/decompiler/target/release/kuna
+export GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1
+export DECBENCH_DECOMPILERS=angr,phoenix,ghidra,ida,binja,kuna
+export DECBENCH_WORKERS=40
+export DECBENCH_DECOMPILE_TIMEOUT=300
+
+ARMPE="betaflight chibios cleanflight crazyflie freertos libopencm3 nuttx riot-os u-boot dexter minipig mydoom x0r-usb"
+
+echo "[overnight] step 1/4: fresh stripped re-decompile + evaluate (all 41 x 6)..."
+python scripts/run_benchmark.py results/full_run >results/overnight_run.log 2>&1
+echo "[overnight] step 1 tail: $(grep -E 'Functions:|RUN_DRIVER_DONE' results/overnight_run.log | tail -2 | tr '\n' ' ')"
+
+echo "[overnight] step 2/4: Docker byte_match for ARM/PE..."
+docker run --rm -v "$(pwd)":/workspace -w /workspace -e PYTHONPATH=/workspace \
+  -e HOME=/tmp --user "$(id -u):$(id -g)" decbench-compile bash -lc \
+  "pip install --quiet --break-system-packages capstone diff-match-patch >/dev/null 2>&1; \
+   python3 scripts/reeval_bytematch.py results/full_run 40 $ARMPE" \
+  >results/overnight_reeval.log 2>&1
+echo "[overnight] step 2 tail: $(tail -1 results/overnight_reeval.log)"
+
+echo "[overnight] step 3/4: rebuild --add-only (merge ARM/PE byte_match)..."
+python scripts/rebuild_function_data.py results/full_run --add-only >results/overnight_rebuild.log 2>&1
+grep -E "functions,|byte_match:" results/overnight_rebuild.log | tail -8
+
+echo "[overnight] step 4/4: render report..."
+python -m decbench.cli report results/full_run/scoreboard.toml -o results/full_run/report.html >results/overnight_render.log 2>&1
+echo "[overnight] OVERNIGHT_DONE -> results/full_run/report.html"

--- a/scripts/rebuild_function_data.py
+++ b/scripts/rebuild_function_data.py
@@ -1,0 +1,349 @@
+"""Rebuild function_results.json + scoreboard.toml from an existing results tree.
+
+Used after :mod:`scripts.reeval_bytematch` recomputes byte_match: this merges the
+fresh byte_match values into the per-function dataset, attaches the report's
+code-carrying extras (side-by-side **samples** with original source, the
+**hardest** functions, per-decompiler **compile rates**), and recomputes the
+scoreboard aggregates — all WITHOUT re-decompiling.
+
+byte_match policy: a function's byte_match is replaced with the freshly computed
+value when its decompiled artifact still exists on disk; where the artifact is
+gone (whole projects were pruned from the snapshot) byte_match is *dropped* for
+that function so the column is uniformly the new metric (per-metric denominators
+already differ, and such functions are simply excluded from Overall).
+
+Usage:  python scripts/rebuild_function_data.py results/sailr_full
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+import sys
+from pathlib import Path
+
+from decbench.models.function_data import FunctionData, HardestEntry, SampleEntry
+from decbench.models.scoreboard import DecompilerScore, MetricScore, Scoreboard
+from decbench.scoring.datasets import assign_datasets
+from decbench.utils import binfmt
+from decbench.utils.source_extract import function_source
+
+MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
+PERFECT = {"ged": 0.0, "type_match": 1.0, "byte_match": 1.0}
+MAX_SAMPLES = 140
+HARDEST_PER = 12
+
+
+def split_functions(c_path: Path) -> dict[str, str]:
+    """name -> decompiled block for one decompiled .c (code only)."""
+    text = c_path.read_text(errors="replace")
+    out: dict[str, str] = {}
+    ms = list(MARKER.finditer(text))
+    for i, m in enumerate(ms):
+        start = m.end()
+        end = ms[i + 1].start() if i + 1 < len(ms) else len(text)
+        out[m.group(1)] = text[start:end].strip()
+    return out
+
+
+class DiskReader:
+    """Lazily reads decompiled blocks and resolves original binaries on disk."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self._dec_cache: dict[tuple, dict[str, str]] = {}
+        self._bin_cache: dict[tuple, Path | None] = {}
+
+    def binary(self, opt: str, proj: str, stem: str) -> Path | None:
+        key = (opt, proj, stem)
+        if key in self._bin_cache:
+            return self._bin_cache[key]
+        comp = self.root / opt / proj / "compiled"
+        found: Path | None = None
+        if comp.is_dir():
+            exact = comp / stem
+            if exact.is_file() and binfmt.detect(exact):
+                found = exact
+            else:
+                for f in comp.iterdir():
+                    if f.is_file() and f.stem == stem and binfmt.detect(f):
+                        found = f
+                        break
+        self._bin_cache[key] = found
+        return found
+
+    def decompiled(self, opt: str, proj: str, stem: str, dec: str) -> dict[str, str]:
+        key = (opt, proj, stem, dec)
+        if key not in self._dec_cache:
+            cf = self.root / opt / proj / "decompiled" / f"{dec}_{stem}.c"
+            self._dec_cache[key] = split_functions(cf) if cf.exists() else {}
+        return self._dec_cache[key]
+
+
+def update_byte_match(
+    fd: FunctionData, new: dict[str, dict], add_only: bool = False
+) -> dict[str, dict]:
+    """Merge freshly recomputed byte_match into the dataset.
+
+    For every (function, decompiler) that was decompiled (``values[dec]`` exists):
+    SET byte_match to the new value when one exists. When ``add_only`` is False
+    (default), also DROP any stale value with no fresh replacement so the column
+    is uniformly the new metric. When ``add_only`` is True, keep existing values
+    untouched and only ADD where ``new`` has a value — used to fold in a partial
+    reeval (e.g. the Docker ARM/PE recompile) without dropping the host-computed
+    x86 byte_match.
+    Returns per-dec compile tallies (over the newly merged values).
+    """
+    tally = {d: {"comp": 0, "tot": 0} for d in fd.decompilers}
+    for g in fd.groups:
+        for f in g.functions:
+            for dec, mv in list(f.values.items()):
+                key = f"{g.opt_level}::{g.project}::{g.binary}::{dec}::{f.function}"
+                rec = new.get(key)
+                if rec is None:
+                    if not add_only:
+                        # No fresh value (artifact gone): drop any stale value.
+                        mv.pop("byte_match", None)
+                        f.perfects.get(dec, {}).pop("byte_match", None)
+                    continue
+                val = float(rec["value"])
+                mv["byte_match"] = val
+                f.perfects.setdefault(dec, {})["byte_match"] = val >= PERFECT["byte_match"]
+                t = tally.setdefault(dec, {"comp": 0, "tot": 0})
+                t["tot"] += 1
+                if rec.get("compilable"):
+                    t["comp"] += 1
+    return tally
+
+
+def build_samples(fd: FunctionData, reader: DiskReader) -> list[SampleEntry]:
+    """Curated side-by-side samples (source + each decompiler's output)."""
+    out: list[SampleEntry] = []
+    # Prefer the 'tiny' representative slice; fall back to any with code.
+    candidates = [(g, f) for g in fd.groups for f in g.functions if "tiny" in (f.datasets or [])]
+    if not candidates:
+        candidates = [(g, f) for g in fd.groups for f in g.functions]
+
+    for g, f in candidates:
+        if len(out) >= MAX_SAMPLES:
+            break
+        binary = reader.binary(g.opt_level, g.project, g.binary)
+        decompiled: dict[str, str] = {}
+        for dec in fd.decompilers:
+            code = reader.decompiled(g.opt_level, g.project, g.binary, dec).get(f.function)
+            if code:
+                decompiled[dec] = code
+        if not decompiled:
+            continue  # nothing to compare
+        source = function_source(binary, f.function) if binary else None
+        out.append(
+            SampleEntry(
+                project=g.project,
+                opt_level=g.opt_level,
+                binary=g.binary,
+                function=f.function,
+                size=f.size,
+                labels=f.labels,
+                source_code=source,
+                decompiled=decompiled,
+                values=f.values,
+                perfects=f.perfects,
+            )
+        )
+    return out
+
+
+def build_hardest(fd: FunctionData, reader: DiskReader) -> list[HardestEntry]:
+    """Worst N per (metric, decompiler), with decompiled + source code."""
+    buckets: dict[tuple[str, str], list] = {}
+    for g in fd.groups:
+        for f in g.functions:
+            for dec, mv in f.values.items():
+                for metric, val in mv.items():
+                    perfect = PERFECT.get(metric, 0.0)
+                    dist = abs(val - perfect)
+                    if dist == 0.0:
+                        continue
+                    buckets.setdefault((metric, dec), []).append((dist, val, g, f))
+
+    out: list[HardestEntry] = []
+    for (metric, dec), cands in buckets.items():
+        cands.sort(key=lambda c: (c[0], c[1]), reverse=True)
+        kept = 0
+        for _dist, val, g, f in cands:
+            if kept >= HARDEST_PER:
+                break
+            code = reader.decompiled(g.opt_level, g.project, g.binary, dec).get(f.function)
+            if not code:
+                continue
+            binary = reader.binary(g.opt_level, g.project, g.binary)
+            out.append(
+                HardestEntry(
+                    metric=metric,
+                    decompiler=dec,
+                    project=g.project,
+                    opt_level=g.opt_level,
+                    binary=g.binary,
+                    function=f.function,
+                    value=val,
+                    perfect_value=PERFECT.get(metric, 0.0),
+                    size=f.size,
+                    labels=f.labels,
+                    decompiled_code=code,
+                    source_code=function_source(binary, f.function) if binary else None,
+                )
+            )
+            kept += 1
+    return out
+
+
+def recompute_scoreboard(fd: FunctionData, old: Scoreboard) -> Scoreboard:
+    """Recompute per-metric + overall aggregates from the updated dataset."""
+    decs, metrics = fd.decompilers, fd.metrics
+    vals: dict[str, dict[str, list[float]]] = {d: {m: [] for m in metrics} for d in decs}
+    perf: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
+    tot: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
+    overall_perf = {d: 0 for d in decs}
+    overall_tot = {d: 0 for d in decs}
+
+    for g in fd.groups:
+        for f in g.functions:
+            for d in decs:
+                fp = f.perfects.get(d)
+                fv = f.values.get(d)
+                if not fp or not fv:
+                    continue
+                for m in metrics:
+                    if m in fv:
+                        tot[d][m] += 1
+                        vals[d][m].append(fv[m])
+                        if fp.get(m):
+                            perf[d][m] += 1
+                # Overall, matching scoring/scoreboard.py + the report JS: count
+                # ONLY functions evaluated on every metric; a function missing a
+                # metric (byte_match abstained for ARM/PE) is EXCLUDED, not failed.
+                if all(m in fp for m in metrics):
+                    overall_tot[d] += 1
+                    if all(fp[m] for m in metrics):
+                        overall_perf[d] += 1
+
+    sb = Scoreboard(
+        name=old.name or "DecBench Scoreboard",
+        description=old.description,
+        version=old.version,
+        projects_evaluated=sorted({g.project for g in fd.groups}),
+        optimization_levels=sorted({g.opt_level for g in fd.groups}),
+        decompilers=decs,
+        metrics=metrics,
+        total_functions=sum(len(g.functions) for g in fd.groups),
+        total_binaries=len(fd.groups),
+    )
+    for d in decs:
+        ds = DecompilerScore(name=d)
+        for m in metrics:
+            n = tot[d][m]
+            ds.metric_scores[m] = MetricScore(
+                metric_name=m,
+                decompiler_name=d,
+                perfect_count=perf[d][m],
+                total_count=n,
+                perfect_percentage=(100 * perf[d][m] / n) if n else 0.0,
+                mean=statistics.fmean(vals[d][m]) if vals[d][m] else 0.0,
+                median=statistics.median(vals[d][m]) if vals[d][m] else 0.0,
+            )
+        ds.overall_perfect_count = overall_perf[d]
+        ds.overall_total_count = overall_tot[d]
+        ds.overall_perfect_percentage = (
+            100 * overall_perf[d] / overall_tot[d] if overall_tot[d] else 0.0
+        )
+        sb.decompiler_scores[d] = ds
+    for m in metrics:
+        for rank, (d, _) in enumerate(sb.get_metric_rankings(m), 1):
+            sb.decompiler_scores[d].metric_scores[m].rank = rank
+    for rank, (d, _) in enumerate(sb.get_overall_rankings(), 1):
+        sb.decompiler_scores[d].overall_rank = rank
+    return sb
+
+
+def update_ged(fd: FunctionData, new: dict[str, dict]) -> int:
+    """Merge freshly recomputed GED (from header-stripped source CFGs) in.
+
+    For every (function, decompiler) with a fresh GED value, SET ged + its perfect
+    flag. Existing GED with no fresh value is kept (the reeval is a superset, so
+    this is rare). Returns the number of (function, decompiler) entries set.
+    """
+    n = 0
+    for g in fd.groups:
+        for f in g.functions:
+            for dec in fd.decompilers:
+                key = f"{g.opt_level}::{g.project}::{g.binary}::{dec}::{f.function}"
+                rec = new.get(key)
+                if rec is None:
+                    continue
+                val = float(rec["value"])
+                f.values.setdefault(dec, {})["ged"] = val
+                f.perfects.setdefault(dec, {})["ged"] = bool(rec.get("perfect", val == 0.0))
+                n += 1
+    return n
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/sailr_full")
+    # --add-only: fold a PARTIAL byte_match_new (e.g. the Docker ARM/PE recompile)
+    # into an already-complete dataset without dropping existing (x86) values, and
+    # keep the existing compile_rates.
+    add_only = "--add-only" in sys.argv[2:]
+    # --ged: merge ged_new.json (header-stripped source CFGs) instead of byte_match;
+    # keeps byte_match + compile_rates untouched.
+    ged_mode = "--ged" in sys.argv[2:]
+    fd = FunctionData.from_json(root / "function_results.json")
+    reader = DiskReader(root)
+
+    print(
+        f"[rebuild] {sum(len(g.functions) for g in fd.groups)} functions, "
+        f"{len(fd.groups)} binaries, decompilers={fd.decompilers}, "
+        f"add_only={add_only}, ged={ged_mode}",
+        flush=True,
+    )
+
+    if ged_mode:
+        new = json.loads((root / "ged_new.json").read_text())
+        n = update_ged(fd, new)
+        print(f"[rebuild] merged GED for {n} (function,decompiler) entries", flush=True)
+    else:
+        new = json.loads((root / "byte_match_new.json").read_text())
+        tally = update_byte_match(fd, new, add_only=add_only)
+        if not add_only:
+            fd.compile_rates = {d: (t["comp"] / t["tot"]) for d, t in tally.items() if t["tot"]}
+        rates_str = ", ".join(f"{d}={100*r:.1f}%" for d, r in (fd.compile_rates or {}).items())
+        print(f"[rebuild] compile rates: {rates_str}", flush=True)
+
+    assign_datasets(fd)
+    fd.samples = build_samples(fd, reader)
+    fd.hardest = build_hardest(fd, reader)
+    src = sum(1 for s in fd.samples if s.source_code)
+    print(
+        f"[rebuild] {len(fd.samples)} samples ({src} with source), " f"{len(fd.hardest)} hardest",
+        flush=True,
+    )
+
+    old_sb = Scoreboard.from_toml(root / "scoreboard.toml")
+    sb = recompute_scoreboard(fd, old_sb)
+
+    fd.to_json(root / "function_results.json")
+    sb.to_toml(root / "scoreboard.toml")
+    print("[rebuild] wrote function_results.json + scoreboard.toml", flush=True)
+    for d in sb.decompilers:
+        ds = sb.decompiler_scores[d]
+        bm = ds.metric_scores.get("byte_match")
+        if bm:
+            print(
+                f"  {d} byte_match: {bm.perfect_percentage:.2f}% perfect, "
+                f"mean {bm.mean:.3f} over {bm.total_count}",
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reeval_bytematch.py
+++ b/scripts/reeval_bytematch.py
@@ -1,0 +1,164 @@
+"""Recompute ONLY the byte_match metric over an existing results tree.
+
+The decompilations (the slow part) are already on disk as ``decompiled/{dec}_
+{binary}.c`` (function blocks delimited by ``// Function: name @ 0xADDR``); the
+original binaries sit in ``compiled/{binary}``. This lets us re-score byte_match
+with the new fixup + operand-normalization metric WITHOUT re-decompiling.
+
+Resumable (per (opt,project,binary,dec) checkpoint JSON) and parallel via the
+'spawn' context (fork deadlocks once angr's threads are live). Output:
+``<results>/byte_match_new.json`` mapping ``opt::project::binary::dec::func`` ->
+{"value": float, "compilable": bool}.
+
+Usage:  python scripts/reeval_bytematch.py results/sailr_full [workers]
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import re
+import sys
+from pathlib import Path
+
+from decbench.utils import binfmt
+
+MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
+DECOMPILERS = ("angr", "phoenix", "ghidra", "ida", "binja", "kuna")
+OPT_LEVELS = ("O0", "O2", "O2-noinline")
+
+
+def split_functions(c_path: Path) -> dict[str, tuple[int, str]]:
+    """name -> (address, decompiled block) for one decompiled .c file."""
+    text = c_path.read_text(errors="replace")
+    out: dict[str, tuple[int, str]] = {}
+    matches = list(MARKER.finditer(text))
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        out[m.group(1)] = (int(m.group(2), 16), text[start:end].strip())
+    return out
+
+
+def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
+    """Worker: recompute byte_match for every function of one (binary, dec).
+
+    ``task`` = (opt, project, binary_stem, dec, binary_path, c_path).
+    Returns (checkpoint_key, {func: {value, compilable}}).
+    """
+    opt, project, stem, dec, binary_path, c_path = task
+    from decbench.metrics.byte_match import ByteMatchMetric
+    from decbench.models.decompilation import FunctionDecompilation
+
+    metric = ByteMatchMetric()
+    binary = Path(binary_path)
+    out: dict[str, dict] = {}
+    for name, (addr, code) in split_functions(Path(c_path)).items():
+        fd = FunctionDecompilation(
+            name=name,
+            address=addr,
+            decompiled_code=code,
+            line_count=code.count("\n") + 1,
+        )
+        try:
+            mv = metric.compute_for_function(fd, original_binary_path=binary)
+        except Exception as e:  # noqa: BLE001
+            out[name] = {"value": 0.0, "compilable": False, "error": str(e)[:120]}
+            continue
+        md = mv.metadata or {}
+        out[name] = {"value": float(mv.value), "compilable": bool(md.get("compilable", False))}
+    key = f"{opt}::{project}::{stem}::{dec}"
+    return key, out
+
+
+def resolve_binary(comp: Path, stem: str) -> Path | None:
+    """Find the original binary for a decompiled stem.
+
+    The decompiled artifact is named ``{dec}_{stem}.c`` where stem = binary.stem,
+    but the on-disk binary keeps its full name — which may carry an extension
+    (``mydoom.exe``, ``psize.aux``) or a version suffix (``libedit.so.0.0.70``).
+    So fall back from an exact match to any sibling whose stem matches and which
+    is a real ELF/PE. (Must agree with rebuild_function_data.DiskReader.binary,
+    else byte_match would be computed here but not merged — or vice versa.)
+    """
+    exact = comp / stem
+    if exact.is_file() and binfmt.detect(exact):
+        return exact
+    for f in comp.iterdir():
+        if f.is_file() and f.stem == stem and binfmt.detect(f):
+            return f
+    return None
+
+
+def build_tasks(
+    root: Path, only: set[str] | None = None
+) -> list[tuple[str, str, str, str, str, str]]:
+    tasks = []
+    for opt in OPT_LEVELS:
+        odir = root / opt
+        if not odir.is_dir():
+            continue
+        for proj in sorted(p for p in odir.iterdir() if p.is_dir()):
+            if only and proj.name not in only:
+                continue
+            comp, dec_dir = proj / "compiled", proj / "decompiled"
+            if not (comp.is_dir() and dec_dir.is_dir()):
+                continue
+            for dec in DECOMPILERS:
+                for cf in sorted(dec_dir.glob(f"{dec}_*.c")):
+                    stem = cf.name[len(dec) + 1 : -2]  # strip "dec_" and ".c"
+                    binary = resolve_binary(comp, stem)
+                    if binary is not None:
+                        tasks.append((opt, proj.name, stem, dec, str(binary), str(cf)))
+    return tasks
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/sailr_full")
+    workers = int(sys.argv[2]) if len(sys.argv) > 2 else 16
+    # Optional trailing project stems restrict the reeval (e.g. only the ARM/PE
+    # projects when recomputing byte_match in the cross-toolchain container).
+    only = {a for a in sys.argv[3:] if not a.lstrip("-").isdigit()} or None
+    ckpt_dir = root / "reeval_bm"
+    ckpt_dir.mkdir(exist_ok=True)
+
+    tasks = build_tasks(root, only=only)
+    pending = []
+    for t in tasks:
+        key = f"{t[0]}::{t[1]}::{t[2]}::{t[3]}"
+        if not (ckpt_dir / (key.replace("::", "__") + ".json")).exists():
+            pending.append(t)
+    print(
+        f"[reeval] {len(tasks)} tasks total, {len(pending)} pending, {workers} workers", flush=True
+    )
+
+    ctx = mp.get_context("spawn")
+    done = 0
+    with ctx.Pool(processes=workers) as pool:
+        for key, result in pool.imap_unordered(eval_one, pending):
+            (ckpt_dir / (key.replace("::", "__") + ".json")).write_text(json.dumps(result))
+            done += 1
+            if done % 25 == 0 or done == len(pending):
+                print(f"[reeval] {done}/{len(pending)} binaries done", flush=True)
+
+    # Merge all checkpoints into one map.
+    merged: dict[str, dict] = {}
+    for cp in ckpt_dir.glob("*.json"):
+        key = cp.stem.replace("__", "::")
+        data = json.loads(cp.read_text())
+        for func, v in data.items():
+            merged[f"{key}::{func}"] = v
+    out_path = root / "byte_match_new.json"
+    out_path.write_text(json.dumps(merged))
+    comp = sum(1 for v in merged.values() if v.get("compilable"))
+    print(
+        f"[reeval] wrote {out_path} ({len(merged)} funcs, {comp} compilable "
+        f"= {100*comp/max(1,len(merged)):.1f}%)",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONWARNINGS", "ignore")
+    main()

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -1,0 +1,192 @@
+"""Recompute ONLY the GED metric over an existing results tree, using the new
+header-stripped source CFGs (decbench.utils.cfg.strip_system_headers).
+
+Why: GED's source CFGs were extracted from full preprocessed .i files, which are
+80-98% inlined system headers — Joern timed out on the big ones, so a huge share
+of functions had NO source CFG and silently dropped out of GED (looked like the
+decompilers' fault). Stripping the headers (keeping the compiler's own ifdef/macro
+resolution) makes Joern fast and complete, so GED can be measured on far more
+functions. This re-scores GED to reflect that.
+
+Two stages, both parallel via the 'spawn' context (fork deadlocks once angr's
+threads are live):
+  A. source CFGs per project (from the O0 .i — source is identical across opt
+     levels), cached to <results>/ged_src/<project>.pkl
+  B. per (opt, project, binary, dec): parse the stored decompiled .c, compute GED
+     for every function whose source CFG exists -> <results>/ged_new.json mapping
+     opt::project::binary::dec::func -> {"value": float, "perfect": bool}.
+
+Usage:  python scripts/reeval_ged.py results/full_run [workers] [only-projects...]
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import os
+import pickle
+import sys
+from pathlib import Path
+
+DECOMPILERS = ("angr", "phoenix", "ghidra", "ida", "binja", "kuna")
+OPT_LEVELS = ("O0", "O2", "O2-noinline")
+SRC_OPT = "O0"  # source CFGs are opt-independent; extract once from here
+
+
+# ---- Stage A: source CFGs per project -------------------------------------
+def src_cfgs_for_i(i_path: str) -> tuple[str, dict]:
+    """Worker: extract (stripped) source CFGs for one .i file."""
+    from decbench.utils.cfg import extract_cfgs_from_source
+
+    try:
+        cfgs = extract_cfgs_from_source(Path(i_path)) or {}
+    except Exception:  # noqa: BLE001
+        cfgs = {}
+    return i_path, cfgs
+
+
+def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
+    """Extract + cache source CFGs per project (one pickle each)."""
+    src_dir = root / "ged_src"
+    src_dir.mkdir(exist_ok=True)
+    # Gather .i files per project that still need a source-CFG cache.
+    todo: dict[str, list[str]] = {}
+    for proj in projects:
+        if (src_dir / f"{proj}.pkl").exists():
+            continue
+        comp = root / SRC_OPT / proj / "compiled"
+        if not comp.is_dir():
+            continue
+        ifiles = [
+            str(f)
+            for f in sorted(comp.glob("*.i"))
+            if "conftest" not in f.name and not f.name.startswith("a-")
+        ]
+        if ifiles:
+            todo[proj] = ifiles
+    if not todo:
+        print("[ged/src] all source-CFG caches present", flush=True)
+        return src_dir
+    # path -> project, for routing results
+    owner = {p: proj for proj, paths in todo.items() for p in paths}
+    all_paths = list(owner)
+    print(
+        f"[ged/src] extracting source CFGs: {len(all_paths)} files over "
+        f"{len(todo)} projects, {workers} workers",
+        flush=True,
+    )
+    acc: dict[str, dict] = {proj: {} for proj in todo}
+    ctx = mp.get_context("spawn")
+    done = 0
+    with ctx.Pool(processes=workers) as pool:
+        for ipath, cfgs in pool.imap_unordered(src_cfgs_for_i, all_paths):
+            acc[owner[ipath]].update(cfgs)
+            done += 1
+            if done % 50 == 0 or done == len(all_paths):
+                print(f"[ged/src] {done}/{len(all_paths)} source files", flush=True)
+    for proj, cfgs in acc.items():
+        (src_dir / f"{proj}.pkl").write_bytes(pickle.dumps(cfgs))
+        print(f"[ged/src] {proj}: {len(cfgs)} source functions cached", flush=True)
+    return src_dir
+
+
+# ---- Stage B: GED per (opt, project, binary, dec) -------------------------
+def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
+    """Worker: recompute GED for every function of one (binary, dec).
+
+    ``task`` = (opt, project, stem, dec, decompiled_c_path, src_pkl_path).
+    """
+    opt, project, stem, dec, c_path, src_pkl = task
+    from decbench.metrics.ged import GEDMetric
+    from decbench.utils.cfg import extract_cfgs_from_source
+
+    src_cfgs = pickle.loads(Path(src_pkl).read_bytes())
+    try:
+        dec_cfgs = extract_cfgs_from_source(Path(c_path)) or {}
+    except Exception:  # noqa: BLE001
+        dec_cfgs = {}
+    metric = GEDMetric()
+    perfect_val = metric.perfect_value
+    out: dict[str, dict] = {}
+    for fn, dcfg in dec_cfgs.items():
+        scfg = src_cfgs.get(fn)
+        if scfg is None:
+            continue
+        try:
+            mv = metric.compute_for_function(None, source_cfg=scfg, decompiled_cfg=dcfg)
+        except Exception:  # noqa: BLE001
+            continue
+        out[fn] = {"value": float(mv.value), "perfect": bool(mv.value == perfect_val)}
+    key = f"{opt}::{project}::{stem}::{dec}"
+    return key, out
+
+
+def build_tasks(root: Path, src_dir: Path, only: set[str] | None) -> list[tuple]:
+    tasks = []
+    for opt in OPT_LEVELS:
+        odir = root / opt
+        if not odir.is_dir():
+            continue
+        for proj in sorted(p for p in odir.iterdir() if p.is_dir()):
+            if only and proj.name not in only:
+                continue
+            src_pkl = src_dir / f"{proj.name}.pkl"
+            dec_dir = proj / "decompiled"
+            if not (src_pkl.exists() and dec_dir.is_dir()):
+                continue
+            for dec in DECOMPILERS:
+                for cf in sorted(dec_dir.glob(f"{dec}_*.c")):
+                    stem = cf.name[len(dec) + 1 : -2]
+                    tasks.append((opt, proj.name, stem, dec, str(cf), str(src_pkl)))
+    return tasks
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/full_run")
+    workers = int(sys.argv[2]) if len(sys.argv) > 2 else 16
+    only = {a for a in sys.argv[3:] if not a.lstrip("-").isdigit()} or None
+
+    projects = sorted(p.name for p in (root / SRC_OPT).iterdir() if p.is_dir())
+    if only:
+        projects = [p for p in projects if p in only]
+    src_dir = build_source_cfgs(root, projects, workers)
+
+    ckpt_dir = root / "reeval_ged"
+    ckpt_dir.mkdir(exist_ok=True)
+    tasks = build_tasks(root, src_dir, only)
+    pending = [
+        t
+        for t in tasks
+        if not (
+            ckpt_dir / (f"{t[0]}::{t[1]}::{t[2]}::{t[3]}".replace("::", "__") + ".json")
+        ).exists()
+    ]
+    print(f"[ged] {len(tasks)} tasks, {len(pending)} pending, {workers} workers", flush=True)
+
+    ctx = mp.get_context("spawn")
+    done = 0
+    with ctx.Pool(processes=workers) as pool:
+        for key, result in pool.imap_unordered(eval_one, pending):
+            (ckpt_dir / (key.replace("::", "__") + ".json")).write_text(json.dumps(result))
+            done += 1
+            if done % 25 == 0 or done == len(pending):
+                print(f"[ged] {done}/{len(pending)} (binary,dec) done", flush=True)
+
+    merged: dict[str, dict] = {}
+    for cp in ckpt_dir.glob("*.json"):
+        key = cp.stem.replace("__", "::")
+        for func, v in json.loads(cp.read_text()).items():
+            merged[f"{key}::{func}"] = v
+    out_path = root / "ged_new.json"
+    out_path.write_text(json.dumps(merged))
+    perf = sum(1 for v in merged.values() if v.get("perfect"))
+    print(
+        f"[ged] wrote {out_path} ({len(merged)} funcs, {perf} perfect "
+        f"= {100*perf/max(1,len(merged)):.1f}%)",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONWARNINGS", "ignore")
+    main()

--- a/scripts/rerender_full_run.sh
+++ b/scripts/rerender_full_run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Re-render full_run after the report-logic changes (decompiled-flag tracking,
+# Errors column, normalize toggle, version hover). No re-decompilation:
+#   1) full resume -> rebuild function_results.json with the new builder
+#      (per-(function,decompiler) decompiled flags + decompiler versions)
+#   2) rebuild --add-only -> re-apply the Docker ARM/PE byte_match (byte_match_new.json)
+#   3) render the report
+set -uo pipefail
+cd /home/mahaloz/github/decbench
+source /home/mahaloz/.virtualenvs/decbench/bin/activate
+export KUNA_BIN=/home/mahaloz/github/kuna/decompiler/target/release/kuna
+export GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1
+export DECBENCH_DECOMPILERS=angr,phoenix,ghidra,ida,binja,kuna
+export DECBENCH_WORKERS=40
+export DECBENCH_DECOMPILE_TIMEOUT=300
+
+echo "[rerender] step 1/3: full resume (rebuild function_data w/ decompiled flags)..."
+python scripts/run_benchmark.py results/full_run >results/rerender_resume.log 2>&1
+echo "[rerender] resume tail: $(grep -E 'Functions:|RUN_DRIVER_DONE' results/rerender_resume.log | tail -2 | tr '\n' ' ')"
+
+echo "[rerender] step 2/3: rebuild --add-only (re-apply Docker ARM/PE byte_match)..."
+python scripts/rebuild_function_data.py results/full_run --add-only >results/rerender_rebuild.log 2>&1
+grep -E "byte_match:|functions," results/rerender_rebuild.log | tail -8
+
+echo "[rerender] step 3/3: render report..."
+python -m decbench.cli report results/full_run/scoreboard.toml -o results/full_run/report.html >results/rerender_render.log 2>&1
+echo "[rerender] RERENDER_DONE -> results/full_run/report.html"

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -21,6 +21,7 @@ import json
 import multiprocessing
 import os
 import pickle
+import re
 import shutil
 import subprocess
 import sys
@@ -48,7 +49,20 @@ from decbench.scoring.function_data_builder import build_function_data
 from decbench.scoring.scoreboard import build_scoreboard
 from decbench.utils.cfg import extract_cfgs_from_source
 
-PROJECTS_DIR = Path("projects/sailr")
+# All benchmark project dirs (top-level *.toml only; cps/disabled/ excluded).
+# sailr = x86, cps = ARM firmware, malware = ARM/PE. Decompilation runs on the
+# host for all of them; byte_match abstains where the matching recompile
+# toolchain is absent (ARM/PE), so GED + type_match carry cps/malware.
+PROJECT_DIRS = [Path("projects/sailr"), Path("projects/cps"), Path("projects/malware")]
+
+
+def gather_tomls() -> list[Path]:
+    out: list[Path] = []
+    for d in PROJECT_DIRS:
+        out.extend(sorted(d.glob("*.toml")))
+    return sorted(out, key=lambda p: p.stem)
+
+
 OPT_LEVELS = [
     OptimizationLevel.O0,
     OptimizationLevel.O2,
@@ -65,10 +79,8 @@ _HERE = Path(__file__).resolve().parent
 _DECOMPILE_ONE = _HERE / "decompile_one.py"
 
 
-def project_source_functions(
-    binary_path: Path, source_stems: set[str]
-) -> set[str]:
-    """Names of functions DEFINED in the project's own source files.
+def project_source_functions(binary_path: Path, source_stems: set[str]) -> dict[int, str]:
+    """Map ``low_pc -> name`` for functions DEFINED in the project's own sources.
 
     Reads the binary's DWARF and keeps DW_TAG_subprogram entries that have a
     low_pc (i.e. are defined in this binary) AND whose decl_file basename stem
@@ -76,51 +88,67 @@ def project_source_functions(
     grep's ``src/*.c``). This excludes bundled gnulib/system-header functions —
     matching SAILR's "evaluate the project's own code" intent — and shrinks the
     decompile/evaluate workload by ~1-2 orders of magnitude on gnulib-heavy
-    binaries. Returns an empty set if there is no usable DWARF (caller then
-    falls back to decompiling everything).
+    binaries. The address (DWARF low_pc, in ELF-file space) is the key so the
+    decompile filter + result re-labeling can work on a STRIPPED binary (no
+    symbols), where decompilers only know functions by address. Returns an empty
+    map if there is no usable DWARF (caller then falls back to all functions).
     """
     if not source_stems:
-        return set()
+        return {}
+    # binfmt.dwarf_info reads DWARF from ELF *or* PE (the MinGW malware targets),
+    # so this filter works for x86/ARM ELF and PE alike.
     try:
-        from elftools.elf.elffile import ELFFile
+        from decbench.utils import binfmt
+
+        dw = binfmt.dwarf_info(binary_path)
     except Exception:  # noqa: BLE001
-        return set()
-    names: set[str] = set()
+        return {}
+    if dw is None:
+        return {}
+    addr2name: dict[int, str] = {}
     try:
-        with open(binary_path, "rb") as f:
-            elf = ELFFile(f)
-            if not elf.has_dwarf_info():
-                return set()
-            dw = elf.get_dwarf_info()
-            for cu in dw.iter_CUs():
-                lp = dw.line_program_for_CU(cu)
-                files: list = [None]
-                if lp is not None:
-                    for fe in lp["file_entry"]:
-                        nm = fe.name
-                        files.append(nm.decode() if isinstance(nm, bytes) else nm)
-                for die in cu.iter_DIEs():
-                    if die.tag != "DW_TAG_subprogram":
-                        continue
-                    attrs = die.attributes
-                    if "DW_AT_low_pc" not in attrs or "DW_AT_name" not in attrs:
-                        continue
-                    fi = attrs.get("DW_AT_decl_file")
-                    if fi is None or fi.value >= len(files) or files[fi.value] is None:
-                        continue
-                    base = os.path.basename(files[fi.value])
-                    stem = base[:-2] if base.endswith(".c") else base
-                    if stem in source_stems:
-                        nm = attrs["DW_AT_name"].value
-                        names.add(nm.decode() if isinstance(nm, bytes) else nm)
+        for cu in dw.iter_CUs():
+            lp = dw.line_program_for_CU(cu)
+            # DW_AT_decl_file indexing is 1-based pre-DWARF5 (entry 0 unused) and
+            # 0-based in DWARF5 (entry 0 = primary source); prepend a placeholder
+            # only for pre-v5 so the index lines up either way.
+            version = 4
+            if lp is not None:
+                version = lp.header.get("version", cu.header.get("version", 4))
+            files: list = [] if version >= 5 else [None]
+            if lp is not None:
+                for fe in lp["file_entry"]:
+                    nm = fe.name
+                    files.append(nm.decode() if isinstance(nm, bytes) else nm)
+            for die in cu.iter_DIEs():
+                if die.tag != "DW_TAG_subprogram":
+                    continue
+                attrs = die.attributes
+                if "DW_AT_low_pc" not in attrs or "DW_AT_name" not in attrs:
+                    continue
+                fi = attrs.get("DW_AT_decl_file")
+                if fi is None or not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                    continue
+                base = os.path.basename(files[fi.value])
+                stem = base[:-2] if base.endswith(".c") else base
+                # Match the decl-file stem to a compiled source unit. Exact match
+                # for sailr/cps (basename.i <-> basename.c); also accept the
+                # object-prefixed naming some targets use (e.g. malware's
+                # `mydoom-main.i` <-> decl `main.c`), where the source stem is a
+                # `<prefix>-<decl>` / `<prefix>_<decl>` suffix.
+                if stem in source_stems or any(
+                    s.endswith("-" + stem) or s.endswith("_" + stem) for s in source_stems
+                ):
+                    nm = attrs["DW_AT_name"].value
+                    addr2name[int(attrs["DW_AT_low_pc"].value)] = (
+                        nm.decode() if isinstance(nm, bytes) else nm
+                    )
     except Exception:  # noqa: BLE001
-        return set()
-    return names
+        return {}
+    return addr2name
 
 
-def extract_source_cfgs(
-    project: Project, opt: OptimizationLevel
-) -> dict[str, dict]:
+def extract_source_cfgs(project: Project, opt: OptimizationLevel) -> dict[str, dict]:
     """Extract source CFGs for every preprocessed source, keyed by .i stem.
 
     Runs once per (project, opt) and is reused for BOTH the decompile filter
@@ -132,7 +160,7 @@ def extract_source_cfgs(
     if not sources:
         return out
     if len(sources) == 1:
-        (name, i_path), = sources.items()
+        ((name, i_path),) = sources.items()
         try:
             out[name] = extract_cfgs_from_source(i_path) or {}
         except Exception:  # noqa: BLE001
@@ -140,8 +168,7 @@ def extract_source_cfgs(
         return out
     with ProcessPoolExecutor(max_workers=WORKERS) as pool:
         futs = {
-            pool.submit(extract_cfgs_from_source, i_path): name
-            for name, i_path in sources.items()
+            pool.submit(extract_cfgs_from_source, i_path): name for name, i_path in sources.items()
         }
         for fut in as_completed(futs):
             name = futs[fut]
@@ -150,6 +177,57 @@ def extract_source_cfgs(
             except Exception:  # noqa: BLE001
                 out[name] = {}
     return out
+
+
+def _stripped_copy(binary: Path, strip_dir: Path) -> Path:
+    """A fully-stripped (no DWARF, no symbol table) copy of ``binary``.
+
+    Decompilers must NEVER see debug info or symbols — that is unwarranted help
+    (DWARF types/vars inflate type_match; symbols hand them function boundaries
+    and names). We compile with ``-g`` for the evaluation ground truth, but the
+    decompiler only ever gets this stripped copy (same filename, so the artifact
+    naming/stem is unchanged). Cached by mtime. ``strip --strip-all`` handles ELF
+    of any arch and PE (BFD); we fall back through objcopy variants.
+    """
+    strip_dir.mkdir(parents=True, exist_ok=True)
+    out = strip_dir / binary.name
+    if out.exists() and out.stat().st_mtime >= binary.stat().st_mtime:
+        return out
+    shutil.copy2(binary, out)
+    for cmd in (
+        ["strip", "--strip-all", str(out)],
+        ["objcopy", "--strip-all", str(out), str(out)],
+        ["objcopy", "--strip-debug", str(out), str(out)],
+    ):
+        try:
+            if subprocess.run(cmd, capture_output=True).returncode == 0:
+                break
+        except Exception:  # noqa: BLE001
+            continue
+    return out
+
+
+def _relabel_to_dwarf(
+    result: DecompilationResult, addr2name: dict[int, str], unstripped: Path
+) -> None:
+    """Re-symbolize a stripped-binary decompilation for evaluation.
+
+    The decompiler analysed the stripped binary, so it named functions by address
+    (``FUN_00102530`` / ``sub_...``). Map each back to the DWARF name at its
+    address — renaming in BOTH the code (so GED's Joern parse keys by the right
+    name) and the function key — and point eval at the UNSTRIPPED (DWARF) binary.
+    This is pure bookkeeping so name-based eval/GED line up; the decompiler got no
+    help (its analysis ran on the stripped binary).
+    """
+    new_funcs: dict[str, object] = {}
+    for fd in list(result.functions.values()):
+        dn = addr2name.get(int(fd.address))
+        if dn and dn != fd.name:
+            fd.decompiled_code = re.sub(r"\b" + re.escape(fd.name) + r"\b", dn, fd.decompiled_code)
+            fd.name = dn
+        new_funcs[fd.name] = fd
+    result.functions = new_funcs  # type: ignore[assignment]
+    result.binary_path = unstripped
 
 
 def _timed_decompile(
@@ -230,51 +308,75 @@ def decompile_project_timed(
     project: Project,
     out_dir: Path,
     opt: OptimizationLevel,
-    source_fn_names: dict[str, set[str]],
+    source_fn_map: dict[str, dict[int, str]],
+    decompilers: list[str] | None = None,
 ) -> tuple[dict, dict[str, int]]:
     """Decompile all of a project's binaries at one opt level, with timeouts.
 
     Concurrency is managed by a thread pool whose threads each block on a
     decompile subprocess (the work happens in the child, so the GIL is free).
-    ``source_fn_names`` maps binary stem -> source function names; when a
-    binary has a non-empty set, decompilation is restricted to it.
+    ``source_fn_map`` maps binary stem -> {low_pc: name} for the project's own
+    source functions. The decompiler is run on a STRIPPED copy (no debug info /
+    symbols) and restricted to those ADDRESSES; results are then re-labeled with
+    the DWARF names and pointed back at the unstripped binary for evaluation.
+    ``decompilers`` (default: the global set) lets callers run a SUBSET — used
+    for incremental runs that add/redo only one or two decompilers.
     Returns (results_dict binary->dec->DecompilationResult, stats).
     """
+    decs = decompilers if decompilers is not None else DECOMPILERS
     binaries = project.compiled_binaries.get(opt, [])
+    by_stem = {b.stem: b for b in binaries}
     dec_out = out_dir / opt.value / project.name / "decompiled"
     dec_out.mkdir(parents=True, exist_ok=True)
+    strip_dir = out_dir / opt.value / project.name / "stripped"
 
-    results: dict[str, dict[str, DecompilationResult]] = {
-        b.stem: {} for b in binaries
-    }
+    results: dict[str, dict[str, DecompilationResult]] = {b.stem: {} for b in binaries}
     stats = {"ok": 0, "partial": 0, "timeout": 0, "error": 0, "filtered": 0}
-    tasks = [(b, d) for b in binaries for d in DECOMPILERS]
+    tasks = [(b, d) for b in binaries for d in decs]
     if not tasks:
         return results, stats
 
-    # Write per-binary source-function-name files once (shared across decompilers).
-    names_dir = Path(tempfile.mkdtemp(prefix="decnames_"))
-    names_files: dict[str, str] = {}
+    # Per binary: a stripped copy for the decompiler + a JSON of the target
+    # ADDRESSES (the decompiler sees no names, so we filter/match by address).
+    names_dir = Path(tempfile.mkdtemp(prefix="decaddrs_"))
+    addr_files: dict[str, str] = {}
+    stripped: dict[str, Path] = {}
     for b in binaries:
-        names = source_fn_names.get(b.stem) or set()
-        if names:
+        stripped[b.stem] = _stripped_copy(b, strip_dir)
+        amap = source_fn_map.get(b.stem) or {}
+        if amap:
             nf = names_dir / f"{b.stem}.json"
-            nf.write_text(json.dumps(sorted(names)))
-            names_files[b.stem] = str(nf)
+            nf.write_text(json.dumps(sorted(amap.keys())))
+            addr_files[b.stem] = str(nf)
             stats["filtered"] += 1
         else:
-            names_files[b.stem] = "NONE"
+            addr_files[b.stem] = "NONE"
 
     try:
         with ThreadPoolExecutor(max_workers=WORKERS) as pool:
             futs = {
-                pool.submit(_timed_decompile, b, d, dec_out, names_files[b.stem]):
-                    (b.stem, d)
+                pool.submit(_timed_decompile, stripped[b.stem], d, dec_out, addr_files[b.stem]): (
+                    b.stem,
+                    d,
+                )
                 for b, d in tasks
             }
             for fut in as_completed(futs):
                 stem, dec_name = futs[fut]
                 res = fut.result()
+                # Re-symbolize from the stripped decompile + point eval at the
+                # unstripped (DWARF) binary; rewrite the .c artifact to match.
+                orig = by_stem.get(stem)
+                amap = source_fn_map.get(stem) or {}
+                if orig is not None:
+                    if amap:
+                        _relabel_to_dwarf(res, amap, orig)
+                    else:
+                        res.binary_path = orig
+                    try:
+                        res.to_c_file(dec_out / f"{dec_name}_{stem}.c")
+                    except Exception:  # noqa: BLE001
+                        pass
                 results[stem][dec_name] = res
                 extra = res.decompiler.extra or {}
                 failure = extra.get("failure", "")
@@ -302,15 +404,30 @@ def discover(project: Project, out_dir: Path) -> int:
     return sum(len(v) for v in project.compiled_binaries.values())
 
 
+def _present_decompilers(decompile_data: dict) -> set[str]:
+    """Set of decompiler ids already present in a checkpoint's decompile dict
+    (``{opt: {binary: {dec: result}}}``)."""
+    decs: set[str] = set()
+    for opt_d in (decompile_data or {}).values():
+        for bin_d in (opt_d or {}).values():
+            decs.update(bin_d.keys())
+    return decs
+
+
 def main() -> int:
     args = sys.argv[1:]
     out_dir = Path(args[0]) if args else Path("results/sailr_full")
     only = set(args[2:]) if len(args) > 2 and args[1] == "--" else set()
 
+    # Incremental runs: re-run ONLY decompilers missing from a checkpoint, plus
+    # any listed in DECBENCH_REDO_DECOMPILERS (force-redo even if present, e.g.
+    # after fixing a backend). Existing decompilers' results are kept & merged.
+    redo = {d for d in (os.environ.get("DECBENCH_REDO_DECOMPILERS") or "").split(",") if d}
+
     ckpt_dir = out_dir / "checkpoints"
     ckpt_dir.mkdir(parents=True, exist_ok=True)
 
-    tomls = sorted(PROJECTS_DIR.glob("*.toml"))
+    tomls = gather_tomls()
     if only:
         tomls = [t for t in tomls if t.stem in only]
 
@@ -328,69 +445,105 @@ def main() -> int:
     for project in projects:
         name = project.name
         ckpt = ckpt_dir / f"{name}.pkl"
+        existing: dict | None = None
         if ckpt.exists():
             try:
-                data = pickle.loads(ckpt.read_bytes())
-                all_decompile[name] = data["decompile"]
-                all_evaluate[name] = data["evaluate"]
-                print(f"[resume] {name}: loaded checkpoint", flush=True)
-                continue
+                existing = pickle.loads(ckpt.read_bytes())
             except Exception as e:  # noqa: BLE001
                 print(f"[resume] {name}: bad checkpoint ({e}); recomputing", flush=True)
+                existing = None
+
+        present = _present_decompilers(existing["decompile"]) if existing else set()
+        # Decompilers to (re)run for this project: those requested but absent,
+        # plus any force-redo. If the checkpoint already has everything, resume.
+        to_run = [d for d in DECOMPILERS if d not in present or d in redo]
+        if existing is not None and not to_run:
+            all_decompile[name] = existing["decompile"]
+            all_evaluate[name] = existing["evaluate"]
+            print(f"[resume] {name}: complete ({sorted(present)})", flush=True)
+            continue
 
         nbin = discover(project, out_dir)
         if nbin == 0:
             print(f"[skip] {name}: no compiled binaries discovered", flush=True)
-            all_decompile[name] = {}
-            all_evaluate[name] = {}
+            all_decompile[name] = (existing or {}).get("decompile", {})
+            all_evaluate[name] = (existing or {}).get("evaluate", {})
             (ckpt_dir / f"{name}.pkl").write_bytes(
-                pickle.dumps({"decompile": {}, "evaluate": {}})
+                pickle.dumps({"decompile": all_decompile[name], "evaluate": all_evaluate[name]})
             )
             continue
 
         t0 = time.time()
-        proj_dec: dict = {}
-        proj_eval: dict = {}
+        # Start from existing results so prior decompilers are preserved; the
+        # per-opt merge below adds/overwrites only the `to_run` decompilers.
+        proj_dec: dict = dict(existing["decompile"]) if existing else {}
+        proj_eval: dict = dict(existing["evaluate"]) if existing else {}
+        print(f"[{name}] running decompilers={to_run} (have={sorted(present)})", flush=True)
         for opt in OPT_LEVELS:
             if opt not in project.compiled_binaries or not project.compiled_binaries[opt]:
                 proj_dec[opt] = {}
                 proj_eval[opt] = {}
                 continue
-            n = len(project.compiled_binaries[opt])
-
-            # 1) Extract source CFGs once (for GED), and compute the per-binary
-            #    decompile filter from DWARF (the project's OWN src functions —
-            #    NOT the preprocessed .i function universe, which includes every
-            #    inlined system/gnulib header and so constrains nothing).
+            # 1) Compute the per-binary decompile filter from DWARF FIRST (cheap
+            #    DWARF read) — the project's OWN src functions, not the .i universe.
+            #    SKIP binaries whose filter is empty: those have no usable debug
+            #    info (e.g. some LTO'd cps firmware), so the only alternative is
+            #    decompiling ALL ~10k+ library/RTOS functions, which times out
+            #    every decompiler and produces noisy, un-typed results. Skipping
+            #    keeps the benchmark to functions we can actually attribute, and
+            #    avoids the (very slow) source-CFG extraction for skipped projects.
             ts = time.time()
-            src_cfgs = extract_source_cfgs(project, opt)
             source_stems = set(project.preprocessed_sources.get(opt, {}).keys())
-            src_fn_names: dict[str, set[str]] = {}
+            src_fn_names: dict[str, dict[int, str]] = {}
+            kept_binaries = []
             for b in project.compiled_binaries[opt]:
-                src_fn_names[b.stem] = project_source_functions(b, source_stems)
+                fns = project_source_functions(b, source_stems)
+                if fns:
+                    src_fn_names[b.stem] = fns
+                    kept_binaries.append(b)
+            skipped = len(project.compiled_binaries[opt]) - len(kept_binaries)
+            if not kept_binaries:
+                print(
+                    f"[{name}/{opt.value}] SKIP: no binary has a usable DWARF "
+                    f"source filter ({skipped} binaries skipped) in "
+                    f"{time.time() - ts:.0f}s",
+                    flush=True,
+                )
+                proj_dec.setdefault(opt, {})
+                proj_eval.setdefault(opt, {})
+                continue
+            project.compiled_binaries[opt] = kept_binaries
+            n = len(kept_binaries)
+
+            # 2) Extract source CFGs (for GED) only for the kept binaries' project.
+            src_cfgs = extract_source_cfgs(project, opt)
             n_filt = sum(len(v) for v in src_fn_names.values())
             print(
                 f"[{name}/{opt.value}] {len(src_cfgs)} sources; DWARF source-fn "
-                f"filter = {n_filt} funcs across {len(src_fn_names)} binaries "
-                f"in {time.time() - ts:.0f}s",
+                f"filter = {n_filt} funcs across {len(kept_binaries)} binaries "
+                f"({skipped} skipped: no DWARF) in {time.time() - ts:.0f}s",
                 flush=True,
             )
 
-            # 2) Decompile, restricted to source functions where known.
+            # 2) Decompile, restricted to source functions where known. Only the
+            #    `to_run` decompilers (incremental); merge into any existing.
             td = time.time()
             print(
-                f"[{name}/{opt.value}] decompiling {n} binaries x {DECOMPILERS} "
+                f"[{name}/{opt.value}] decompiling {n} binaries x {to_run} "
                 f"(timeout {DECOMPILE_TIMEOUT}s)...",
                 flush=True,
             )
             try:
                 dec, dstats = decompile_project_timed(
-                    project, out_dir, opt, src_fn_names
+                    project, out_dir, opt, src_fn_names, decompilers=to_run
                 )
             except Exception as e:  # noqa: BLE001
                 print(f"[{name}/{opt.value}] decompile ERROR: {e}", flush=True)
                 dec, dstats = {}, {}
-            proj_dec[opt] = dec
+            merged_dec = proj_dec.get(opt, {})
+            for b_stem, dmap in dec.items():
+                merged_dec.setdefault(b_stem, {}).update(dmap)
+            proj_dec[opt] = merged_dec
             print(
                 f"[{name}/{opt.value}] decompiled in {time.time() - td:.0f}s "
                 f"(ok={dstats.get('ok', 0)} partial={dstats.get('partial', 0)} "
@@ -404,13 +557,22 @@ def main() -> int:
             print(f"[{name}/{opt.value}] evaluating...", flush=True)
             try:
                 ev = evaluate_project(
-                    project, dec, out_dir, opt, None, parallel=True,
-                    workers=WORKERS, precomputed_source_cfgs=src_cfgs,
+                    project,
+                    dec,
+                    out_dir,
+                    opt,
+                    None,
+                    parallel=True,
+                    workers=WORKERS,
+                    precomputed_source_cfgs=src_cfgs,
                 )
             except Exception as e:  # noqa: BLE001
                 print(f"[{name}/{opt.value}] evaluate ERROR: {e}", flush=True)
                 ev = {}
-            proj_eval[opt] = ev
+            merged_eval = proj_eval.get(opt, {})
+            for b_stem, emap in ev.items():
+                merged_eval.setdefault(b_stem, {}).update(emap)
+            proj_eval[opt] = merged_eval
             print(f"[{name}/{opt.value}] evaluated in {time.time() - te:.0f}s", flush=True)
 
         all_decompile[name] = proj_dec
@@ -440,6 +602,21 @@ def main() -> int:
         decompilers=DECOMPILERS,
     )
     fd = build_function_data(all_evaluate, projects, all_decompile)
+    # Populate the report's code-carrying extras: dataset tags (full/hard/tiny),
+    # side-by-side Compare samples (with source), Hardest functions, and
+    # per-decompiler compile rates. Without this the report has no Compare view,
+    # no Hardest list, and no dataset selector.
+    try:
+        from decbench.scoring.report_extras import attach_extras
+
+        attach_extras(
+            fd,
+            evaluation_results=all_evaluate,
+            decompile_results=all_decompile,
+            projects=projects,
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"[warn] attach_extras failed: {e}", flush=True)
     fd_path = out_dir / "function_results.json"
     fd.to_json(fd_path)
     scoreboard.raw_data_path = fd_path

--- a/tests/test_byte_match_fixup.py
+++ b/tests/test_byte_match_fixup.py
@@ -1,0 +1,162 @@
+"""Tests for the byte-match compilability fixup + operand normalization."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from decbench.metrics.byte_match import _normalize_operands
+from decbench.metrics.fixup import compile_with_fixup, sanitize_tokens
+
+gcc_available = shutil.which("gcc") is not None
+needs_gcc = pytest.mark.skipif(not gcc_available, reason="gcc not installed")
+
+
+class TestSanitizeTokens:
+    def test_strips_symbol_version_qualifier(self) -> None:
+        # angr emits illegal `GLIBC_2.2.5::stderr`; the bare identifier remains.
+        out = sanitize_tokens("fprintf(GLIBC_2.2.5::stderr, msg);")
+        assert "::" not in out
+        assert "stderr" in out
+
+    def test_leaves_plain_code_untouched(self) -> None:
+        code = "int f(int a) { return a + 1; }"
+        assert sanitize_tokens(code) == code
+
+    def test_strips_decompiler_annotations(self) -> None:
+        # Binary Ninja / IDA / Ghidra emit annotations that aren't valid C where
+        # they appear; stripping them lets the body still compile.
+        assert "__noreturn" not in sanitize_tokens("int main() __noreturn {")
+        assert "__convention" not in sanitize_tokens('void f() __convention("regparm") {')
+        out = sanitize_tokens("int __cdecl g(int a)")
+        assert "__cdecl" not in out and "g(int a)" in out
+
+
+class TestNormalizeOperands:
+    def test_branch_target_blanked(self) -> None:
+        # Two calls to different (link-dependent) targets normalize equal.
+        a = _normalize_operands("call", "0x1234")
+        b = _normalize_operands("call", "0x9abc")
+        assert a == b == "X"
+
+    def test_rip_relative_blanked(self) -> None:
+        a = _normalize_operands("lea", "rax, [rip + 0x2e04]")
+        b = _normalize_operands("lea", "rax, [rip + 0x10]")
+        assert a == b
+        assert "0x2e04" not in a
+
+    def test_non_branch_immediate_preserved(self) -> None:
+        # A real constant in a non-branch instruction must NOT be blanked.
+        out = _normalize_operands("add", "rax, 0x10")
+        assert "0x10" in out
+
+    def test_indirect_branch_displacement_preserved(self) -> None:
+        # An indirect call's memory displacement is a (base-independent) struct
+        # offset — a real difference that must be kept, not blanked.
+        a = _normalize_operands("call", "qword ptr [rax + 0x20]")
+        b = _normalize_operands("call", "qword ptr [rax + 0x40]")
+        assert a != b
+        assert "0x20" in a
+
+    def test_arm_adrp_immediate_blanked(self) -> None:
+        # AArch64 adrp immediate is a PC-relative page address (link-dependent).
+        a = _normalize_operands("adrp", "x0, #0x400000")
+        b = _normalize_operands("adrp", "x0, #0x10000")
+        assert a == b
+        assert "0x400000" not in a
+
+    def test_arm_pc_literal_load_blanked(self) -> None:
+        a = _normalize_operands("ldr", "x0, [pc, #0x2e04]")
+        b = _normalize_operands("ldr", "x0, [pc, #0x10]")
+        assert a == b
+        assert "0x2e04" not in a
+
+
+@needs_gcc
+class TestCompileWithFixup:
+    def test_plain_function_compiles(self) -> None:
+        res = compile_with_fixup("int add(int a, int b) { return a + b; }", "add")
+        assert res.compilable
+        assert res.obj_path is not None and res.obj_path.exists()
+        shutil.rmtree(res.obj_path.parent, ignore_errors=True)
+
+    def test_ghidra_pseudotypes_get_defined(self) -> None:
+        # `undefined4`/`uint`/`code` are undefined in C; the fixup must typedef
+        # them via gcc-error-driven self-repair so the function builds.
+        code = (
+            "uint compute(undefined4 x) {\n" "    uint r = (uint)x;\n" "    return r + 1;\n" "}\n"
+        )
+        res = compile_with_fixup(code, "compute")
+        assert res.compilable, res.error
+        assert res.iterations >= 2  # needed at least one repair pass
+        shutil.rmtree(res.obj_path.parent, ignore_errors=True)
+
+    def test_undeclared_symbol_stubbed(self) -> None:
+        code = "int g(void) { return helper_fn(global_thing); }"
+        res = compile_with_fixup(code, "g")
+        assert res.compilable, res.error
+        shutil.rmtree(res.obj_path.parent, ignore_errors=True)
+
+    def test_unrepairable_returns_no_object(self) -> None:
+        # A hard syntax error cannot be repaired by declaration injection.
+        res = compile_with_fixup("int bad(void) { return", "bad")
+        assert not res.compilable
+        assert res.obj_path is None
+
+    def test_abstains_when_toolchain_missing(self, tmp_path) -> None:
+        # When the matching recompile toolchain is unavailable (e.g. ARM/PE on an
+        # x86 host), byte_match must ABSTAIN (no per-function results), not score
+        # 0 — so cps/malware aren't unfairly penalized.
+        import subprocess
+
+        from decbench.metrics.byte_match import ByteMatchMetric
+        from decbench.models.decompilation import (
+            DecompilationResult,
+            DecompilerMetadata,
+            FunctionDecompilation,
+        )
+        from decbench.utils import binfmt
+
+        if not gcc_available:
+            pytest.skip("gcc not installed")
+        binary = tmp_path / "b"
+        src = tmp_path / "b.c"
+        src.write_text("int add(int a,int b){return a+b;}\nint main(){return add(2,3);}\n")
+        subprocess.run(["gcc", "-O0", "-g", "-o", str(binary), str(src)], check=True)
+
+        dr = DecompilationResult(
+            binary_path=binary,
+            binary_name="b",
+            decompiler=DecompilerMetadata(decompiler_name="angr"),
+            functions={
+                "add": FunctionDecompilation(
+                    name="add", address=0x1000, decompiled_code="int add(int a,int b){return a+b;}"
+                )
+            },
+        )
+        metric = ByteMatchMetric()
+        orig = binfmt.tool_available
+        binfmt.tool_available = lambda name: False  # force "toolchain missing"
+        try:
+            result = metric.compute_for_binary(dr)
+        finally:
+            binfmt.tool_available = orig
+        assert result.function_results == {}  # abstained, not scored 0
+        assert any("abstain" in e for e in result.errors)
+
+    def test_failure_paths_do_not_leak_temp_dirs(self, tmp_path) -> None:
+        # Every non-success path must clean up its mkdtemp dir. Isolate the temp
+        # root to tmp_path so a concurrent benchmark run's decbench_bm_* dirs
+        # don't race this assertion.
+        import glob
+        import tempfile
+
+        old = tempfile.tempdir
+        tempfile.tempdir = str(tmp_path)
+        try:
+            for _ in range(5):
+                compile_with_fixup("int bad(void) { return", "bad")
+        finally:
+            tempfile.tempdir = old
+        assert glob.glob(f"{tmp_path}/decbench_bm_*") == []  # no leaked dirs

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -247,7 +247,7 @@ class TestScoringPipeline:
             assert "Recompilation Bytematch" in content
             assert "Overall" in content
             # No function data -> banner present, no embedded data.
-            assert "interactive filtering unavailable" in content.lower()
+            assert "interactive views unavailable" in content.lower()
             assert "const DATA" not in content
 
     def test_html_report_with_function_data(self) -> None:
@@ -333,9 +333,10 @@ class TestScoringPipeline:
 
             # Embedded data + interactive sections present.
             assert "const DATA" in content
-            assert 'id="filters"' in content
-            assert 'id="comparison-matrix"' in content
-            assert 'id="per-binary-breakdown"' in content
+            # Sidebar layout: nav + JS-driven leaderboard + view routing.
+            assert 'class="sidebar"' in content
+            assert 'id="leaderboard-table"' in content
+            assert 'data-view="metrics"' in content
 
             # The raw "</script>" sequence must NOT appear inside the
             # embedded JSON. The script tag itself closes with "</script>",

--- a/tests/test_report_extras.py
+++ b/tests/test_report_extras.py
@@ -1,0 +1,92 @@
+"""Tests for report extras: side-by-side samples, hardest source, compile rates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from decbench.models.function_data import (
+    BinaryGroup,
+    FunctionData,
+    FunctionRecord,
+)
+from decbench.scoring.report_extras import (
+    build_hardest,
+    build_samples,
+    compute_compile_rates,
+)
+
+SOURCE = """\
+int target(int a, int b) {
+    int s = a + b;
+    return s * 2;
+}
+"""
+
+
+def _make_decompile_results(binary_path: Path):
+    """proj -> opt -> binary -> dec -> DecompilationResult-ish mock."""
+    func = SimpleNamespace(decompiled_code="int target(int a,int b){return a+b+b;}", line_count=1)
+    dec_result = SimpleNamespace(binary_path=binary_path, functions={"target": func})
+    return {"proj": {"O0": {"bin1": {"angr": dec_result}}}}
+
+
+def _function_data():
+    fr = FunctionRecord(
+        function="target",
+        values={"angr": {"ged": 0.0, "type_match": 1.0, "byte_match": 0.5}},
+        perfects={"angr": {"ged": True, "type_match": True, "byte_match": False}},
+        labels=["O0"],
+        datasets=["full", "tiny"],
+        size=4,
+    )
+    return FunctionData(
+        decompilers=["angr"],
+        metrics=["ged", "type_match", "byte_match"],
+        perfect_values={"ged": 0.0, "type_match": 1.0, "byte_match": 1.0},
+        groups=[BinaryGroup(project="proj", opt_level="O0", binary="bin1", functions=[fr])],
+    )
+
+
+def test_build_samples_includes_source_and_decompiled(tmp_path: Path) -> None:
+    # A fake binary with a sibling .c source (source_extract finds it w/o DWARF).
+    binary = tmp_path / "bin1"
+    binary.write_bytes(b"\x7fELF not-really")
+    (tmp_path / "bin1.c").write_text(SOURCE)
+
+    fd = _function_data()
+    samples = build_samples(fd, _make_decompile_results(binary))
+    assert len(samples) == 1
+    s = samples[0]
+    assert s.function == "target"
+    assert "angr" in s.decompiled
+    assert "return a+b+b" in s.decompiled["angr"]
+    assert s.source_code is not None
+    assert "return s * 2;" in s.source_code
+    # Carries the per-metric scores for display.
+    assert s.values["angr"]["byte_match"] == 0.5
+
+
+def test_build_hardest_fills_source(tmp_path: Path) -> None:
+    binary = tmp_path / "bin1"
+    binary.write_bytes(b"\x7fELF")
+    (tmp_path / "bin1.c").write_text(SOURCE)
+
+    bm = SimpleNamespace(function_results={"target": SimpleNamespace(value=0.5)})
+    evaluation = {"proj": {"O0": {"bin1": {"angr": {"byte_match": bm}}}}}
+    entries = build_hardest(evaluation, _make_decompile_results(binary))
+    assert entries
+    e = entries[0]
+    assert e.function == "target"
+    assert e.decompiled_code is not None
+    assert e.source_code is not None and "return s * 2;" in e.source_code
+
+
+def test_compute_compile_rates() -> None:
+    def mv(compilable: bool):
+        return SimpleNamespace(metadata={"compilable": compilable})
+
+    bm = SimpleNamespace(function_results={"a": mv(True), "b": mv(False), "c": mv(True)})
+    evaluation = {"proj": {"O0": {"bin1": {"angr": {"byte_match": bm}}}}}
+    rates = compute_compile_rates(evaluation)
+    assert abs(rates["angr"] - (2 / 3)) < 1e-9

--- a/tests/test_source_extract.py
+++ b/tests/test_source_extract.py
@@ -1,0 +1,72 @@
+"""Tests for per-function source extraction (the Compare view's source side)."""
+
+from __future__ import annotations
+
+from decbench.utils.source_extract import extract_from_text
+
+SRC = """\
+#include <stdio.h>
+
+static int helper(int x) {
+    return x * 2;
+}
+
+int main(int argc, char **argv) {
+    int total = 0;
+    for (int i = 0; i < argc; i++) {
+        total += helper(i);   /* call site, not a definition */
+    }
+    if (total > 10) { total = 10; }
+    return total;
+}
+
+void cleanup(void) {
+    printf("bye\\n");
+}
+"""
+
+
+class TestExtractFromText:
+    def test_extracts_simple_function(self) -> None:
+        out = extract_from_text(SRC, "helper")
+        assert out is not None
+        assert out.startswith("static int helper(int x)")
+        assert "return x * 2;" in out
+        # Must stop at the function's closing brace, not run into main.
+        assert "int main" not in out
+
+    def test_brace_matching_handles_nested_blocks(self) -> None:
+        out = extract_from_text(SRC, "main")
+        assert out is not None
+        assert out.startswith("int main(")
+        assert "return total;" in out
+        # Balanced braces.
+        assert out.count("{") == out.count("}")
+        # Should not swallow the following function.
+        assert "void cleanup" not in out
+
+    def test_call_site_not_mistaken_for_definition(self) -> None:
+        # `helper` is called inside main; extraction must return the real def.
+        out = extract_from_text(SRC, "helper")
+        assert "return x * 2;" in out
+
+    def test_missing_function_returns_none(self) -> None:
+        assert extract_from_text(SRC, "does_not_exist") is None
+
+    def test_string_with_brace_does_not_break_matching(self) -> None:
+        out = extract_from_text(SRC, "cleanup")
+        assert out is not None
+        assert "bye" in out
+        assert out.count("{") == out.count("}")
+
+    def test_function_pointer_parameter_signature(self) -> None:
+        # The param list contains parens; the naive "first )" would reject this.
+        src = (
+            "int registerit(void (*cb)(int), int n) {\n"
+            "    return cb ? n : 0;\n"
+            "}\n"
+        )
+        out = extract_from_text(src, "registerit")
+        assert out is not None
+        assert out.startswith("int registerit(")
+        assert "return cb ? n : 0;" in out


### PR DESCRIPTION
Decompiler-facing fairness:
- Decompilers now get a fully STRIPPED binary (no DWARF, no symbols); evaluation uses the unstripped DWARF copy. The source-function filter matches by DWARF low_pc (address) and results are re-labeled by address->name, so decompilers get no unwarranted help (esp. type_match no longer echoing DWARF types). (scripts/run_benchmark.py, decompilers/raw/common.py, scripts/decompile_one.py)
- byte_match v2: gcc-diagnostic-driven compilability fixup + operand normalization; abstains when the recompile toolchain is absent (ARM/PE on x86). (metrics/fixup.py, metrics/byte_match.py)
- GED: strip inlined system headers from preprocessed .i before Joern (it was timing out on header bloat, not failing), and match each binary against the UNION of the project's source CFGs. (utils/cfg.py, pipeline/evaluate.py)

Decompilers:
- binja emits pseudo-C (was raw HLIL); angr Phoenix structurer backend.

Report (rendering/html.py, scoring/*):
- swebench-style sortable leaderboard, Metrics, side-by-side Compare, Hardest, Historical, sidebar dataset selector.
- One denominator per decompiler (= functions decompiled) via per-(function, decompiler) decompiled/errored tracking -> Errors column; "normalize failures" toggle; decompiler version on hover.
- New Dataset page: software-type categories, projects, total LOC, and Joern source/output parse-failure pipeline health. (scripts/compute_dataset_info.py)

Targets / infra:
- cps debug builds (betaflight/chibios/cleanflight); slim cross/mingw Dockerfile.compile; resilient drivers: reeval_bytematch, reeval_ged, rebuild_function_data (--add-only/--ged), overnight_run + finalize/rerender.
- Tests: byte_match fixup, report extras, source extract.


Claude-Session: https://claude.ai/code/session_01RzUkv7A5mKLPFrJDn5BRPA