### PR TITLE
Add `decbench improvements`: find where one decompiler beats another

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,11 @@ decbench report scoreboard.toml     # Generate HTML report (interactive if
 decbench dataset save results/sailr_full sailr   # snapshot compiled binaries (no recompile later)
 decbench dataset materialize sailr results/reuse # lay back out, then: decbench run --skip-compile
 decbench subset results/sailr_full/function_results.json  # large-function subset manifest
+# Find per-function improvement targets: functions where a BASE decompiler beats
+# a TARGET on a metric (respects each metric's direction; --perfect-only = base is
+# a perfect match, e.g. GED 0). Reads a results tree's function_results.json and
+# resolves each case to its binary path + function symbol/address on disk.
+decbench improvements results/full_run -b angr -t kuna -m ged --perfect-only
 decbench decompiler-build retdec    # build a dockerized decompiler image
 # Caching is automatic (content-addressed); DECBENCH_NO_CACHE=1 disables it.
 # Quick end-to-end smoke (raw backends + 2 Ghidra versions + caching + report):

--- a/README.md
+++ b/README.md
@@ -130,6 +130,55 @@ switches between views and holds a **dataset selector** (`full` / `hard` /
 | **Hardest** | the worst-scoring functions, with decompiled code and source |
 | **Historical** | per-metric perfect % across decompiler versions (e.g. `ghidra@12.0` vs `ghidra@12.1`) |
 
+## Finding improvement cases
+
+`decbench improvements` mines a results tree for the concrete functions where one
+decompiler beats another on a metric — a targeted to-do list for whoever is
+improving the losing decompiler. It reads the `function_results.json` produced by
+a run and, per function, compares a **base** decompiler (the winner) against a
+**target** (the one to improve), respecting the metric's direction.
+
+The example below uses **GED** (structural correctness — CFG graph edit distance,
+where **lower is better** and `0` is a perfect structural match):
+
+```bash
+# Where does angr (base) structurally beat ghidra (target)? -m ged is the default.
+decbench improvements results/sailr_full -b angr -t ghidra -m ged
+
+# Strongest signal only: functions angr recovers *perfectly* (GED == 0) while
+# ghidra does not — the clearest wins to learn from.
+decbench improvements results/sailr_full -b angr -t ghidra -m ged --perfect-only
+```
+
+Each row locates the function on disk — binary, path to the compiled binary, and
+the function symbol + address — so you can jump straight to it:
+
+```
+angr beats ghidra on 'ged' — 356 case(s)  [base-perfect only]
+metric: ged  (lower is better, perfect = 0)
+showing 3 of 356, largest margin first
+
+── libacl / O0 / getfacl ──  results/sailr_full/O0/libacl/compiled/getfacl
+   0x281a  get_list   angr=0*  ghidra=38  Δ38
+── coreutils / O2-noinline / shred ──  results/sailr_full/O2-noinline/coreutils/compiled/shred
+   0x4160  do_wipefd  angr=0*  ghidra=36  Δ36
+```
+
+`Δ` is how much better the base scored (here, ghidra's GED); `*` marks a perfect
+base score. Cases are ordered by the largest base advantage first.
+
+| Flag | Meaning |
+|------|---------|
+| `-b, --base-decompiler` | the decompiler that is **winning** (required) |
+| `-t, --target-decompiler` | the decompiler that is **losing** — the one to improve (required) |
+| `-m, --metric` | metric to compare on: `ged` (default), `type_match`, or `byte_match`. Direction is applied automatically — GED is lower-is-better/perfect `0`; type_match and byte_match are higher-is-better/perfect `1` |
+| `--perfect-only` | only functions where the base is a **perfect** match on the metric (GED `0`, type/byte_match `1`) |
+| `--include-target-missing` | also include functions the base scored but the target has no usable score for (failed to decompile, or the metric errored) |
+| `--limit N` | cap the cases shown (`0` = all; default 50) |
+| `-f, --format text\|json` | `json` emits one object per case (binary path, address, values, margin, labels) for scripting |
+
+`RESULTS` may be a results directory or a `function_results.json` file directly.
+
 ## Project Configuration
 
 Projects are defined via TOML files:

--- a/decbench/cli.py
+++ b/decbench/cli.py
@@ -19,7 +19,8 @@ def main() -> None:
 @main.command()
 @click.argument("projects", nargs=-1, type=click.Path(exists=True))
 @click.option(
-    "-o", "--output",
+    "-o",
+    "--output",
     type=click.Path(),
     default="results",
     help="Output directory for results",
@@ -137,6 +138,7 @@ def run(
 
         if results.scoreboard:
             from decbench.scoring.scoreboard import render_scoreboard_text
+
             console.print(render_scoreboard_text(results.scoreboard))
 
         console.print(f"\nTotal time: {results.total_time_seconds:.1f}s")
@@ -150,12 +152,14 @@ def run(
 @main.command()
 @click.argument("binary", type=click.Path(exists=True))
 @click.option(
-    "-s", "--source",
+    "-s",
+    "--source",
     type=click.Path(exists=True),
     help="Path to source/preprocessed file for comparison",
 )
 @click.option(
-    "-o", "--output",
+    "-o",
+    "--output",
     type=click.Path(),
     default="results",
     help="Output directory",
@@ -284,13 +288,15 @@ def show(scoreboard_path, format) -> None:
         console.print(render_scoreboard_markdown(scoreboard))
     elif format == "json":
         import json
+
         console.print(json.dumps(scoreboard.to_display_dict(), indent=2))
 
 
 @main.command()
 @click.argument("scoreboard_path", type=click.Path(exists=True))
 @click.option(
-    "-o", "--output",
+    "-o",
+    "--output",
     type=click.Path(),
     default="results/report.html",
     help="Output HTML file path",
@@ -299,8 +305,7 @@ def show(scoreboard_path, format) -> None:
     "--function-data",
     type=click.Path(),
     default=None,
-    help="Path to function_results.json for interactive report "
-    "(default: sibling of scoreboard)",
+    help="Path to function_results.json for interactive report " "(default: sibling of scoreboard)",
 )
 def report(scoreboard_path, output, function_data) -> None:
     """Generate an HTML report from a scoreboard."""
@@ -332,9 +337,7 @@ def report(scoreboard_path, output, function_data) -> None:
             )
             fd = None
     else:
-        console.print(
-            "[yellow]No function data found; generating static report.[/yellow]"
-        )
+        console.print("[yellow]No function data found; generating static report.[/yellow]")
 
     # Ensure the dataset presets (full/hard/hard-inlined/tiny) are tagged so the
     # report's dataset selector works even when re-rendering older data.
@@ -354,7 +357,8 @@ def report(scoreboard_path, output, function_data) -> None:
 @main.command()
 @click.argument("name")
 @click.option(
-    "-o", "--output",
+    "-o",
+    "--output",
     type=click.Path(),
     default=".",
     help="Output directory for project file",
@@ -404,9 +408,7 @@ def dataset_save(results_dir, name, store) -> None:
     from decbench.dataset import save_dataset
 
     console = Console()
-    manifest = save_dataset(
-        Path(results_dir), name, store_root=Path(store) if store else None
-    )
+    manifest = save_dataset(Path(results_dir), name, store_root=Path(store) if store else None)
     console.print(
         f"Saved dataset [bold]{name}[/bold]: {len(manifest.binaries)} binaries "
         f"across {len(manifest.compile_sets())} compile-sets."
@@ -455,11 +457,16 @@ def dataset_materialize(name, dest, store) -> None:
 @main.command()
 @click.argument("function_data", type=click.Path(exists=True))
 @click.option(
-    "-o", "--output", type=click.Path(), default="subset_large.json",
+    "-o",
+    "--output",
+    type=click.Path(),
+    default="subset_large.json",
     help="Where to write the subset manifest",
 )
 @click.option(
-    "--method", type=click.Choice(["std", "percentile"]), default="std",
+    "--method",
+    type=click.Choice(["std", "percentile"]),
+    default="std",
     help="Tail selection: mean+k*std, or top-(100-k) percentile",
 )
 @click.option("--k", type=float, default=1.0, help="std multiplier or percentile")
@@ -483,6 +490,126 @@ def subset(function_data, output, method, k) -> None:
         f"Large subset: [bold]{len(manifest.functions)}[/bold] / {dist['count']} "
         f"functions (threshold size >= {manifest.threshold:.1f}) -> {output}"
     )
+
+
+@main.command()
+@click.argument("results", type=click.Path(exists=True))
+@click.option(
+    "-b",
+    "--base-decompiler",
+    "base",
+    required=True,
+    help="Decompiler that is WINNING on the metric (the reference to learn from)",
+)
+@click.option(
+    "-t",
+    "--target-decompiler",
+    "target",
+    required=True,
+    help="Decompiler that is LOSING on the metric (the one to improve)",
+)
+@click.option(
+    "-m",
+    "--metric",
+    default="ged",
+    show_default=True,
+    help="Metric to compare on (e.g. ged, type_match, byte_match)",
+)
+@click.option(
+    "--perfect-only",
+    is_flag=True,
+    help="Only show functions where the base decompiler is a PERFECT match on "
+    "the metric (GED == 0, type_match/byte_match == 1)",
+)
+@click.option(
+    "--include-target-missing",
+    is_flag=True,
+    help="Also include functions the base scored but for which the target has "
+    "no usable score — it failed to decompile, or the metric errored (e.g. GED "
+    "inf). Counts as the target losing.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Maximum number of cases to show (0 = all)",
+)
+@click.option(
+    "-f",
+    "--format",
+    "out_format",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format",
+)
+def improvements(
+    results, base, target, metric, perfect_only, include_target_missing, limit, out_format
+) -> None:
+    """Find per-function cases where BASE beats TARGET on a metric.
+
+    RESULTS is a benchmark results directory (or a function_results.json file).
+    Each reported function is a concrete place the TARGET decompiler could
+    improve: it lists the binary, the path to it on disk, and the function
+    symbol + address (when resolvable). Respects each metric's direction, so
+    "beats" means a genuinely better score.
+
+    Example: places angr beats kuna on structural correctness, base perfect:
+
+        decbench improvements results/full_run -b angr -t kuna -m ged --perfect-only
+    """
+    import json as _json
+
+    from decbench.models.function_data import FunctionData
+    from decbench.scoring.improvements import find_improvement_cases, render_text
+
+    results_path = Path(results)
+    if results_path.is_dir():
+        fd_path = results_path / "function_results.json"
+        results_root: Path | None = results_path
+    else:
+        fd_path = results_path
+        results_root = results_path.parent
+
+    if not fd_path.exists():
+        raise click.ClickException(
+            f"No function_results.json found at {fd_path}. Point RESULTS at a "
+            "benchmark results directory (or the function_results.json itself)."
+        )
+
+    fd = FunctionData.from_json(fd_path)
+
+    try:
+        cases = find_improvement_cases(
+            fd,
+            base,
+            target,
+            metric,
+            perfect_only=perfect_only,
+            include_target_missing=include_target_missing,
+            results_root=results_root,
+        )
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+
+    shown = cases if limit in (0, None) else cases[:limit]
+
+    if out_format == "json":
+        click.echo(_json.dumps([c.to_dict() for c in shown], indent=2))
+    else:
+        # click.echo (not rich) so wide tabular rows are not soft-wrapped.
+        click.echo(
+            render_text(
+                shown,
+                fd,
+                base=base,
+                target=target,
+                metric=metric,
+                total=len(cases),
+                perfect_only=perfect_only,
+            )
+        )
 
 
 @main.command("decompiler-build")

--- a/decbench/scoring/improvements.py
+++ b/decbench/scoring/improvements.py
@@ -1,0 +1,330 @@
+"""Find per-function *improvement cases* between two decompilers.
+
+A decompiler developer wants to know: *where does another decompiler (the base)
+beat mine (the target) on a given metric?* Each such function is a concrete,
+actionable place to improve the target. This module reads an already-computed
+:class:`~decbench.models.function_data.FunctionData` (the ``function_results.json``
+persisted next to a scoreboard) and returns the functions where ``base`` scores
+strictly better than ``target`` on one metric, respecting the metric's direction
+(GED is lower-is-better with a perfect value of 0; byte_match/type_match are
+higher-is-better with a perfect value of 1).
+
+The comparison is per function; each :class:`ImprovementCase` carries enough to
+locate the function on disk — the binary name, the resolved path to the compiled
+binary, the function symbol, and (best effort) its address — by walking the
+results tree with :mod:`decbench.utils.results_tree`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from decbench.models.function_data import FunctionData
+from decbench.utils import results_tree
+
+
+@dataclass
+class ImprovementCase:
+    """One function where ``base`` beats ``target`` on ``metric``."""
+
+    project: str
+    opt_level: str
+    binary: str
+    function: str
+    base: str
+    target: str
+    metric: str
+
+    base_value: float
+    # None when the target produced no value for this metric on this function
+    # (e.g. it failed to decompile it) and ``include_target_missing`` is set.
+    target_value: float | None
+    base_perfect: bool
+    # Base's advantage magnitude (>= 0), always oriented "higher = base wins by
+    # more"; ``inf`` when the target is missing entirely.
+    margin: float
+    target_missing: bool
+
+    labels: list[str] = field(default_factory=list)
+    binary_path: Path | None = None
+    address: int | None = None
+
+    def to_dict(self) -> dict:
+        """JSON-friendly representation (paths as strings, address as hex)."""
+        return {
+            "project": self.project,
+            "opt_level": self.opt_level,
+            "binary": self.binary,
+            "binary_path": str(self.binary_path) if self.binary_path else None,
+            "function": self.function,
+            "address": self.address,
+            "address_hex": (f"0x{self.address:x}" if self.address is not None else None),
+            "base": self.base,
+            "target": self.target,
+            "metric": self.metric,
+            "base_value": self.base_value,
+            "base_perfect": self.base_perfect,
+            "target_value": self.target_value,
+            "target_missing": self.target_missing,
+            "margin": (None if math.isinf(self.margin) else self.margin),
+            "labels": list(self.labels),
+        }
+
+
+def metric_direction(metric: str, fd: FunctionData) -> tuple[bool, float]:
+    """Return ``(lower_is_better, perfect_value)`` for ``metric``.
+
+    Prefers the registered metric's own attributes; falls back to the perfect
+    value recorded in the dataset (treating a perfect value of 0 as
+    lower-is-better) so the function still works for metrics not importable here.
+    """
+    perfect = fd.perfect_values.get(metric)
+    try:
+        import decbench.metrics  # noqa: F401  (register built-in metrics)
+        from decbench.metrics.registry import MetricRegistry
+
+        m = MetricRegistry.get(metric)
+        return bool(m.lower_is_better), (perfect if perfect is not None else m.perfect_value)
+    except Exception:
+        if perfect is None:
+            perfect = 0.0
+        return (perfect == 0.0), perfect
+
+
+def _base_beats_target(
+    base_value: float,
+    target_value: float | None,
+    lower_is_better: bool,
+) -> tuple[bool, float]:
+    """Whether base wins and by how much (margin >= 0; inf if target missing)."""
+    if target_value is None:
+        return True, math.inf
+    if lower_is_better:
+        return base_value < target_value, target_value - base_value
+    return base_value > target_value, base_value - target_value
+
+
+def find_improvement_cases(
+    fd: FunctionData,
+    base: str,
+    target: str,
+    metric: str = "ged",
+    *,
+    perfect_only: bool = False,
+    include_target_missing: bool = False,
+    results_root: Path | None = None,
+) -> list[ImprovementCase]:
+    """Return functions where ``base`` beats ``target`` on ``metric``.
+
+    Args:
+        fd: The per-function dataset (``function_results.json``).
+        base: Decompiler id whose wins we look for.
+        target: Decompiler id being improved (the loser).
+        metric: Metric to compare on (default ``ged``).
+        perfect_only: Only include functions where ``base`` is a *perfect* match
+            on the metric (GED == 0, byte/type_match == 1).
+        include_target_missing: Also include functions ``base`` scored but for
+            which ``target`` has no usable score — either no value at all (a
+            decompile failure) or a non-finite error value (e.g. a GED of ``inf``
+            when the target decompiled the function but GED could not be
+            computed). Off by default so the result is strictly a metric win.
+        results_root: Root of the results tree. When given, each case is resolved
+            to its compiled-binary path and function address on disk.
+
+    Returns:
+        Cases sorted by margin (largest base advantage first; target-missing
+        first), then by project / binary / function for a stable order.
+    """
+    if base not in fd.decompilers:
+        raise ValueError(f"base decompiler {base!r} not in dataset {fd.decompilers}")
+    if target not in fd.decompilers:
+        raise ValueError(f"target decompiler {target!r} not in dataset {fd.decompilers}")
+    if base == target:
+        raise ValueError("base and target decompilers must differ")
+    if metric not in fd.metrics:
+        raise ValueError(f"metric {metric!r} not in dataset {fd.metrics}")
+
+    lower_is_better, perfect_value = metric_direction(metric, fd)
+    cases: list[ImprovementCase] = []
+
+    for group in fd.groups:
+        group_cases: list[ImprovementCase] = []
+        for rec in group.functions:
+            base_value = rec.values.get(base, {}).get(metric)
+            if base_value is None or not math.isfinite(base_value):
+                continue  # base must actually have a (finite) score to be winning
+            base_perfect = bool(rec.perfects.get(base, {}).get(metric, False))
+            if perfect_only and not base_perfect:
+                continue
+
+            target_value = rec.values.get(target, {}).get(metric)
+            # A non-finite target score (e.g. GED's ``inf`` error sentinel) is a
+            # tooling failure, not a place the target is genuinely worse — treat
+            # it exactly like a missing value so it is gated behind
+            # ``include_target_missing`` and never ranked as a real metric win.
+            if target_value is not None and not math.isfinite(target_value):
+                target_value = None
+            target_missing = target_value is None
+            if target_missing and not include_target_missing:
+                continue
+
+            won, margin = _base_beats_target(base_value, target_value, lower_is_better)
+            if not won:
+                continue
+
+            group_cases.append(
+                ImprovementCase(
+                    project=group.project,
+                    opt_level=group.opt_level,
+                    binary=group.binary,
+                    function=rec.function,
+                    base=base,
+                    target=target,
+                    metric=metric,
+                    base_value=base_value,
+                    target_value=target_value,
+                    base_perfect=base_perfect,
+                    margin=margin,
+                    target_missing=target_missing,
+                    labels=list(rec.labels),
+                )
+            )
+
+        if group_cases and results_root is not None:
+            _resolve_locations(group_cases, results_root, base, target, fd.decompilers)
+        cases.extend(group_cases)
+
+    # Largest base advantage first (target-missing → inf sorts first), then a
+    # stable secondary order so equal-margin rows are deterministic.
+    cases.sort(
+        key=lambda c: (
+            -c.margin if math.isfinite(c.margin) else float("-inf"),
+            c.project,
+            c.opt_level,
+            c.binary,
+            c.function,
+        )
+    )
+    return cases
+
+
+def _artifact_name(decompiler_id: str) -> str:
+    """The unversioned name a decompiler writes its artifacts under.
+
+    Decompiler ids may be ``name@version`` (e.g. ``ghidra@12.1``) but
+    ``DecompilationResult.to_c_file`` names the artifact by the bare ``name``
+    (``ghidra_<stem>.c``), so map ids back to that.
+    """
+    return decompiler_id.split("@", 1)[0]
+
+
+def _resolve_locations(
+    group_cases: list[ImprovementCase],
+    results_root: Path,
+    base: str,
+    target: str,
+    all_decompilers: list[str],
+) -> None:
+    """Fill in ``binary_path`` and ``address`` for one binary's cases in place."""
+    g = group_cases[0]
+    comp = results_tree.compiled_dir(results_root, g.opt_level, g.project)
+    binary_path = results_tree.resolve_binary(comp, g.binary)
+
+    # Addresses are decompiler-emitted (in the .c header). Any decompiler that
+    # decompiled the function has the same file-space address, so try the base
+    # first, then the target, then any other decompiler's artifact for this
+    # binary until every function is located.
+    addr_map: dict[str, int] = {}
+    tried: set[str] = set()
+    wanted = {c.function for c in group_cases}
+
+    def merge(decompiler_id: str) -> bool:
+        """Parse one decompiler's artifact; return True once all funcs are found."""
+        art = _artifact_name(decompiler_id)
+        if art not in tried:
+            tried.add(art)
+            c_path = results_tree.decompiled_c_path(
+                results_root, g.opt_level, g.project, art, g.binary
+            )
+            for name, addr in results_tree.function_addresses(c_path).items():
+                addr_map.setdefault(name, addr)
+        return wanted.issubset(addr_map)
+
+    done = merge(base) or merge(target)
+    if not done:
+        for dec in all_decompilers:
+            if merge(dec):
+                break
+
+    for c in group_cases:
+        c.binary_path = binary_path
+        c.address = addr_map.get(c.function)
+
+
+def _fmt_value(v: float | None) -> str:
+    if v is None:
+        return "(no score)"
+    if math.isinf(v):
+        return "inf"
+    return f"{v:g}"
+
+
+def render_text(
+    cases: list[ImprovementCase],
+    fd: FunctionData,
+    *,
+    base: str,
+    target: str,
+    metric: str,
+    total: int,
+    perfect_only: bool = False,
+) -> str:
+    """Render (a possibly-truncated) list of cases as an aligned text report.
+
+    ``cases`` is what to display (already limited); ``total`` is the full count
+    before any limit was applied.
+    """
+    lower_is_better, perfect_value = metric_direction(metric, fd)
+    direction = "lower is better" if lower_is_better else "higher is better"
+
+    lines: list[str] = []
+    flag = "  [base-perfect only]" if perfect_only else ""
+    lines.append(f"{base} beats {target} on '{metric}' — {total} case(s){flag}")
+    lines.append(f"metric: {metric}  ({direction}, perfect = {perfect_value:g})")
+    if not cases:
+        lines.append("(no functions matched)")
+        return "\n".join(lines)
+    if len(cases) < total:
+        lines.append(f"showing {len(cases)} of {total}, largest margin first")
+    else:
+        lines.append(f"showing all {total}, largest margin first")
+    lines.append("")
+
+    addr_w = max((len(f"0x{c.address:x}") for c in cases if c.address is not None), default=1)
+    addr_w = max(addr_w, 3)
+    func_w = min(max(len(c.function) for c in cases), 48)
+
+    # Group consecutive cases by (project, opt, binary) preserving margin order.
+    last_key: tuple[str, str, str] | None = None
+    for c in cases:
+        key = (c.project, c.opt_level, c.binary)
+        if key != last_key:
+            last_key = key
+            path = str(c.binary_path) if c.binary_path else "(binary not found)"
+            lines.append(f"── {c.project} / {c.opt_level} / {c.binary} ──  {path}")
+        addr = f"0x{c.address:x}" if c.address is not None else "?"
+        star = "*" if c.base_perfect else " "
+        margin = "—" if math.isinf(c.margin) else f"{c.margin:g}"
+        lines.append(
+            f"   {addr:<{addr_w}}  {c.function[:func_w]:<{func_w}}  "
+            f"{base}={_fmt_value(c.base_value)}{star}  "
+            f"{target}={_fmt_value(c.target_value)}  Δ{margin}"
+        )
+
+    binaries = {(c.project, c.opt_level, c.binary) for c in cases}
+    projects = {c.project for c in cases}
+    lines.append("")
+    lines.append(f"{len(cases)} shown across {len(binaries)} binaries, {len(projects)} projects")
+    return "\n".join(lines)

--- a/decbench/utils/results_tree.py
+++ b/decbench/utils/results_tree.py
@@ -1,0 +1,92 @@
+"""Navigate an on-disk benchmark results tree.
+
+A results tree produced by the pipeline (``decbench run`` /
+``scripts/run_benchmark.py``) is laid out as::
+
+    <root>/<opt>/<project>/
+        compiled/<binary>            # the ELF/PE binary (name may carry a suffix)
+        decompiled/<dec>_<stem>.c    # decompiled C, function blocks delimited by
+                                     #   "// Function: <name> @ 0x<addr>"
+        decompiled/<dec>_<stem>.toml # per-function metadata (address, line_count)
+        evaluated/<binary>.toml
+
+(see :mod:`decbench.pipeline.compile` and :mod:`decbench.pipeline.decompile` for
+where these paths are written). ``function_results.json`` identifies a function
+only by ``(project, opt, binary_stem, function)`` and stores **no address**, so
+this module centralises the mapping from that identity back to the concrete
+compiled-binary path and the decompiler-emitted function address recorded in the
+decompiled ``.c`` artifacts. Shared by ``scripts/reeval_bytematch.py`` and the
+``decbench improvements`` CLI command.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from decbench.utils import binfmt
+
+# The header comment DecompilationResult.to_c_file writes before each function
+# block: ``// Function: <name> @ 0x<addr>``.
+FUNCTION_MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
+
+# Optimization sub-directories a results tree can contain (top level, per-opt).
+OPT_LEVELS = ("O0", "O2", "O2-noinline")
+
+
+def compiled_dir(root: Path, opt: str, project: str) -> Path:
+    """Directory holding a project's compiled binaries for one opt level."""
+    return root / opt / project / "compiled"
+
+
+def decompiled_dir(root: Path, opt: str, project: str) -> Path:
+    """Directory holding a project's decompiled artifacts for one opt level."""
+    return root / opt / project / "decompiled"
+
+
+def decompiled_c_path(root: Path, opt: str, project: str, decompiler: str, stem: str) -> Path:
+    """Path to one decompiler's decompiled ``.c`` file for a binary stem.
+
+    The artifact is named by the decompiler's unversioned ``name`` (not its
+    ``name@version`` id), matching ``DecompilationResult.to_c_file``.
+    """
+    return decompiled_dir(root, opt, project) / f"{decompiler}_{stem}.c"
+
+
+def split_functions(c_path: Path) -> dict[str, tuple[int, str]]:
+    """``name -> (address, decompiled block)`` for one decompiled ``.c`` file."""
+    text = c_path.read_text(errors="replace")
+    out: dict[str, tuple[int, str]] = {}
+    matches = list(FUNCTION_MARKER.finditer(text))
+    for i, m in enumerate(matches):
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        out[m.group(1)] = (int(m.group(2), 16), text[start:end].strip())
+    return out
+
+
+def function_addresses(c_path: Path) -> dict[str, int]:
+    """``name -> address`` parsed from a decompiled ``.c`` header (``{}`` if absent)."""
+    if not c_path.is_file():
+        return {}
+    return {name: addr for name, (addr, _code) in split_functions(c_path).items()}
+
+
+def resolve_binary(comp: Path, stem: str) -> Path | None:
+    """Find the original binary for a decompiled stem inside ``comp`` (a compiled dir).
+
+    The decompiled artifact is named ``{dec}_{stem}.c`` where ``stem`` =
+    ``binary.stem``, but the on-disk binary keeps its full name — which may carry
+    an extension (``mydoom.exe``, ``psize.aux``) or a version suffix
+    (``libedit.so.0.0.70``). So fall back from an exact match to any sibling
+    whose stem matches and which is a real ELF/PE. (Must agree with
+    ``scripts/rebuild_function_data.DiskReader.binary``.)
+    """
+    exact = comp / stem
+    if exact.is_file() and binfmt.detect(exact):
+        return exact
+    if comp.is_dir():
+        for f in sorted(comp.iterdir()):
+            if f.is_file() and f.stem == stem and binfmt.detect(f):
+                return f
+    return None

--- a/scripts/rebuild_function_data.py
+++ b/scripts/rebuild_function_data.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from decbench.models.function_data import FunctionData, HardestEntry, SampleEntry
 from decbench.models.scoreboard import DecompilerScore, MetricScore, Scoreboard
 from decbench.scoring.datasets import assign_datasets
-from decbench.utils import binfmt
+from decbench.utils.results_tree import resolve_binary
 from decbench.utils.source_extract import function_source
 
 MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
@@ -59,17 +59,7 @@ class DiskReader:
         key = (opt, proj, stem)
         if key in self._bin_cache:
             return self._bin_cache[key]
-        comp = self.root / opt / proj / "compiled"
-        found: Path | None = None
-        if comp.is_dir():
-            exact = comp / stem
-            if exact.is_file() and binfmt.detect(exact):
-                found = exact
-            else:
-                for f in comp.iterdir():
-                    if f.is_file() and f.stem == stem and binfmt.detect(f):
-                        found = f
-                        break
+        found = resolve_binary(self.root / opt / proj / "compiled", stem)
         self._bin_cache[key] = found
         return found
 

--- a/scripts/reeval_bytematch.py
+++ b/scripts/reeval_bytematch.py
@@ -18,27 +18,12 @@ from __future__ import annotations
 import json
 import multiprocessing as mp
 import os
-import re
 import sys
 from pathlib import Path
 
-from decbench.utils import binfmt
+from decbench.utils.results_tree import OPT_LEVELS, resolve_binary, split_functions
 
-MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
 DECOMPILERS = ("angr", "phoenix", "ghidra", "ida", "binja", "kuna")
-OPT_LEVELS = ("O0", "O2", "O2-noinline")
-
-
-def split_functions(c_path: Path) -> dict[str, tuple[int, str]]:
-    """name -> (address, decompiled block) for one decompiled .c file."""
-    text = c_path.read_text(errors="replace")
-    out: dict[str, tuple[int, str]] = {}
-    matches = list(MARKER.finditer(text))
-    for i, m in enumerate(matches):
-        start = m.end()
-        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
-        out[m.group(1)] = (int(m.group(2), 16), text[start:end].strip())
-    return out
 
 
 def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
@@ -70,25 +55,6 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
         out[name] = {"value": float(mv.value), "compilable": bool(md.get("compilable", False))}
     key = f"{opt}::{project}::{stem}::{dec}"
     return key, out
-
-
-def resolve_binary(comp: Path, stem: str) -> Path | None:
-    """Find the original binary for a decompiled stem.
-
-    The decompiled artifact is named ``{dec}_{stem}.c`` where stem = binary.stem,
-    but the on-disk binary keeps its full name — which may carry an extension
-    (``mydoom.exe``, ``psize.aux``) or a version suffix (``libedit.so.0.0.70``).
-    So fall back from an exact match to any sibling whose stem matches and which
-    is a real ELF/PE. (Must agree with rebuild_function_data.DiskReader.binary,
-    else byte_match would be computed here but not merged — or vice versa.)
-    """
-    exact = comp / stem
-    if exact.is_file() and binfmt.detect(exact):
-        return exact
-    for f in comp.iterdir():
-        if f.is_file() and f.stem == stem and binfmt.detect(f):
-            return f
-    return None
 
 
 def build_tasks(

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -1,0 +1,274 @@
+"""Tests for the ``decbench improvements`` case finder.
+
+Covers metric-direction-aware "base beats target" selection, the perfect-only
+and target-missing options, ordering, validation, and the on-disk resolution of
+each case to its compiled-binary path + function address.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from decbench.models.function_data import BinaryGroup, FunctionData, FunctionRecord
+from decbench.scoring.improvements import find_improvement_cases, render_text
+
+PERFECT = {"ged": 0.0, "type_match": 1.0, "byte_match": 1.0}
+
+
+def _rec(function: str, **dec_values: dict[str, float]) -> FunctionRecord:
+    """Build a record; ``dec_values`` maps decompiler -> {metric: value}."""
+    values = {d: dict(mv) for d, mv in dec_values.items()}
+    perfects = {d: {m: (v == PERFECT[m]) for m, v in mv.items()} for d, mv in values.items()}
+    return FunctionRecord(function=function, values=values, perfects=perfects)
+
+
+def _fd(functions: list[FunctionRecord], *, project="proj", opt="O0", binary="bin") -> FunctionData:
+    group = BinaryGroup(project=project, opt_level=opt, binary=binary, functions=functions)
+    return FunctionData(
+        decompilers=["angr", "kuna"],
+        metrics=["ged", "type_match", "byte_match"],
+        perfect_values=dict(PERFECT),
+        groups=[group],
+    )
+
+
+def _fake_elf(path: Path) -> None:
+    """A minimal file binfmt.detect() recognizes as an ELF."""
+    path.write_bytes(b"\x7fELF" + b"\x00" * 16)
+
+
+# --------------------------------------------------------------------------- #
+# Core selection (GED — lower is better)
+# --------------------------------------------------------------------------- #
+
+
+def test_ged_selects_only_wins_sorted_by_margin() -> None:
+    fd = _fd(
+        [
+            _rec("win_big", angr={"ged": 0.0}, kuna={"ged": 10.0}),  # win, margin 10
+            _rec("win_small", angr={"ged": 3.0}, kuna={"ged": 5.0}),  # win, margin 2
+            _rec("tie", angr={"ged": 5.0}, kuna={"ged": 5.0}),  # tie -> excluded
+            _rec("base_loses", angr={"ged": 8.0}, kuna={"ged": 2.0}),  # loss -> excluded
+        ]
+    )
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged")
+    assert [c.function for c in cases] == ["win_big", "win_small"]
+    assert cases[0].base_value == 0.0 and cases[0].target_value == 10.0
+    assert cases[0].margin == 10.0 and cases[0].base_perfect is True
+    assert cases[1].margin == 2.0 and cases[1].base_perfect is False
+
+
+def test_perfect_only_filters_to_base_perfect() -> None:
+    fd = _fd(
+        [
+            _rec("perfect", angr={"ged": 0.0}, kuna={"ged": 10.0}),
+            _rec("nonperfect", angr={"ged": 3.0}, kuna={"ged": 5.0}),
+        ]
+    )
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged", perfect_only=True)
+    assert [c.function for c in cases] == ["perfect"]
+
+
+def test_target_missing_excluded_by_default_included_on_flag() -> None:
+    fd = _fd(
+        [
+            _rec("both", angr={"ged": 0.0}, kuna={"ged": 4.0}),
+            _rec("only_angr", angr={"ged": 1.0}),  # kuna produced nothing
+        ]
+    )
+    assert [c.function for c in find_improvement_cases(fd, "angr", "kuna", "ged")] == ["both"]
+
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged", include_target_missing=True)
+    # target-missing sorts first (infinite margin) then real wins.
+    assert [c.function for c in cases] == ["only_angr", "both"]
+    miss = cases[0]
+    assert miss.target_missing is True
+    assert miss.target_value is None
+    assert math.isinf(miss.margin)
+
+
+def test_base_without_value_is_never_a_win() -> None:
+    # base has no ged value; even though kuna is worse it cannot "win".
+    fd = _fd([_rec("no_base", kuna={"ged": 9.0})])
+    assert find_improvement_cases(fd, "angr", "kuna", "ged") == []
+
+
+def test_nonfinite_target_treated_as_missing() -> None:
+    # A target GED of inf (metric errored though it decompiled) is NOT a genuine
+    # win: it must be gated behind include_target_missing, not ranked #1.
+    fd = _fd(
+        [
+            _rec("real_win", angr={"ged": 0.0}, kuna={"ged": 5.0}),
+            _rec("errored", angr={"ged": 0.0}, kuna={"ged": float("inf")}),
+        ]
+    )
+    # Default: the inf-target function is excluded, only the real win shows.
+    assert [c.function for c in find_improvement_cases(fd, "angr", "kuna", "ged")] == ["real_win"]
+
+    # With the flag it appears, but normalized to the "no usable score" bucket.
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged", include_target_missing=True)
+    errored = next(c for c in cases if c.function == "errored")
+    assert errored.target_missing is True
+    assert errored.target_value is None  # not inf
+    # ...and its JSON is valid (no `Infinity` token).
+    import json
+
+    dumped = json.dumps(errored.to_dict())
+    assert "Infinity" not in dumped
+    assert json.loads(dumped)["margin"] is None
+
+
+def test_nonfinite_target_with_perfect_only() -> None:
+    # perfect_only + a non-finite target must still not sneak the inf case in.
+    fd = _fd([_rec("errored", angr={"ged": 0.0}, kuna={"ged": float("inf")})])
+    assert find_improvement_cases(fd, "angr", "kuna", "ged", perfect_only=True) == []
+
+
+# --------------------------------------------------------------------------- #
+# Direction handling (type_match — higher is better)
+# --------------------------------------------------------------------------- #
+
+
+def test_higher_is_better_metric_direction() -> None:
+    fd = _fd(
+        [
+            _rec("win", angr={"type_match": 1.0}, kuna={"type_match": 0.5}),  # win 0.5
+            _rec("loss", angr={"type_match": 0.5}, kuna={"type_match": 0.8}),  # excluded
+            _rec("win2", angr={"type_match": 0.8}, kuna={"type_match": 0.5}),  # win 0.3
+        ]
+    )
+    cases = find_improvement_cases(fd, "angr", "kuna", "type_match")
+    assert [c.function for c in cases] == ["win", "win2"]
+    assert cases[0].margin == pytest.approx(0.5)
+    assert cases[0].base_perfect is True
+
+    perfect = find_improvement_cases(fd, "angr", "kuna", "type_match", perfect_only=True)
+    assert [c.function for c in perfect] == ["win"]
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "base,target,metric",
+    [
+        ("nope", "kuna", "ged"),
+        ("angr", "nope", "ged"),
+        ("angr", "kuna", "nope"),
+        ("angr", "angr", "ged"),  # base must differ from target
+    ],
+)
+def test_invalid_inputs_raise(base: str, target: str, metric: str) -> None:
+    fd = _fd([_rec("f", angr={"ged": 0.0}, kuna={"ged": 1.0})])
+    with pytest.raises(ValueError):
+        find_improvement_cases(fd, base, target, metric)
+
+
+# --------------------------------------------------------------------------- #
+# On-disk resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_resolves_binary_path_and_address(tmp_path: Path) -> None:
+    root = tmp_path
+    comp = root / "O0" / "proj" / "compiled"
+    dec = root / "O0" / "proj" / "decompiled"
+    comp.mkdir(parents=True)
+    dec.mkdir(parents=True)
+    _fake_elf(comp / "bin")
+    (dec / "angr_bin.c").write_text(
+        "// Function: foo @ 0x1234\nint foo(){return 0;}\n"
+        "// Function: bar @ 0x5678\nint bar(){return 1;}\n"
+    )
+
+    fd = _fd(
+        [
+            _rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0}),
+            _rec("bar", angr={"ged": 0.0}, kuna={"ged": 3.0}),
+        ]
+    )
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged", results_root=root)
+    by_name = {c.function: c for c in cases}
+    assert by_name["foo"].binary_path == comp / "bin"
+    assert by_name["foo"].address == 0x1234
+    assert by_name["bar"].address == 0x5678
+
+
+def test_versioned_binary_stem_resolution(tmp_path: Path) -> None:
+    # group binary stem is "libz.so.1.2" but the real file is "libz.so.1.2.13".
+    root = tmp_path
+    comp = root / "O0" / "proj" / "compiled"
+    dec = root / "O0" / "proj" / "decompiled"
+    comp.mkdir(parents=True)
+    dec.mkdir(parents=True)
+    _fake_elf(comp / "libz.so.1.2.13")
+    (dec / "angr_libz.so.1.2.c").write_text("// Function: zfoo @ 0xabc\nvoid zfoo(){}\n")
+
+    fd = _fd([_rec("zfoo", angr={"ged": 0.0}, kuna={"ged": 2.0})], binary="libz.so.1.2")
+    (case,) = find_improvement_cases(fd, "angr", "kuna", "ged", results_root=root)
+    assert case.binary_path == comp / "libz.so.1.2.13"
+    assert case.address == 0xABC
+
+
+def test_versioned_decompiler_artifact_name(tmp_path: Path) -> None:
+    # A versioned id (ghidra@12.0) must resolve addresses from the unversioned
+    # artifact filename (ghidra_bin.c), which is how to_c_file names them.
+    root = tmp_path
+    comp = root / "O0" / "proj" / "compiled"
+    dec = root / "O0" / "proj" / "decompiled"
+    comp.mkdir(parents=True)
+    dec.mkdir(parents=True)
+    _fake_elf(comp / "bin")
+    (dec / "ghidra_bin.c").write_text("// Function: foo @ 0x111\nvoid foo(){}\n")
+
+    rec = FunctionRecord(
+        function="foo",
+        values={"ghidra@12.0": {"ged": 0.0}, "angr": {"ged": 5.0}},
+        perfects={"ghidra@12.0": {"ged": True}, "angr": {"ged": False}},
+    )
+    fd = FunctionData(
+        decompilers=["angr", "ghidra@12.0"],
+        metrics=["ged"],
+        perfect_values={"ged": 0.0},
+        groups=[BinaryGroup(project="proj", opt_level="O0", binary="bin", functions=[rec])],
+    )
+    (case,) = find_improvement_cases(fd, "ghidra@12.0", "angr", "ged", results_root=root)
+    assert case.binary_path == comp / "bin"
+    assert case.address == 0x111
+
+
+def test_missing_tree_degrades_gracefully(tmp_path: Path) -> None:
+    # results_root exists but has no compiled/decompiled artifacts.
+    fd = _fd([_rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0})])
+    (case,) = find_improvement_cases(fd, "angr", "kuna", "ged", results_root=tmp_path)
+    assert case.binary_path is None
+    assert case.address is None
+
+
+def test_no_results_root_leaves_locations_unset() -> None:
+    fd = _fd([_rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0})])
+    (case,) = find_improvement_cases(fd, "angr", "kuna", "ged")
+    assert case.binary_path is None and case.address is None
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def test_render_text_and_to_dict() -> None:
+    fd = _fd([_rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0})])
+    cases = find_improvement_cases(fd, "angr", "kuna", "ged")
+    text = render_text(cases, fd, base="angr", target="kuna", metric="ged", total=len(cases))
+    assert "angr beats kuna on 'ged'" in text
+    assert "lower is better" in text
+    assert "foo" in text and "proj" in text
+
+    d = cases[0].to_dict()
+    assert d["function"] == "foo" and d["margin"] == 7.0
+    assert d["base_perfect"] is True and d["target_value"] == 7.0


### PR DESCRIPTION
New CLI command that mines a results tree's function_results.json for the per-function cases where a BASE decompiler beats a TARGET on a metric — a targeted to-do list for improving the target decompiler. Each case is resolved to its binary, on-disk path, and function symbol + address.

- decbench/scoring/improvements.py: find_improvement_cases respects each metric's direction (GED lower-is-better/perfect 0; type_match & byte_match higher-is-better/perfect 1); --perfect-only, --include-target-missing, margin-sorted; text + JSON rendering. Non-finite target scores (e.g. GED's inf error sentinel) are treated as "no usable score" so they're gated behind --include-target-missing rather than ranked as maximal wins.
- decbench/utils/results_tree.py: shared results-tree navigation (compiled-binary path + "// Function: … @ 0x…" address resolution), extracted from scripts/reeval_bytematch.py; scripts/rebuild_function_data.py now shares the same resolve_binary so the "must agree" invariant holds by construction.
- decbench/cli.py: the `improvements` command (-b/--base-decompiler, -t/--target-decompiler, -m/--metric, --perfect-only, --include-target-missing, --limit, -f/--format).
- tests/test_improvements.py: 17 tests (selection/direction/validation, on-disk resolution incl. versioned ids and non-finite targets, rendering).
- README.md / CLAUDE.md: usage docs with a GED example.

Verified against results/full_run: angr beats kuna on GED in 13,125 functions (1,728 where angr is a perfect GED match).


Claude-Session: https://claude.ai/code/session_01Qek4KwqhrJj76rBhubVHFD