### PR TITLE
kuna backend: process-group kill on timeout (no more orphaned kuna children)

### DIFF
--- a/decbench/decompilers/raw/kuna_raw.py
+++ b/decbench/decompilers/raw/kuna_raw.py
@@ -39,6 +39,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -234,6 +235,37 @@ class RawKunaDecompiler(Decompiler):
             cmd += ["--option", str(key), str(value)]
         return cmd
 
+    @staticmethod
+    def _kill_group(p: subprocess.Popen) -> None:
+        """SIGKILL kuna's whole process group (pgid == pid via start_new_session).
+
+        Mirrors ``scripts/run_benchmark._kill_process_group``: a plain
+        ``p.kill()`` (what ``subprocess.run(timeout=)`` does) kills only the
+        direct child, letting a hung kuna ORPHAN and spin at 100% CPU forever.
+        """
+        try:
+            os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                p.kill()
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            p.wait(timeout=15)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _timeout_seconds(self) -> float | None:
+        """Per-binary timeout: ``$DECBENCH_KUNA_TIMEOUT`` (seconds) if set,
+        else ``config.binary_timeout_seconds``."""
+        env = os.environ.get("DECBENCH_KUNA_TIMEOUT")
+        if env:
+            try:
+                return int(env)
+            except ValueError:
+                _l.warning("ignoring non-integer DECBENCH_KUNA_TIMEOUT=%r", env)
+        return self.config.binary_timeout_seconds
+
     def _run_decompile_all(self, binary_path: Path) -> Any:
         """Run ``kuna decompile-all --json`` and parse the JSON document.
 
@@ -245,16 +277,28 @@ class RawKunaDecompiler(Decompiler):
             return self._payload_cache[key]
         cmd = self._build_command(binary_path)
         _l.debug("kuna run: %s", " ".join(cmd))
-        p = subprocess.run(
+        # start_new_session=True makes kuna lead its own process group so a
+        # timeout (or any other failure) can SIGKILL the WHOLE tree. It also
+        # means an outer harness killpg can no longer reach it — this backend
+        # must own the kill on every exit path.
+        p = subprocess.Popen(
             cmd,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=self.config.binary_timeout_seconds,
+            start_new_session=True,
         )
-        if p.returncode != 0 and not (p.stdout or "").strip():
-            tail = (p.stderr or "")[-500:]
+        try:
+            stdout, stderr = p.communicate(timeout=self._timeout_seconds())
+        finally:
+            # TimeoutExpired or ANY other exception: reap the group, then let
+            # the exception propagate unchanged so callers behave identically.
+            if p.poll() is None:
+                self._kill_group(p)
+        if p.returncode != 0 and not (stdout or "").strip():
+            tail = (stderr or "")[-500:]
             raise RuntimeError(f"kuna exited {p.returncode}: {tail}")
-        payload = json.loads(p.stdout)
+        payload = json.loads(stdout)
         self._payload_cache[key] = payload
         return payload
 


### PR DESCRIPTION
## The bug

`RawKunaDecompiler._run_decompile_all` invoked the kuna CLI with `subprocess.run(cmd, timeout=config.binary_timeout_seconds)`. On `TimeoutExpired`, `subprocess.run` kills **only the direct child** — nothing reaps the rest of the process tree. During the overnight `full_run` this left **9 orphaned kuna processes burning 100% CPU for 4+ hours each** after their harness slots had long timed out.

It also explains **mirai-win's missing benchmark output**: kuna itself completes fine on that binary (measured directly) — the empty result was this harness bug eating the run, not a kuna failure.

## The fix

Mirror the repo's own correct pattern, `scripts/run_benchmark.py::_kill_process_group`:

- Spawn kuna with `subprocess.Popen(..., start_new_session=True)` so it leads its own process group (pgid == pid), then `communicate(timeout=...)`.
- On `TimeoutExpired` — or **any** exception path (`finally` + liveness check) — `os.killpg(os.getpgid(pid), SIGKILL)` with the same `ProcessLookupError`/`PermissionError`/`OSError` → `p.kill()` fallbacks, then `p.wait(timeout=15)`, and re-raise unchanged so existing callers (`decompile_binary`'s `except subprocess.TimeoutExpired`) behave identically.
- The backend must own the kill: with `start_new_session=True` an outer harness `killpg` can no longer reach the child group.

## Timeout override

The timeout stays `config.binary_timeout_seconds` by default, now overridable via `DECBENCH_KUNA_TIMEOUT` (integer seconds). `run_benchmark.py` already applies its own external per-decompiler budget during benchmark runs, and once kuna's internal per-function watchdog lands, whole-binary runs on big binaries legitimately need more than the default.

## Testing

- `python -m py_compile` (decbench venv) — clean.
- Functional smoke test: fake `kuna` that forks a grandchild and hangs → `TimeoutExpired` re-raised at exactly the (env-overridden) deadline **and the grandchild is reaped** (previously it would orphan); success path still parses JSON; nonzero-exit path still raises the same `RuntimeError`.
- `tests/test_decompilers.py`: 5 passed, 1 pre-existing environmental failure (`test_decompile_tiny_binary[ghidra]`) that fails identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J