### PR TITLE
ged: exclude degenerate (<=1 node) source CFGs instead of rewarding truncated output

### DIFF
--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -20,6 +20,16 @@ if TYPE_CHECKING:
 # distance so the run stays bounded. Tunable via DECBENCH_GED_MAX_NODES.
 GED_MAX_NODES = int(os.environ.get("DECBENCH_GED_MAX_NODES") or "60")
 
+# A source CFG with this many nodes or fewer is NOT a usable structural graph.
+# In practice source_nodes == 1 means Joern only saw a prototype/declaration of
+# the function (or the wrong translation unit was matched), not its real body.
+# Scoring against such a graph inverts the metric: GED then rewards whichever
+# decompiler emitted the FEWEST nodes — a truncated one-block stub scores a
+# perfect 0 while a complete, correct decompilation is "penalized" by its real
+# size. Treat these like a missing source CFG (excluded from scoring) instead.
+# Tunable via DECBENCH_GED_MIN_SOURCE_NODES.
+GED_MIN_SOURCE_NODES = int(os.environ.get("DECBENCH_GED_MIN_SOURCE_NODES") or "1")
+
 
 @register_metric("ged")
 class GEDMetric(Metric):
@@ -70,6 +80,27 @@ class GEDMetric(Metric):
                 metadata={"error": "Missing CFG"},
             )
 
+        # Degenerate source CFG (see GED_MIN_SOURCE_NODES above): there is no
+        # source structure to compare against, so exclude the function (same
+        # treatment as a missing CFG) rather than hand a perfect 0 to whichever
+        # decompiler emitted the least output. Checked BEFORE the cache so
+        # entries recorded under the old (rewarding) semantics are never served.
+        # NOTE: this covers the degenerate-SOURCE half only. A truncated
+        # decompilation (e.g. angr's CFGFast mis-splitting a function at a
+        # function_prologs byte pattern and emitting a prologue-only stub) can
+        # still score well against a genuinely tiny source function; detecting
+        # that needs decompiler-side signals and is left as future work.
+        s_nodes = source_cfg.number_of_nodes()
+        if s_nodes <= GED_MIN_SOURCE_NODES:
+            return MetricValue(
+                value=float("inf"),
+                metadata={
+                    "error": f"degenerate source CFG (source_nodes={s_nodes})",
+                    "source_nodes": s_nodes,
+                    "decompiled_nodes": decompiled_cfg.number_of_nodes(),
+                },
+            )
+
         # GED is a pure function of the two CFG structures (node/edge sets) and
         # the oversize threshold. Key on their canonical, sorted shapes so the
         # super-polynomial computation is never repeated for identical graphs.
@@ -105,8 +136,10 @@ class GEDMetric(Metric):
 
         # Cheap structural fallback for oversized graphs: exact GED is too slow
         # and these are rarely a perfect match anyway. The size delta is a sound
-        # lower bound on the true edit distance, so a 0 here is still a genuine
-        # structural match.
+        # LOWER BOUND on the true edit distance — but a 0 here only means the
+        # two graphs have the same node and edge counts (necessary, not
+        # sufficient, for a true structural match). Consumers can tell the
+        # approximation apart via the "approximated" metadata flag.
         if s_nodes > GED_MAX_NODES or d_nodes > GED_MAX_NODES:
             approx = float(
                 abs(s_nodes - d_nodes)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -85,6 +85,51 @@ class TestGEDMetric:
         result = metric.compute_for_function(func, source_cfg=None, decompiled_cfg=None)
         assert result.value == float("inf")
 
+    def test_ged_degenerate_source_cfg(self) -> None:
+        """A <=1-node source CFG (prototype-only / wrong TU) is not scorable.
+
+        It must be EXCLUDED (inf, like a missing CFG) — never a finite score.
+        Before this guard, a truncated one-block decompilation scored a perfect
+        0 against a 1-node source graph while complete decompilations were
+        penalized by their real size.
+        """
+        import networkx as nx
+
+        from decbench.metrics.ged import GEDMetric
+
+        # What Joern produces when it only sees a declaration: one lone node.
+        source = nx.DiGraph()
+        source.add_node("decl_only")
+
+        # A truncated (prologue-only) decompilation stub: also one node. Under
+        # exact GED these "match" for 0 — the exact artifact being excluded.
+        stub = nx.DiGraph()
+        stub.add_node("stub_block")
+
+        func = FunctionDecompilation(
+            name="test",
+            address=0x1000,
+            decompiled_code="void test(void) { /* truncated */ }",
+        )
+
+        metric = GEDMetric()
+        result = metric.compute_for_function(func, source_cfg=source, decompiled_cfg=stub)
+        assert result.value == float("inf")
+        assert "degenerate source CFG" in result.metadata["error"]
+        assert result.metadata["source_nodes"] == 1
+
+        # A degenerate source must exclude the function no matter how big the
+        # decompiled CFG is (previously: bigger output = worse score).
+        big = nx.DiGraph()
+        big.add_edges_from((i, i + 1) for i in range(10))
+        result_big = metric.compute_for_function(func, source_cfg=source, decompiled_cfg=big)
+        assert result_big.value == float("inf")
+
+        # An empty source graph is degenerate too.
+        empty = nx.DiGraph()
+        result_empty = metric.compute_for_function(func, source_cfg=empty, decompiled_cfg=stub)
+        assert result_empty.value == float("inf")
+
     def test_ged_identical_cfgs(self) -> None:
         """GED of identical graphs should be 0."""
         pytest.importorskip("cfgutils")


### PR DESCRIPTION
## Problem

The kuna campaign triaged 28 angr-GED-0 / kuna-GED-nonzero cases and found that a large share were **decbench scoring artifacts, not decompiler deficits** — angr scored a perfect 0 it didn't earn. Two mechanisms:

**1. A degenerate source CFG rewards ANY output.** The GED source CFG is Joern-parsed from the O0 `.i`. When the per-project source pool matches the wrong translation unit, or only finds a prototype/declaration for the function, the source CFG collapses to **1 node**. GED then rewards whichever decompiler emitted the *fewest* nodes: a truncated stub "matches" the 1-node graph for a perfect 0, while a complete, correct decompilation is penalized by its real size. Confirmed by rescoring campaign cases: e.g. `ce_inc_search` (libedit, 294-margin) and `chown_files` (coreutils, 491-margin) both recompute with `source_nodes: 1`.

The TU-matching root cause is visible in `scripts/reeval_ged.py`: all of a project's `.i` parses are pooled into one dict with `imap_unordered` + `dict.update` — **last parse wins** on function-name collisions, so a TU that only *declares* a function can nondeterministically overwrite the defining TU's real CFG with a 1-node prototype CFG.

**2. Truncated decompilations score 0.** angr sometimes emits a prologue-only stub (CFGFast mis-splits a function at an archinfo `function_prologs` byte pattern — e.g. `write_fatal_details` in tar starts with a stack-clash probe and angr splits at entry+6). The stub's tiny CFG matches a small source CFG while full decompilers are penalized. This half is decompiler-side and harder to detect; it is documented as future work in a code comment (the degenerate-source guard already removes the worst instances, which co-occur with mechanism 1).

## Fix

`GEDMetric.compute_for_function` now treats a source CFG with `source_nodes <= 1` exactly like a missing CFG: it returns `inf` with metadata `{"error": "degenerate source CFG (source_nodes=N)"}`, so the function is **excluded** from scoring instead of handing a perfect 0 to whichever decompiler emitted the least output.

- The check runs **before** the metric cache, so entries recorded under the old (rewarding) semantics are never served.
- Threshold is a config knob: `DECBENCH_GED_MIN_SOURCE_NODES` (default `1`), mirroring `DECBENCH_GED_MAX_NODES`.
- Also corrects the oversized-graph approximation comment: a size-delta of 0 is a lower bound (equal node/edge counts), *necessary but not sufficient* for a true structural match — consumers can detect it via the `"approximated"` metadata flag.

## Test

New `test_ged_degenerate_source_cfg` in `tests/test_metrics.py`: a 1-node source CFG vs a 1-node stub (previously a perfect 0) now yields `inf` + the degenerate-source error; same for a big decompiled CFG (previously penalized) and an empty source graph. Runs without cfgutils/Joern.

```
tests/test_metrics.py -k ged: 4 passed
tests/test_metrics.py + test_improvements.py: 50 passed
metric-adjacent files (test_metrics, test_e2e_pipeline, test_models,
  test_report_extras, test_source_extract, test_byte_match_fixup): 86 passed
```

No pre-existing failures in those files on this branch's base. (Test runs rebuild `tests/example_project/` artifacts in-place; those side effects were restored, not committed.)

## Impact estimate (bounded, no re-run)

From `results/full_run/function_results.json` there are **1728** angr-GED-0 / kuna-GED>0 function-cases. Classifying each function against its project's pooled O0 `.i` TU set (header-stripped, same pooling as `reeval_ged.py`):

- **176 / 1728 (10%)** have **no definition in any TU** — their source CFG can only be a prototype (1 node) or absent: guaranteed to flip from "angr perfect 0" to **excluded**. (Example cluster: all of `bash/mkbuiltins`, whose sources aren't in the pooled `.i` set at all.)
- **700 / 1728 (41%)** are **collision-possible**: defined in exactly one TU but the name appears at call/decl position in other TUs, so last-parse-wins pooling *may* have scored them against a 1-node prototype CFG in the recorded run. A subset of these flip.
- 852 / 1728 look clean by this text-level proxy.

Of the 28 triaged campaign cases: 1 `no_def` + 15 `multi_tu` = **16/28 at risk**, consistent with the campaign's ≥10 confirmed artifacts (`ce_inc_search`, `xheader_set_option`, `beyond`, `abort_gzip`, `xalloc_die`, `write_fatal_details`, …).

## `filesavespackage` drift note (fyi)

dpkg's `filesavespackage` recorded GED 99 but recomputes to ~25 on byte-identical decompiled output. The metric cache cannot cause this (keys include the full graph shapes). The likely cause is the same pooling nondeterminism: `filesavespackage(` appears in **three** dpkg TUs (`archives.i`, `cleanup.i`, `unpack.i`), and `reeval_ged.py`'s `imap_unordered` + last-write-wins pooling picks a different TU's CFG entry run-to-run, changing the source CFG (and hence the GED) across runs. Future work: prefer definition CFGs (>1 node) over declaration CFGs when pooling per-project source CFGs — that's a `reeval_ged.py`/builder-side change, orthogonal to this metric guard (which already excludes the 1-node losers of that race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DV2MXxQAAWK7xLPBmsq9J
