### PR TITLE
Fix misleadingly-low metric scores: GED source-CFG collision, denomin…

### DIFF
--- a/decbench/decompilers/raw/binja_raw.py
+++ b/decbench/decompilers/raw/binja_raw.py
@@ -76,15 +76,27 @@ class RawBinjaDecompiler(Decompiler):
             return "unknown"
 
     def _load(self, binary_path: Path) -> Any:
-        """Open + analyze a binary, returning a BinaryView."""
+        """Open + analyze a binary, returning a BinaryView.
+
+        CRITICAL: always ``update_analysis_and_wait()`` before rendering. Even
+        though ``binaryninja.load()`` kicks off analysis, it can return before
+        per-function HLIL / the linear language-representation view is ready, so
+        the Pseudo-C render emits the literal ``Loading...`` placeholder instead
+        of code (previously ~73% of binja function bodies on large binaries —
+        the dominant cause of binja's near-zero GED/byte scores). Waiting here
+        forces analysis to completion first.
+        """
         import binaryninja
 
         # ``load`` runs analysis and is the modern entry point; fall back to the
         # older BinaryViewType API if ``load`` is unavailable.
         if hasattr(binaryninja, "load"):
-            return binaryninja.load(str(binary_path))
-        bv = binaryninja.BinaryViewType.get_view_of_file(str(binary_path))
-        bv.update_analysis_and_wait()
+            bv = binaryninja.load(str(binary_path))
+        else:
+            bv = binaryninja.BinaryViewType.get_view_of_file(str(binary_path))
+        if bv is not None:
+            with contextlib.suppress(Exception):
+                bv.update_analysis_and_wait()
         return bv
 
     def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
@@ -284,19 +296,30 @@ class RawBinjaDecompiler(Decompiler):
         try:
             import binaryninja as bn
 
-            settings = bn.DisassemblySettings()
-            lvo = bn.LinearViewObject.single_function_language_representation(func, settings)
-            cursor = bn.LinearViewCursor(lvo)
-            cursor.seek_to_begin()
-            lines: list[str] = []
-            # Bound the walk so a pathological function can't spin forever.
-            for _ in range(100000):
-                for ln in cursor.lines:
-                    lines.append(str(ln))
-                if not cursor.next():
-                    break
-            text = "\n".join(lines).strip("\n")
-            if text.strip():
+            def _walk() -> str:
+                settings = bn.DisassemblySettings()
+                lvo = bn.LinearViewObject.single_function_language_representation(func, settings)
+                cursor = bn.LinearViewCursor(lvo)
+                cursor.seek_to_begin()
+                lines: list[str] = []
+                # Bound the walk so a pathological function can't spin forever.
+                for _ in range(100000):
+                    for ln in cursor.lines:
+                        lines.append(str(ln))
+                    if not cursor.next():
+                        break
+                return "\n".join(lines).strip("\n")
+
+            text = _walk()
+            # If analysis wasn't ready the body is the literal 'Loading...'
+            # placeholder (not C). Force this function's analysis and re-render
+            # once; a still-placeholder body is treated as a FAILURE (return "")
+            # rather than emitting junk that pollutes GED/byte_match.
+            if not text.strip() or "Loading..." in text:
+                with contextlib.suppress(Exception):
+                    func.view.update_analysis_and_wait()
+                text = _walk()
+            if text.strip() and "Loading..." not in text:
                 return text
         except Exception:  # noqa: BLE001
             pass

--- a/decbench/decompilers/raw/binja_raw.py
+++ b/decbench/decompilers/raw/binja_raw.py
@@ -310,11 +310,22 @@ class RawBinjaDecompiler(Decompiler):
                         break
                 return "\n".join(lines).strip("\n")
 
+            # Force HLIL (and thus pseudo-C) generation for THIS function before
+            # rendering. Even after full binary analysis, binja 3.1's linear-view
+            # language representation returns the literal 'Loading...' placeholder
+            # until the function's HLIL is generated (it's lazy per-function).
+            # Touching func.hlil forces that computation so the render yields real
+            # C — without this, ~all functions in large binaries (e.g. bash: 2486
+            # of 2499) render as Loading and get dropped.
+            with contextlib.suppress(Exception):
+                _ = func.hlil
+                _ = len(list(func.hlil.instructions))
+
             text = _walk()
-            # If analysis wasn't ready the body is the literal 'Loading...'
-            # placeholder (not C). Force this function's analysis and re-render
-            # once; a still-placeholder body is treated as a FAILURE (return "")
-            # rather than emitting junk that pollutes GED/byte_match.
+            # If the body is STILL the 'Loading...' placeholder (not C), force
+            # this function's analysis and re-render once; a still-placeholder
+            # body is treated as a FAILURE (return "") rather than emitting junk
+            # that pollutes GED/byte_match.
             if not text.strip() or "Loading..." in text:
                 with contextlib.suppress(Exception):
                     func.view.update_analysis_and_wait()

--- a/decbench/metrics/base.py
+++ b/decbench/metrics/base.py
@@ -105,6 +105,7 @@ class Metric(ABC):
         **kwargs: Any,
     ) -> MetricResult:
         """Compute this metric for all functions in a binary."""
+        import math
         import time
 
         start_time = time.time()
@@ -130,6 +131,12 @@ class Metric(ABC):
                     decompiled_cfg=decompiled_cfg,
                     **kwargs,
                 )
+                # A non-finite value means "unmeasurable for everyone" (e.g. GED
+                # with an empty-prototype/degenerate source CFG). ABSTAIN — don't
+                # record it — so it's excluded from this metric's denominator
+                # uniformly for all decompilers, rather than counted as a failure.
+                if not math.isfinite(value.value):
+                    continue
                 function_results[func_name] = value
 
             except Exception as e:

--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -153,16 +153,18 @@ def _disassemble_bytes(data: bytes, address: int = 0, arch_mode: tuple | None = 
         return []
 
 
-def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> float:
-    """Compute Jaccard similarity between two lists of assembly lines.
+def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> tuple[float, int]:
+    """Jaccard similarity AND absolute changed-line count between two asm listings.
 
-    Uses line-level diff (diff_match_patch style) to compute:
-    shared / (a_only + shared + b_only)
+    Returns ``(similarity, changed_lines)`` where similarity = ``shared / (a_only +
+    shared + b_only)`` and ``changed_lines = a_only + b_only`` (the raw edit
+    distance surfaced on the report's 'distance' view — number of assembly lines
+    that differ). Uses a line-level diff (diff_match_patch style).
     """
     if not lines_a and not lines_b:
-        return 1.0
+        return 1.0, 0
     if not lines_a or not lines_b:
-        return 0.0
+        return 0.0, len(lines_a) + len(lines_b)
 
     try:
         from diff_match_patch import diff_match_patch
@@ -194,8 +196,8 @@ def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> float
 
         total = a_only + shared + b_only
         if total == 0:
-            return 1.0
-        return shared / total
+            return 1.0, 0
+        return shared / total, a_only + b_only
 
     except ImportError:
         # Fall back to simple set-based Jaccard
@@ -204,8 +206,8 @@ def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> float
         intersection = set_a & set_b
         union = set_a | set_b
         if not union:
-            return 1.0
-        return len(intersection) / len(union)
+            return 1.0, 0
+        return len(intersection) / len(union), len(set_a ^ set_b)
 
 
 def _compile_function(
@@ -389,6 +391,7 @@ class ByteMatchMetric(Metric):
                     metadata={
                         **fixup_meta,
                         "exact_match": True,
+                        "changed_lines": 0,
                         "original_size": len(original_bytes),
                         "recompiled_size": len(recompiled_bytes),
                     },
@@ -399,7 +402,9 @@ class ByteMatchMetric(Metric):
             recompiled_asm = _disassemble_bytes(recompiled_bytes, 0, arch_mode)
 
             if original_asm and recompiled_asm:
-                similarity = _compute_jaccard_similarity(original_asm, recompiled_asm)
+                similarity, changed_lines = _compute_jaccard_similarity(
+                    original_asm, recompiled_asm
+                )
             else:
                 # Fallback: raw byte comparison ratio
                 min_len = min(len(original_bytes), len(recompiled_bytes))
@@ -411,6 +416,7 @@ class ByteMatchMetric(Metric):
                         1 for i in range(min_len) if original_bytes[i] == recompiled_bytes[i]
                     )
                     similarity = matching / max_len
+                changed_lines = abs(len(original_bytes) - len(recompiled_bytes))
 
             # A perfect match requires similarity == 1.0
             return MetricValue(
@@ -420,6 +426,9 @@ class ByteMatchMetric(Metric):
                     **fixup_meta,
                     "exact_match": False,
                     "jaccard_similarity": similarity,
+                    # Absolute edit distance (# changed asm lines) for the report's
+                    # 'distance' view; does not affect the (unchanged) jaccard score.
+                    "changed_lines": changed_lines,
                     "original_size": len(original_bytes),
                     "recompiled_size": len(recompiled_bytes),
                     "original_asm_lines": len(original_asm),

--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -51,6 +51,12 @@ class GEDMetric(Metric):
     requires_source_cfg = True
     requires_decompiled_cfg = True
 
+    # v2: exclude only EMPTY-prototype source CFGs (all-Nop single block), not
+    # every <=1-node source, so genuine straight-line functions are scored; the
+    # non-finite (degenerate/error) result is dropped from the denominator at the
+    # recording layer (metrics/base.py) instead of counting as a failure.
+    cache_version = "2"
+
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)
         self._vj_ged = None
@@ -80,18 +86,22 @@ class GEDMetric(Metric):
                 metadata={"error": "Missing CFG"},
             )
 
-        # Degenerate source CFG (see GED_MIN_SOURCE_NODES above): there is no
-        # source structure to compare against, so exclude the function (same
-        # treatment as a missing CFG) rather than hand a perfect 0 to whichever
-        # decompiler emitted the least output. Checked BEFORE the cache so
+        # EMPTY-prototype source CFG (see is_degenerate_source_cfg): Joern only
+        # saw a declaration (an all-Nop single block) because the function's
+        # defining translation unit wasn't captured, so there is no structure to
+        # compare against. Return non-finite so the recording layer DROPS it from
+        # GED's denominator (unmeasurable for everyone, uniformly), rather than
+        # counting it as a per-decompiler failure. Genuine single-block functions
+        # (real straight-line bodies) are NOT degenerate and ARE scored — a
+        # correct 1-block decompilation earns GED 0. Checked BEFORE the cache so
         # entries recorded under the old (rewarding) semantics are never served.
-        # NOTE: this covers the degenerate-SOURCE half only. A truncated
-        # decompilation (e.g. angr's CFGFast mis-splitting a function at a
-        # function_prologs byte pattern and emitting a prologue-only stub) can
-        # still score well against a genuinely tiny source function; detecting
-        # that needs decompiler-side signals and is left as future work.
+        # NOTE: a truncated decompilation (e.g. angr's CFGFast emitting a
+        # prologue-only stub) can still score well against a genuinely tiny source
+        # function; detecting that needs decompiler-side signals (future work).
+        from decbench.utils.cfg import is_degenerate_source_cfg
+
         s_nodes = source_cfg.number_of_nodes()
-        if s_nodes <= GED_MIN_SOURCE_NODES:
+        if is_degenerate_source_cfg(source_cfg):
             return MetricValue(
                 value=float("inf"),
                 metadata={

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -132,6 +132,104 @@ def normalize_type(type_str: str) -> set[str]:
     return forms
 
 
+# --- Uncommitted (width-only) decompiler types --------------------------------
+# A decompiler often recovers a variable's SIZE but not a committed C type
+# (Ghidra ``undefined8``, IDA ``__int64``/``_QWORD``, kuna ``int8``). Crediting
+# such an uncommitted N-byte type against a ground-truth scalar of the same width
+# is fair ("it knew it was 8 bytes"); crediting it against a POINTER or an
+# aggregate is NOT — recovering a ``char *`` as a bare 8-byte scalar is a real
+# type miss (and ``struct *`` -> ``void *`` stays a miss too, handled by exact
+# name matching, not here).
+_UNCOMMITTED_TYPES = re.compile(
+    r"^\s*(?:"
+    r"undefined\d*"  # Ghidra: undefined, undefined1..8
+    r"|__u?int(?:8|16|32|64)"  # IDA: __int64 / __uint32 / ...
+    r"|_(?:BYTE|WORD|DWORD|QWORD)"  # IDA: _QWORD / _DWORD / ...
+    r"|u?int[1-8]"  # kuna: int4 / uint8 (sized in BYTES)
+    r"|byte|word|dword|qword"  # Ghidra: byte / word / dword / qword
+    r"|uchar"
+    r")\s*$"
+)
+# Byte width implied by an uncommitted spelling when ``VariableInfo.size`` is
+# absent (angr/ghidra usually populate ``size``, so this is a fallback).
+_UNCOMMITTED_WIDTH: dict[str, int] = {
+    "undefined": 1,
+    "undefined1": 1,
+    "byte": 1,
+    "uchar": 1,
+    "_BYTE": 1,
+    "int1": 1,
+    "uint1": 1,
+    "__int8": 1,
+    "__uint8": 1,
+    "undefined2": 2,
+    "word": 2,
+    "_WORD": 2,
+    "int2": 2,
+    "uint2": 2,
+    "__int16": 2,
+    "__uint16": 2,
+    "undefined4": 4,
+    "dword": 4,
+    "_DWORD": 4,
+    "int4": 4,
+    "uint4": 4,
+    "__int32": 4,
+    "__uint32": 4,
+    "undefined8": 8,
+    "qword": 8,
+    "_QWORD": 8,
+    "int8": 8,
+    "uint8": 8,
+    "__int64": 8,
+    "__uint64": 8,
+}
+# Normalized ground-truth scalar names of each byte width. An uncommitted N-byte
+# decompiler var matches a GT var whose normalized type set intersects this.
+# Integer + bool only (a committed ``float``/``double`` is a type the decompiler
+# demonstrably failed to recover, so it stays a miss); pointers/aggregates never
+# appear here, so scalar<->pointer and struct*->void* correctly stay misses.
+_SIZE_SCALARS: dict[int, set[str]] = {
+    1: {"char", "bool"},
+    2: {"short"},
+    4: {"int"},
+    8: {"long long"},
+}
+
+# Ghidra/IDA encode a stack slot's frame offset in the variable NAME
+# (``local_28``, ``var_28``) but sometimes leave ``stack_offset`` unset. These
+# names are unambiguously frame-negative locals; the per-binary/-function
+# calibration absorbs the constant base difference vs DWARF, and its "needs >=2
+# aligned" guard means a wrongly-parsed offset simply fails to calibrate (no
+# harm). Deliberately excludes ``*Stack_*`` names (mixed sign conventions).
+_NAME_OFFSET = re.compile(r"^(?:local|var)_([0-9a-fA-F]+)$")
+
+
+def _uncommitted_size(var: Any) -> int | None:
+    """Byte width of an uncommitted (width-only) decompiler type, else ``None``.
+
+    A pointer spelling (contains ``*``) is a committed type, never uncommitted.
+    """
+    t = (getattr(var, "type", "") or "").strip()
+    if "*" in t or not _UNCOMMITTED_TYPES.match(t):
+        return None
+    size = getattr(var, "size", None)
+    if size in _SIZE_SCALARS:
+        return int(size)
+    return _UNCOMMITTED_WIDTH.get(t)
+
+
+def _effective_offset(var: Any) -> int | None:
+    """Stack offset for a decompiled var, recovering it from ``local_``/``var_``
+    names when ``stack_offset`` is unset (Ghidra register-SSA vars stay ``None``)."""
+    if getattr(var, "stack_offset", None) is not None:
+        return var.stack_offset
+    m = _NAME_OFFSET.match(getattr(var, "name", "") or "")
+    if m:
+        return -int(m.group(1), 16)
+    return None
+
+
 def extract_ground_truth_types(binary_path: Path) -> dict[str, list[dict[str, Any]]]:
     """Extract ground truth variable types from DWARF debug info.
 
@@ -613,7 +711,9 @@ class TypeMatchMetric(Metric):
     # v2: per-function, adaptive (uncapped) stack-offset calibration so IDA's
     # frame-bottom-relative offsets align with DWARF (the old binary-wide ±32
     # shift silently failed for IDA, scoring most of its stack vars as misses).
-    cache_version = "2"
+    # v3: uncommitted (width-only) types match a same-width GT scalar; recover
+    # local_/var_ name-encoded stack offsets; pointers/aggregates stay strict.
+    cache_version = "3"
 
     weight = 1.0
     lower_is_better = False
@@ -699,7 +799,7 @@ class TypeMatchMetric(Metric):
         calibration_shift: int | None,
     ) -> MetricValue:
         gt_stack_vars = sum(1 for gv in ground_truth_vars if gv.get("rbp_offset"))
-        decomp_stack_vars = sum(1 for v in decompiled.variables if v.stack_offset is not None)
+        decomp_stack_vars = sum(1 for v in decompiled.variables if _effective_offset(v) is not None)
 
         if decompiled.variables:
             return self._match_structured(
@@ -762,9 +862,10 @@ class TypeMatchMetric(Metric):
         gt_offsets: list[int] = []
         for gv in ground_truth_vars:
             gt_offsets.extend(gv.get("rbp_offset", []))
-        decomp_offsets = [
-            v.stack_offset for v in decompiled.variables if v.stack_offset is not None
-        ]
+        # Effective offsets recover ``local_``/``var_`` name-encoded slots that
+        # some backends leave with ``stack_offset=None`` (see _effective_offset).
+        var_offsets: list[int | None] = [_effective_offset(v) for v in decompiled.variables]
+        decomp_offsets = [o for o in var_offsets if o is not None]
         gt_off_set = set(gt_offsets)
 
         def _aligned(kk: int | None) -> int:
@@ -795,16 +896,32 @@ class TypeMatchMetric(Metric):
         k = shift if shift is not None else 0
 
         var_types: list[set[str]] = [normalize_type(v.type) for v in decompiled.variables]
+        # Width of each decompiled var's uncommitted (undefinedN/__intN/...) type,
+        # else None. An uncommitted N-byte var matches a GT scalar of that width.
+        var_unc: list[int | None] = [_uncommitted_size(v) for v in decompiled.variables]
         by_arg_index: dict[int, int] = {}
         by_off: dict[int, list[int]] = {}
         by_name: dict[str, list[int]] = {}
         for i, v in enumerate(decompiled.variables):
             if v.arg_index is not None and v.arg_index not in by_arg_index:
                 by_arg_index[v.arg_index] = i
-            if v.stack_offset is not None:
-                by_off.setdefault(v.stack_offset + k, []).append(i)
+            if var_offsets[i] is not None:
+                by_off.setdefault(var_offsets[i] + k, []).append(i)
             if v.name:
                 by_name.setdefault(v.name, []).append(i)
+
+        def _matches(gt_forms: set[str], i: int) -> bool:
+            """Does decompiled var ``i`` type-match a GT var with these forms?
+
+            True on an exact normalized-name intersection OR when the decompiled
+            var is an uncommitted (width-only) type and the GT var is a scalar of
+            the same width. Pointers/aggregates never enter ``_SIZE_SCALARS``, so
+            scalar<->pointer and struct*->void* stay misses.
+            """
+            if gt_forms & var_types[i]:
+                return True
+            sz = var_unc[i]
+            return sz is not None and bool(_SIZE_SCALARS.get(sz, set()) & gt_forms)
 
         used: set[int] = set()
 
@@ -813,7 +930,7 @@ class TypeMatchMetric(Metric):
             avail = [i for i in candidates if i not in used]
             if not avail:
                 return None
-            hit = next((i for i in avail if gt_types & var_types[i]), None)
+            hit = next((i for i in avail if _matches(gt_types, i)), None)
             if hit is not None:
                 used.add(hit)
                 return True
@@ -836,7 +953,7 @@ class TypeMatchMetric(Metric):
                 continue
             used.add(di)
             decided[gi] = True
-            verdicts[gi] = bool(set(gv.get("type", [])) & var_types[di])
+            verdicts[gi] = _matches(set(gv.get("type", [])), di)
             pass_counts["arg"] += 1
 
         # Pass 2: stack variables by calibrated offset (any-of across the
@@ -1050,7 +1167,9 @@ class TypeMatchMetric(Metric):
             if not gt_vars:
                 continue
             func_gt = [o for gv in gt_vars for o in gv.get("rbp_offset", [])]
-            func_dec = [v.stack_offset for v in func_decomp.variables if v.stack_offset is not None]
+            func_dec = [
+                o for o in (_effective_offset(v) for v in func_decomp.variables) if o is not None
+            ]
             if func_gt and func_dec:
                 pairs.append((func_gt, func_dec))
 

--- a/decbench/models/function_data.py
+++ b/decbench/models/function_data.py
@@ -25,6 +25,14 @@ class FunctionRecord(BaseModel):
         default_factory=dict,
         description="decompiler -> metric -> whether the value is perfect",
     )
+    distances: dict[str, dict[str, float]] = Field(
+        default_factory=dict,
+        description="decompiler -> metric -> raw EDIT DISTANCE to a perfect result "
+        "(lower is better): GED = the graph edit distance itself; type_match = "
+        "number of type-flips to exact (fp+fn); byte_match = number of changed "
+        "assembly lines. Powers the report's 'distance' view; absent for a "
+        "(decompiler, metric) with no computed value.",
+    )
     decompiled: dict[str, bool] = Field(
         default_factory=dict,
         description="decompiler -> whether it successfully produced output for "

--- a/decbench/pipeline/evaluate.py
+++ b/decbench/pipeline/evaluate.py
@@ -141,14 +141,20 @@ def evaluate_project(
     else:
         logger.warning("No preprocessed sources for %s/%s", project.name, optimization)
 
-    # A binary's source functions may be defined in ANY of the project's
-    # translation units (multi-.c binaries), and decompiled functions are matched
-    # to source by NAME, so match every binary against the UNION of all the
-    # project's source CFGs rather than only its same-named .i — the per-binary
-    # lookup otherwise lost most GED coverage on multi-source binaries.
-    all_source_cfgs: dict = {}
-    for _cfgs in source_cfgs_by_binary.values():
-        all_source_cfgs.update(_cfgs or {})
+    # Match each binary's decompiled functions against source CFGs TU-aware:
+    # prefer the binary's OWN translation unit (so per-program functions like
+    # main/usage/static helpers hit the RIGHT body, not an arbitrary same-named
+    # function from another binary of the project), and fall back to the cross-TU
+    # best-by-name only for functions the own TU doesn't define (statically-linked
+    # library code). This replaces the old name-keyed union whose last-writer-wins
+    # collisions scored, e.g., nologin's 5-node main against another binary's
+    # 56-node main. See decbench.utils.cfg.resolved_source_for_binary.
+    from decbench.utils.cfg import best_source_by_name, resolved_source_for_binary
+
+    best_by_name = best_source_by_name(source_cfgs_by_binary)
+
+    def _source_for(binary_name: str) -> dict:
+        return resolved_source_for_binary(binary_name, source_cfgs_by_binary, best_by_name)
 
     if parallel:
         workers = workers or cpu_count()
@@ -157,7 +163,7 @@ def evaluate_project(
             futures = {}
 
             for binary_name, dec_results in decompilations.items():
-                source_cfgs = all_source_cfgs
+                source_cfgs = _source_for(binary_name)
 
                 for dec_name, decompilation in dec_results.items():
                     future = executor.submit(
@@ -182,7 +188,7 @@ def evaluate_project(
                     results[binary_name][dec_name] = {}
     else:
         for binary_name, dec_results in decompilations.items():
-            source_cfgs = all_source_cfgs
+            source_cfgs = _source_for(binary_name)
             results[binary_name] = {}
 
             for dec_name, decompilation in dec_results.items():

--- a/decbench/pipeline/executor.py
+++ b/decbench/pipeline/executor.py
@@ -12,8 +12,7 @@ from decbench.models.project import OptimizationLevel, Project
 from decbench.pipeline.compile import compile_projects
 from decbench.pipeline.decompile import decompile_projects
 from decbench.pipeline.evaluate import evaluate_projects
-from decbench.scoring.aggregator import aggregate_results
-from decbench.scoring.scoreboard import build_scoreboard
+from decbench.scoring.scoreboard import build_scoreboard_from_function_data
 
 if TYPE_CHECKING:
     from decbench.models.scoreboard import Scoreboard
@@ -216,17 +215,11 @@ class PipelineExecutor:
                 self.config.workers,
             )
 
-        # Step 4: Build scoreboard
-        print("Building scoreboard...")
-        aggregated = aggregate_results(results.evaluate_results)
-        results.scoreboard = build_scoreboard(
-            aggregated,
-            projects=[p.name for p in projects],
-            optimization_levels=[o.value for o in self.config.optimization_levels],
-            decompilers=self.config.decompilers,
-        )
-
-        # Build and persist per-function data for the interactive report
+        # Build per-function data FIRST — it carries the true function universe
+        # (every function any decompiler produced + explicit failures) and the
+        # measurability of each metric, which the scoreboard denominators derive
+        # from. Building it before the scoreboard makes scoreboard.toml and the
+        # HTML report share ONE source of truth (identical denominators).
         from decbench.scoring.function_data_builder import build_function_data
 
         function_data = build_function_data(
@@ -234,6 +227,12 @@ class PipelineExecutor:
             projects,
             results.decompile_results,
         )
+
+        # Step 4: Build scoreboard from the per-function universe (shared per-metric
+        # denominators; a decompile/metric failure is a not-perfect miss, not an
+        # exclusion). See scoring/scoreboard.py::build_scoreboard_from_function_data.
+        print("Building scoreboard...")
+        results.scoreboard = build_scoreboard_from_function_data(function_data)
 
         # Attach the "hardest functions" table and any historical samples for
         # the interactive report. Best-effort: never let report extras break a

--- a/decbench/publish/layout.py
+++ b/decbench/publish/layout.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 # Normative constants from the publishing contract.
 DATASET_NAME = "decbench-dataset"
 DATASET_REPO_ID = "noelo-lab/decbench-dataset"
-DEFAULT_CONFIGS = ["tiny", "hard", "hard-inlined", "full"]
+DEFAULT_CONFIGS = ["tiny", "hard", "hard-inlined", "unoptimized", "full"]
 _FULL = "full"
 
 Logger = Callable[[str], None]

--- a/decbench/publish/layout.py
+++ b/decbench/publish/layout.py
@@ -529,6 +529,9 @@ _GITATTRIBUTES_LINES = [
     "binaries/** filter=lfs diff=lfs merge=lfs -text",
     "results/**/*.c -filter -diff -merge text",
     "results/function_results.json filter=lfs diff=lfs merge=lfs -text",
+    # Per-config filtered scores are large for broad configs (e.g. 'unoptimized' =
+    # every O0 function, ~tens of MB) — LFS-track them too.
+    "configs/**/function_results.json filter=lfs diff=lfs merge=lfs -text",
 ]
 
 

--- a/decbench/rendering/html.py
+++ b/decbench/rendering/html.py
@@ -80,6 +80,7 @@ def _build_html(scoreboard: Scoreboard, function_data: FunctionData | None) -> s
     nav_items = [
         ("leaderboard", "leaderboard", True),
         ("metrics", "metrics", True),
+        ("distance", "distance", has_data),
         ("dataset", "dataset", has_data),
         ("compare", "compare", has_data),
         ("hardest", "hardest", has_data),
@@ -98,6 +99,7 @@ def _build_html(scoreboard: Scoreboard, function_data: FunctionData | None) -> s
 
     leaderboard = _build_leaderboard_section(scoreboard, function_data)
     metrics_view = _build_metrics_section(scoreboard, function_data)
+    distance_view = _build_distance_section(function_data) if has_data else ""
     dataset_view = _build_dataset_overview_section(function_data) if has_data else ""
     compare_view = _build_compare_section(function_data) if has_data else ""
     hardest_view = _build_hardest_section(function_data) if has_data else ""
@@ -149,6 +151,7 @@ def _build_html(scoreboard: Scoreboard, function_data: FunctionData | None) -> s
             {banner}
             {leaderboard}
             {metrics_view}
+            {distance_view}
             {dataset_view}
             {compare_view}
             {hardest_view}
@@ -553,6 +556,32 @@ def _static_metrics_table(scoreboard: Scoreboard) -> str:
     return f"<table><thead><tr>{headers}</tr></thead><tbody>{rows}</tbody></table>"
 
 
+def _build_distance_section(function_data: FunctionData) -> str:
+    """The 'distance' page: raw per-metric edit distance instead of perfect-rate.
+
+    Rendered client-side from ``FunctionRecord.distances`` so it tracks the
+    dataset selector / normalize toggle like every other view.
+    """
+    return """
+    <section class="view" id="view-distance" data-view="distance">
+        <h2 class="view-title">distance</h2>
+        <p class="view-desc">
+            The raw <em>edit distance</em> to a perfect result for each metric
+            (lower is better) — a finer signal than the perfect / not-perfect rate
+            on the leaderboard. <strong>GED</strong> = the graph edit distance
+            itself; <strong>types</strong> = number of type-flips to reach the
+            ground truth (false-typed + missing vars); <strong>byte</strong> =
+            number of changed assembly lines after recompiling. Each cell shows the
+            <em>mean</em>, the <em>median</em>, and how many functions are already
+            at distance 0 (perfect). Averaged over the functions each decompiler was
+            scored on.
+        </p>
+        <p class="view-desc" id="distance-table-note">over the selected dataset
+            (mean &middot; median &middot; #at-0 / #measured).</p>
+        <table id="distance-table"><thead><tr></tr></thead><tbody></tbody></table>
+    </section>"""
+
+
 def _build_dataset_overview_section(function_data: FunctionData) -> str:
     """The Dataset/About page: software types, projects, total LOC, Joern health.
 
@@ -737,11 +766,29 @@ _JS_TEMPLATE = """
     // tooling stat on the Dataset page.
     function hasGed(func, d) {
         const v = func.values[d];
-        return !!(v && ("ged" in v));
+        // A finite GED only: a non-finite/degenerate-source result is unmeasurable
+        // (our source front-end had no real CFG), not a decompiler miss.
+        return !!(v && ("ged" in v) && isFinite(v.ged));
     }
     function sourceParsed(func) {
         if (DATA.metrics.indexOf("ged") < 0) return true;
         for (const d of DATA.decompilers) if (hasGed(func, d)) return true;
+        return false;
+    }
+    // Is metric m measurable for this function AT ALL (for anyone)? This is the
+    // per-metric universe filter: a function where NO decompiler could be scored
+    // on m for reasons outside any decompiler's control — GED with no/degenerate
+    // source CFG, byte_match abstained (no recompile toolchain), type_match with
+    // no DWARF ground truth — is excluded from m's denominator UNIFORMLY for every
+    // decompiler (so denominators stay identical across decompilers). A function
+    // that IS measurable but which a given decompiler simply failed on counts as
+    // that decompiler's not-perfect miss (see recompute()).
+    function metricMeasurable(func, m) {
+        if (m === "ged") return sourceParsed(func);
+        for (const d of DATA.decompilers) {
+            const v = func.values[d];
+            if (v && (m in v) && isFinite(v[m])) return true;
+        }
         return false;
     }
 
@@ -764,6 +811,11 @@ _JS_TEMPLATE = """
                 if (!isActive(group, func)) continue;
                 activeFunctions += 1; groupActive = true;
                 const srcOk = sourceParsed(func);
+                // Per-metric measurability for THIS function (identical for every
+                // decompiler) — the shared per-metric denominator universe.
+                const meas = {};
+                for (const m of metrics) meas[m] = metricMeasurable(func, m);
+                const allMeas = metrics.every(m => meas[m]);
                 for (const d of decs) {
                     // Errors: a function is "in scope" for d if d attempted it
                     // (present in the decompiled map); errored if it didn't
@@ -773,28 +825,30 @@ _JS_TEMPLATE = """
                         errors[d].scope += 1;
                         if (!dd[d]) errors[d].errored += 1;
                     }
-                    // DENOMINATOR = functions d decompiled (one denominator for
-                    // every metric). A metric not computed on a decompiled
-                    // function counts as not-perfect (it still counts in total) —
-                    // EXCEPT GED excludes functions where our source parser (Joern)
-                    // failed on the source, since that's not the decompiler's fault.
-                    if (!decompiledBy(func, d)) continue;
+                    // DENOMINATOR = the shared per-metric universe: EVERY decompiler
+                    // is scored over the SAME set of functions for a metric (those
+                    // where the metric is measurable for anyone). A decompiler that
+                    // failed to decompile the function, or was decompiled but has no
+                    // value for a measurable metric, counts as a NOT-PERFECT miss —
+                    // it is NOT dropped from the denominator. Only metrics that are
+                    // unmeasurable for everyone (excluded uniformly) leave the denom.
                     const fperf = func.perfects[d] || {};
                     for (const m of metrics) {
-                        if (m === "ged" && !srcOk) continue;  // source-parse fail: exclude
+                        if (!meas[m]) continue;  // unmeasurable for all: exclude uniformly
                         perMetric[d][m].total += 1;
                         if (fperf[m]) perMetric[d][m].perfect += 1;
                     }
                     // Per-decompiler Joern-on-output failure (source parsed but
                     // Joern couldn't parse THIS decompiler's output) — a tooling
-                    // diagnostic surfaced on the Dataset page, not a score.
-                    if (srcOk) {
+                    // diagnostic surfaced on the Dataset page, not a score. Scoped
+                    // to functions d actually decompiled.
+                    if (srcOk && decompiledBy(func, d)) {
                         joernOutFail[d].scope += 1;
                         if (!hasGed(func, d)) joernOutFail[d].failed += 1;
                     }
-                    // Overall (perfect on ALL metrics) needs GED, so it too
-                    // excludes source-parse failures from its denominator.
-                    if (srcOk) {
+                    // Overall (perfect on ALL metrics), over functions where every
+                    // metric is measurable — same denominator for every decompiler.
+                    if (allMeas) {
                         overall[d].total += 1;
                         let allPerfect = true;
                         for (const m of metrics) { if (!fperf[m]) { allPerfect = false; break; } }
@@ -1058,7 +1112,68 @@ _JS_TEMPLATE = """
         lastResult = recompute();
         buildLeaderboard(lastResult);
         buildMetricsTable(lastResult);
+        buildDistance();
         updateStats(lastResult);
+    }
+
+    // ---- Distance view (raw edit distance per metric; lower is better) ----
+    function buildDistance() {
+        const tbl = document.getElementById("distance-table");
+        if (!tbl) return;
+        const decs = DATA.decompilers, metrics = orderedMetrics();
+        const arr = {};
+        for (const d of decs) { arr[d] = {}; for (const m of metrics) arr[d][m] = []; }
+        for (const group of DATA.groups) {
+            for (const func of group.functions) {
+                if (!isActive(group, func)) continue;
+                const dd = func.distances || {};
+                for (const d of decs) {
+                    const dm = dd[d]; if (!dm) continue;
+                    for (const m of metrics) {
+                        const v = dm[m];
+                        if (v != null && isFinite(v)) arr[d][m].push(v);
+                    }
+                }
+            }
+        }
+        function stat(a) {
+            if (!a.length) return null;
+            const s = a.slice().sort((x, y) => x - y);
+            const mean = a.reduce((p, c) => p + c, 0) / a.length;
+            const median = s[Math.floor(s.length / 2)];
+            const perfect = a.filter(x => x === 0).length;
+            return {mean, median, n: a.length, perfect};
+        }
+        let head = "<th>decompiler</th>";
+        for (const m of metrics) head += "<th>" + escapeHtml(METRIC_SHORT[m] || m) + " dist</th>";
+        tbl.querySelector("thead tr").innerHTML = head;
+        // Best (lowest) mean per metric -> highlight; sort rows by mean GED.
+        const rows = decs.map(d => ({d, cells: metrics.map(m => stat(arr[d][m]))}));
+        const best = {};
+        metrics.forEach((m, i) => {
+            best[m] = Math.min.apply(null, rows.map(r => r.cells[i] ? r.cells[i].mean : Infinity));
+        });
+        rows.sort((a, b) => {
+            const av = a.cells[0] ? a.cells[0].mean : Infinity;
+            const bv = b.cells[0] ? b.cells[0].mean : Infinity;
+            return av - bv;
+        });
+        let body = "";
+        for (const r of rows) {
+            let row = '<tr class="binrow"><td class="lb-name">' + escapeHtml(r.d) + '</td>';
+            r.cells.forEach((st, i) => {
+                if (!st) { row += '<td class="metric-cell">&mdash;</td>'; return; }
+                const isBest = st.mean <= best[metrics[i]] + 1e-9;
+                row += '<td class="metric-cell">' +
+                    '<span class="cell-pct ' + (isBest ? 'pct-high' : '') + '">' +
+                    st.mean.toFixed(1) + '</span> ' +
+                    '<span class="cell-count">med ' + st.median + ' &middot; ' +
+                    st.perfect + '/' + st.n + ' at 0</span></td>';
+            });
+            row += '</tr>';
+            body += row;
+        }
+        tbl.querySelector("tbody").innerHTML = body;
     }
 
     // ---- Compare view ----

--- a/decbench/scoring/function_data_builder.py
+++ b/decbench/scoring/function_data_builder.py
@@ -26,6 +26,28 @@ def _perfect_value_for(metric_name: str) -> float:
         return 0.0
 
 
+def _distance_for(metric_name: str, value: object) -> float | None:
+    """Raw edit distance to perfect for the report's 'distance' view (or None).
+
+    GED = the graph edit distance itself; type_match = type-flips to exact
+    (fp+fn); byte_match = number of changed assembly lines (``changed_lines``).
+    """
+    import math
+
+    md = getattr(value, "metadata", None) or {}
+    v = getattr(value, "value", None)
+    if metric_name == "ged":
+        return float(v) if isinstance(v, (int, float)) and math.isfinite(v) else None
+    if metric_name == "type_match":
+        if "fp" in md and "fn" in md:
+            return float(int(md["fp"]) + int(md["fn"]))
+        return None
+    if metric_name == "byte_match":
+        cl = md.get("changed_lines")
+        return float(cl) if cl is not None else None
+    return None
+
+
 def _line_count_for(
     decompile_results,
     project_name: str,
@@ -141,6 +163,9 @@ def build_function_data(
                             record.perfects.setdefault(dec_name, {})[metric_name] = (
                                 value.value == perfect_value
                             )
+                            dist = _distance_for(metric_name, value)
+                            if dist is not None:
+                                record.distances.setdefault(dec_name, {})[metric_name] = dist
 
                 # --- Decompile success/failure universe --------------------
                 # Record, per (function, decompiler), whether the decompiler

--- a/decbench/scoring/scoreboard.py
+++ b/decbench/scoring/scoreboard.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import math
+import statistics
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from decbench.models.scoreboard import (
     DecompilerScore,
@@ -10,6 +13,102 @@ from decbench.models.scoreboard import (
     Scoreboard,
 )
 from decbench.scoring.aggregator import AggregatedResults
+
+if TYPE_CHECKING:
+    from decbench.models.function_data import FunctionData
+
+
+def build_scoreboard_from_function_data(
+    fd: FunctionData,
+    name: str = "DecBench Scoreboard",
+    description: str = "",
+    version: str = "2.0",
+) -> Scoreboard:
+    """Build a scoreboard from the per-function dataset — the single source of
+    truth shared by the HTML report and ``scoreboard.toml``.
+
+    Denominator policy (matches ``rendering/html.py`` ``recompute()``): for every
+    (decompiler, metric) the denominator is the SAME shared universe — the set of
+    functions where that metric is *measurable for anyone* (a finite value from
+    some decompiler). A decompiler that failed to decompile a function, or was
+    decompiled but has no value for a measurable metric, counts as a NOT-PERFECT
+    miss IN the denominator (so every decompiler shares one denominator per
+    metric). Only metrics unmeasurable for everyone — GED with no/degenerate
+    source CFG, byte_match abstained, type_match with no DWARF ground truth — are
+    excluded, uniformly. ``mean``/``median`` still summarize the *measured* values.
+    """
+    decs, metrics = fd.decompilers, fd.metrics
+
+    def measurable(f: object, m: str) -> bool:
+        for d in decs:
+            v = getattr(f, "values", {}).get(d) or {}
+            if m in v and math.isfinite(v[m]):
+                return True
+        return False
+
+    vals: dict[str, dict[str, list[float]]] = {d: {m: [] for m in metrics} for d in decs}
+    perf: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
+    tot: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
+    overall_perf = {d: 0 for d in decs}
+    overall_tot = {d: 0 for d in decs}
+
+    for g in fd.groups:
+        for f in g.functions:
+            meas = {m: measurable(f, m) for m in metrics}
+            all_meas = bool(metrics) and all(meas.values())
+            for d in decs:
+                fp = f.perfects.get(d) or {}
+                fv = f.values.get(d) or {}
+                for m in metrics:
+                    if not meas[m]:
+                        continue
+                    tot[d][m] += 1
+                    if m in fv and math.isfinite(fv[m]):
+                        vals[d][m].append(fv[m])
+                    if fp.get(m):
+                        perf[d][m] += 1
+                if all_meas:
+                    overall_tot[d] += 1
+                    if all(fp.get(m) for m in metrics):
+                        overall_perf[d] += 1
+
+    sb = Scoreboard(
+        name=name,
+        description=description,
+        version=version,
+        generated_at=datetime.now(),
+        projects_evaluated=sorted({g.project for g in fd.groups}),
+        optimization_levels=sorted({g.opt_level for g in fd.groups}),
+        decompilers=decs,
+        metrics=metrics,
+        total_functions=sum(len(g.functions) for g in fd.groups),
+        total_binaries=len(fd.groups),
+    )
+    for d in decs:
+        ds = DecompilerScore(name=d)
+        for m in metrics:
+            n = tot[d][m]
+            ds.metric_scores[m] = MetricScore(
+                metric_name=m,
+                decompiler_name=d,
+                perfect_count=perf[d][m],
+                total_count=n,
+                perfect_percentage=(100 * perf[d][m] / n) if n else 0.0,
+                mean=statistics.fmean(vals[d][m]) if vals[d][m] else 0.0,
+                median=statistics.median(vals[d][m]) if vals[d][m] else 0.0,
+            )
+        ds.overall_perfect_count = overall_perf[d]
+        ds.overall_total_count = overall_tot[d]
+        ds.overall_perfect_percentage = (
+            100 * overall_perf[d] / overall_tot[d] if overall_tot[d] else 0.0
+        )
+        sb.decompiler_scores[d] = ds
+    for m in metrics:
+        for rank, (d, _) in enumerate(sb.get_metric_rankings(m), 1):
+            sb.decompiler_scores[d].metric_scores[m].rank = rank
+    for rank, (d, _) in enumerate(sb.get_overall_rankings(), 1):
+        sb.decompiler_scores[d].overall_rank = rank
+    return sb
 
 
 def build_scoreboard(

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -61,6 +61,75 @@ def strip_system_headers(preprocessed: str) -> str:
     return "\n".join(keep) + "\n"
 
 
+def is_degenerate_source_cfg(cfg: DiGraph) -> bool:  # type: ignore
+    """True when a source CFG has no real structure to compare GED against.
+
+    Two cases, both meaning "there is nothing to score": zero nodes, or a single
+    block whose statements are ALL ``Nop`` (``FUNCTION_START``/``FUNCTION_END``) —
+    an *empty prototype* Joern emitted from a declaration-only view of a function
+    whose defining translation unit wasn't captured. A genuine single-block
+    function (a straight-line ``return foo(...);``) has real statements and is NOT
+    degenerate, so it stays scorable (a correct 1-block decompilation → GED 0).
+    """
+    n = cfg.number_of_nodes()
+    if n == 0:
+        return True
+    if n >= 2:
+        return False
+    for node in cfg.nodes():
+        for stmt in getattr(node, "statements", None) or []:
+            if type(stmt).__name__ != "Nop":
+                return False
+    return True
+
+
+def _source_rank(cfg: DiGraph) -> tuple[int, int]:  # type: ignore
+    """Sort key preferring a non-degenerate, then larger, source CFG."""
+    return (0 if is_degenerate_source_cfg(cfg) else 1, cfg.number_of_nodes())
+
+
+def best_source_by_name(
+    source_cfgs_by_binary: dict[str, dict[str, DiGraph]],
+) -> dict[str, DiGraph]:  # type: ignore
+    """Collapse per-TU source CFGs to one-per-name, preferring the real body.
+
+    A function name that appears in several translation units (``main``, ``usage``,
+    gnulib helpers) is reduced to its **non-degenerate, largest** CFG. Used as the
+    cross-TU FALLBACK when a binary's own TU doesn't define a function (e.g. a
+    statically-linked gnulib helper) — see :func:`resolved_source_for_binary`.
+    """
+    best: dict[str, DiGraph] = {}
+    for cfgs in source_cfgs_by_binary.values():
+        for name, cfg in (cfgs or {}).items():
+            cur = best.get(name)
+            if cur is None or _source_rank(cfg) > _source_rank(cur):
+                best[name] = cfg
+    return best
+
+
+def resolved_source_for_binary(
+    binary_stem: str,
+    source_cfgs_by_binary: dict[str, dict[str, DiGraph]],
+    best_by_name: dict[str, DiGraph],
+) -> dict[str, DiGraph]:  # type: ignore
+    """Source CFGs to score ONE binary against, TU-aware (fixes name collisions).
+
+    Prefers the binary's **own translation unit** (``nologin`` binary ↔
+    ``nologin.i``) for each function so per-program functions (``main``, ``usage``,
+    static helpers) are compared against the RIGHT body — not an arbitrary
+    same-named function from another binary of the project (the old project-wide,
+    name-keyed, last-writer-wins union scored ``nologin``'s 5-node ``main`` against
+    another binary's 56-node ``main``). Falls back to the cross-TU
+    :func:`best_source_by_name` for functions the own TU doesn't define
+    (statically-linked library code) or defines only as an empty prototype.
+    """
+    resolved = dict(best_by_name)
+    for name, cfg in (source_cfgs_by_binary.get(binary_stem) or {}).items():
+        if not is_degenerate_source_cfg(cfg):
+            resolved[name] = cfg
+    return resolved
+
+
 def extract_cfgs_from_source(source_path: Path) -> dict[str, DiGraph]:
     """Extract CFGs from a C source file using pyjoern.
 

--- a/docs/JOERN_FAILURES.md
+++ b/docs/JOERN_FAILURES.md
@@ -1,0 +1,190 @@
+# GED Metric Failure Catalog — decbench `results/full_run`
+
+> **STATUS (branch `fix/metric-fairness-and-denominators`).** The dominant issues
+> below are **FIXED** in this branch and applied on the next re-eval:
+> - **Source-CFG merge / name-collision** (cat 1b + cat 2, the biggest win): source
+>   CFGs are now cached **per translation unit** and matched TU-aware (own TU first,
+>   then the non-degenerate/largest across TUs) — see
+>   `decbench/utils/cfg.py::resolved_source_for_binary` + `best_source_by_name`,
+>   `pipeline/evaluate.py`, `scripts/reeval_ged.py`.
+> - **Empty-prototype vs genuine 1-block** (cat 1, the 1,963 branchless funcs): only
+>   all-Nop single-block sources are excluded; genuine straight-line bodies are now
+>   scored (`is_degenerate_source_cfg`). Non-finite GED is dropped from the
+>   denominator at the recording layer (`metrics/base.py`) instead of counting as a
+>   failure.
+> - **binja `Loading...`** (cat 4): `update_analysis_and_wait()` + placeholder guard
+>   in `decompilers/raw/binja_raw.py`.
+>
+> **STILL OPEN for a follow-up agent** (smaller, ~2.4k evals): cat 4 decompiled-parse
+> breakers — array/aggregate return types `T [N] name(...)` (angr/phoenix/ghidra),
+> binja `arg @ rax` register annotations, ida `__int128`, and binja's whole-file
+> error-recovery cascade (parse each decompiled function individually instead of the
+> concatenated file). These need a pre-parse cleanup pass in
+> `decbench/utils/cfg.py::extract_cfgs_from_source`/`_from_decompilation`.
+
+Scope: the 25 x86 **sailr** projects (the only ones with source CFGs / `ged_new.json`;
+cps + malware have no source CFGs). 6 decompilers: angr, phoenix, ghidra, ida, binja,
+kuna. 3 opt levels: O0, O2, O2-noinline. All numbers verified against the on-disk data
+with `DECBENCH_NO_CACHE=1`. Machine-readable detail + capped examples in `catalog.json`;
+per-category raw JSON in `cat*.json`.
+
+## Headline
+
+`ged_new.json` has **225,753** GED evals. Only **105,236 (46.6%)** are a real structural
+comparison. **120,517 (53.4%)** return `value=inf` — the metric never compared anything
+because the cached **source** CFG had <=1 node.
+
+The dominant cause is NOT "Joern couldn't see the source." It is a **broken source-CFG
+merge**: source CFGs are cached per project by function **name** with last-writer-wins
+(`acc[proj].update(cfgs)` in `scripts/reeval_ged.py::build_source_cfgs`, mirrored in
+`decbench/pipeline/evaluate.py` `all_source_cfgs.update(...)`), and the writes arrive in
+**nondeterministic** `imap_unordered` order. Every `.i` that merely *declares* (prototypes)
+a function yields a degenerate 1-node stub for it; whichever `.i` finishes last wins. So a
+real body is routinely clobbered by a prototype stub from an unrelated translation unit.
+
+PROVEN: parsed fresh, zlib **`deflate` = 176 nodes** and e2fsprogs **`e2fsck_pass1` = 443
+nodes**; the cache stores both at **1 node**. In `compress.i` (which only calls `deflate`)
+Joern emits `deflate` as a 1-node stub — that stub is what landed in the cache.
+
+**~64-77% of the 120,517 inf evals are recoverable by fixing the merge alone** (77,236
+strict / 92,774 loose — see cat1b), raising real-GED coverage by **~73-88%, nearly doubling
+it**. Single highest-value fix; it also subsumes the name-collision problem (cat2).
+
+---
+
+## Category 1 — Degenerate / empty-prototype source CFG (<=1 node) -> `inf`
+
+`ged.py` returns `inf` when `source_cfg.number_of_nodes() <= GED_MIN_SOURCE_NODES` (=1).
+
+- Distinct source functions across the 25 pkls: **17,745**.
+- Degenerate (<=1 node): **11,023 (62.1%)** — matches the ~62% claim exactly.
+  - **Empty-prototype (declaration-only, body only Nop/markers): 9,060 (82.2%)** — matches ~82%.
+  - **Genuine straight-line body (1 real block, no branches): 1,963 (17.8%)** — e.g.
+    `keephome(){ return scan_infos(...); }`. Real functions dropped only because a branchless
+    function is a single basic block.
+- Inf **evals**: 120,517 (empty-proto 96,494 / straight-line 24,023);
+  by opt O0 43,643 / O2 34,409 / O2-noinline 42,465; roughly even across decompilers (42-55%).
+- Worst projects by inf evals: openssh-portable 57,111, coreutils 12,542, bash 8,181,
+  zlib 6,136, gnutls 5,186, libedit 4,707.
+
+Top empty-prototype names are classic **gnulib** helpers declared in kept project headers but
+whose body lives in another (proto-clobbered or uncaptured) TU: `xmalloc` (8 projects),
+`xrealloc`, `error_at_line`, `xstrdup`, `xalloc_die`, `last_component`, `error`, `gettime`,
+`rpl_fcntl`, `base_len`, `xcalloc`, `mdir_name`, `strip_trailing_slashes`, `xmemdup`, ...
+
+### Category 1b — how much of cat1 is actually RECOVERABLE (the real story)
+
+For a degenerate cached function, if some decompiler produced a large branchy body, a real
+source body demonstrably exists and was lost to the merge:
+
+- **2,579** (proj,func) are cached <=1 node but ghidra decompiles >=2 branches (strict);
+  **3,394** with >=1 branch or >=10 lines (loose). Worst offenders are core functions:
+  `e2fsck_pass1` (394 ghidra branches), iproute2 `iplink_parse` (337), `BZ2_compressBlock`
+  (259), zlib `deflate` (166), bash `execute_command_internal` (129), `brace_expand` (129),
+  diffutils `diff_2_files` (169) — all currently `inf` for *every* decompiler.
+- Mapped to evals: **77,236 inf evals (64%) recoverable (strict)** / **92,774 (77%) (loose)**.
+  Recoverable inf by dec (strict): ghidra 18,528, ida 18,297, kuna 14,449, phoenix 11,791,
+  angr 11,364, binja 2,807.
+- Recoverable by project: bash 673, openssh 654, libselinux 184, libedit 174, tar 156, ...
+
+Non-recoverable remainder (~23-36% of inf) = genuinely branchless straight-line functions
+(correctly ~1 node) + helpers whose body was never captured in any `.i`.
+
+---
+
+## Category 2 — Name-collision / wrong-source CFG
+
+Same merge bug, different symptom: a name **defined with different bodies in >1 binary**
+(main, usage, per-program statics) is scored against ONE arbitrary cached version.
+
+- **508 true-collision (opt,proj,func) groups** (structurally-different source across binaries,
+  via ghidra control-flow-skeleton hashing) vs **5,615 harmless gnulib dups** (identical
+  skeleton across binaries — same source compiled into each binary).
+- **Wrong-source evals: 11,665 upper bound (8,457 finite/real-GED).** At most one binary per
+  group can be the "correct" match; all others are scored against a wrong CFG.
+- Worst names (bins / distinct ghidra skeletons / cached nodes):
+  - coreutils `main` 108 / 97 / 34 -> ~635 wrong evals/opt; `usage` 107 / 54 / **4**.
+  - shadow `main` 40 / 38 / 56 -> 234/opt (the proven `nologin` case: its own main = 5 nodes);
+    `usage` 35 / 15 / **1** (cached winner is a prototype -> also `inf`), `process_flags` 22/18/163.
+  - openssh `main` 12 / 12 / 275; sysvinit `main` 14 / 14 / 39; gnutls `main` 9 / 9 / 91.
+- Per project wrong-source evals: coreutils 4,481, openssh 2,493, shadow 2,461, gnutls 836,
+  sysvinit 449, dpkg 204, diffutils 157, libacl 148, zlib 138, bash 126.
+
+cat1 n cat2 overlap: several collided names (shadow `usage`, openssh `sshfatal`,
+`cleanup_exit`, `tilde_expand_filename`) have `cached_nodes=1` — the merge picked a prototype,
+so every binary's copy is *both* collided and excluded as degenerate.
+
+---
+
+## Category 3 — Binary Ninja `Loading...` placeholder (a decompile bug, tagged distinctly)
+
+`binja_raw.py` dumps HLIL before per-function analysis is ready, emitting a literal
+`Loading...` body (signature present, no code). Not a Joern failure, but it produces zero GED
+coverage for those functions.
+
+- O0: **18,018 / 24,757 = 72.8% Loading** (matches ~73%). All opts: **49,989 / 66,495 = 75.2%**
+  (includes cps/malware binja files). Why binja has only ~10.6k GED evals vs ~50k for ghidra/ida.
+- **28 binaries are 100% Loading**, incl. bash (1,053 fns), openssh `ssh`/`ssh-add`/`ssh-agent`,
+  iproute2 `ip` (757), e2fsprogs `e2fsck` (409), coreutils `ls` (216), dpkg `dpkg` (238),
+  cleanflight. Larger binaries lose the analysis race; small ones (base-passwd, gzip, shadow,
+  zlib, cronie) are 0% Loading.
+
+---
+
+## Category 4 — Decompiled-parse failures (decompiler produced a real body, Joern got no CFG)
+
+Counts across all opts: angr **525**, phoenix **541**, ida **452**, binja **826**,
+ghidra **40**, **kuna 0**. Breakers (all confirmed by parsing minimal repros):
+
+- **angr / phoenix / ghidra — aggregate/array return type.** Functions returning a
+  struct/aggregate by value are rendered `T [N] name(...)` (`unsigned int [4] read_tree(void)`,
+  angr's bogus `unsigned int [1277633] pqdownheap`; ghidra's `undefined1 [16] wrap_db_fetch`).
+  Joern parses **nothing** for such a function. ~all of angr (524/525), phoenix (540/541),
+  ghidra (36/40).
+- **binja — `arg @ rax` register annotations** in the signature
+  (`rpl_fcntl(..., char arg3 @ rax)`) -> Joern parses nothing (182). `int128_t` alone is fine.
+- **binja — whole-file parse cascade (~538).** Functions that parse fine *in isolation*
+  (diffutils `print_context_script`, `find_function`) are dropped when the whole
+  `binja_<bin>.c` is parsed at once (dense with `@reg`-malformed neighbors + Loading stubs).
+  Confirmed: `binja_diff.c` produced 18 non-Loading fns, Joern kept 14.
+- **ida — `__int128` params/returns** (`unsigned __int128 a1`) -> Joern parses nothing; plus
+  multi-underscore marker<->symbol name mismatches (`__fdnlist` vs parsed `_fdnlist`).
+- **kuna — 0.** kuna output is Joern-clean.
+
+---
+
+## Category 5 — Source-parse outright failures
+
+**Effectively nonexistent.** Header-stripping (`strip_system_headers`) eliminated the old
+Joern timeouts. Probe of the 2 largest `.i` per project (49 files): **0 exceptions, 0 empty
+returns**. The many degenerate CFGs *within* a parsed file are prototype stubs (cat1), not
+parse failures.
+
+---
+
+## Prioritized fix list (by GED-coverage payoff)
+
+1. **Fix the source-CFG merge — by far the biggest win.** Root cause of cat1b AND cat2.
+   - Best: **key source CFGs per translation unit** and match each binary's decompiled function
+     to the definition from that binary's OWN `.i` (per-program `main`/`usage` from the
+     program's own TU; shared-lib functions are identical everywhere). Fixes both
+     prototype-clobber and cross-program collisions.
+   - Minimal interim: when merging same-named CFGs, **keep the one with the most nodes** (a real
+     definition always beats a prototype stub). Instantly recovers the ~77k-93k recoverable inf
+     evals (cat1b); does not fully fix cat2 collisions between two real definitions.
+   - Payoff: real-GED coverage ~105k -> ~180-200k evals (~ +73-88%), plus 8.5k finite evals
+     stop being scored against the wrong function.
+
+2. **Fix cat4 decompiled-parse breakers (cheap, ~2.4k evals, mostly uniform per dec).** In a
+   pre-parse cleanup / `extract_cfgs_from_decompilation`: rewrite `T [N] name(...)` return types
+   to `T name(...)` (fixes angr/phoenix/ghidra ~1.1k); strip binja `@ <reg>` annotations (~182);
+   rewrite `__int128` (ida chunk); and **parse each decompiled function individually** rather
+   than the whole binary file to stop the binja error-recovery cascade (~538).
+
+3. **Fix binja `Loading...` (cat3) in `binja_raw.py`.** Biggest single-decompiler hole — ~75%
+   of binja bodies and 28 whole binaries produce no GED at all. Ensure per-function analysis is
+   complete before rendering HLIL (await analysis / retry on `Loading...`).
+
+4. **Decide policy for branchless straight-line source (1,963 real functions, cat1).** Excluded
+   as `inf` only because a branchless function is one basic block. Consider scoring them
+   (node/edge match) instead of dropping — lower priority, independent of the merge fix.

--- a/docs/joern_failures/cat1_degenerate.json
+++ b/docs/joern_failures/cat1_degenerate.json
@@ -1,0 +1,966 @@
+{
+ "per_project": {
+  "base-passwd": {
+   "total": 48,
+   "degenerate": 11,
+   "empty_proto": 0,
+   "straightline_body": 11,
+   "pct_degen": 22.9
+  },
+  "bash": {
+   "total": 2962,
+   "degenerate": 1948,
+   "empty_proto": 1671,
+   "straightline_body": 277,
+   "pct_degen": 65.8
+  },
+  "bzip2": {
+   "total": 117,
+   "degenerate": 52,
+   "empty_proto": 32,
+   "straightline_body": 20,
+   "pct_degen": 44.4
+  },
+  "coreutils": {
+   "total": 1735,
+   "degenerate": 768,
+   "empty_proto": 458,
+   "straightline_body": 310,
+   "pct_degen": 44.3
+  },
+  "cronie": {
+   "total": 112,
+   "degenerate": 63,
+   "empty_proto": 53,
+   "straightline_body": 10,
+   "pct_degen": 56.2
+  },
+  "diffutils": {
+   "total": 306,
+   "degenerate": 162,
+   "empty_proto": 121,
+   "straightline_body": 41,
+   "pct_degen": 52.9
+  },
+  "dpkg": {
+   "total": 622,
+   "degenerate": 467,
+   "empty_proto": 421,
+   "straightline_body": 46,
+   "pct_degen": 75.1
+  },
+  "e2fsprogs": {
+   "total": 1327,
+   "degenerate": 1048,
+   "empty_proto": 801,
+   "straightline_body": 247,
+   "pct_degen": 79.0
+  },
+  "findutils": {
+   "total": 523,
+   "degenerate": 338,
+   "empty_proto": 241,
+   "straightline_body": 97,
+   "pct_degen": 64.6
+  },
+  "gnutls": {
+   "total": 1972,
+   "degenerate": 1520,
+   "empty_proto": 1388,
+   "straightline_body": 132,
+   "pct_degen": 77.1
+  },
+  "grep": {
+   "total": 279,
+   "degenerate": 180,
+   "empty_proto": 168,
+   "straightline_body": 12,
+   "pct_degen": 64.5
+  },
+  "gzip": {
+   "total": 241,
+   "degenerate": 143,
+   "empty_proto": 105,
+   "straightline_body": 38,
+   "pct_degen": 59.3
+  },
+  "iproute2": {
+   "total": 1101,
+   "degenerate": 552,
+   "empty_proto": 399,
+   "straightline_body": 153,
+   "pct_degen": 50.1
+  },
+  "kmod": {
+   "total": 288,
+   "degenerate": 173,
+   "empty_proto": 156,
+   "straightline_body": 17,
+   "pct_degen": 60.1
+  },
+  "libacl": {
+   "total": 121,
+   "degenerate": 78,
+   "empty_proto": 73,
+   "straightline_body": 5,
+   "pct_degen": 64.5
+  },
+  "libbsd": {
+   "total": 176,
+   "degenerate": 94,
+   "empty_proto": 57,
+   "straightline_body": 37,
+   "pct_degen": 53.4
+  },
+  "libedit": {
+   "total": 516,
+   "degenerate": 325,
+   "empty_proto": 236,
+   "straightline_body": 89,
+   "pct_degen": 63.0
+  },
+  "libexpat": {
+   "total": 122,
+   "degenerate": 96,
+   "empty_proto": 68,
+   "straightline_body": 28,
+   "pct_degen": 78.7
+  },
+  "libselinux": {
+   "total": 442,
+   "degenerate": 269,
+   "empty_proto": 244,
+   "straightline_body": 25,
+   "pct_degen": 60.9
+  },
+  "openssh-portable": {
+   "total": 2389,
+   "degenerate": 1191,
+   "empty_proto": 1017,
+   "straightline_body": 174,
+   "pct_degen": 49.9
+  },
+  "rsyslog": {
+   "total": 713,
+   "degenerate": 615,
+   "empty_proto": 573,
+   "straightline_body": 42,
+   "pct_degen": 86.3
+  },
+  "shadow": {
+   "total": 363,
+   "degenerate": 243,
+   "empty_proto": 229,
+   "straightline_body": 14,
+   "pct_degen": 66.9
+  },
+  "sysvinit": {
+   "total": 158,
+   "degenerate": 30,
+   "empty_proto": 10,
+   "straightline_body": 20,
+   "pct_degen": 19.0
+  },
+  "tar": {
+   "total": 946,
+   "degenerate": 574,
+   "empty_proto": 463,
+   "straightline_body": 111,
+   "pct_degen": 60.7
+  },
+  "zlib": {
+   "total": 166,
+   "degenerate": 83,
+   "empty_proto": 76,
+   "straightline_body": 7,
+   "pct_degen": 50.0
+  }
+ },
+ "totals": {
+  "total_funcs": 17745,
+  "degenerate": 11023,
+  "empty_proto": 9060,
+  "straightline_body": 1963
+ },
+ "top_empty_proto_names": [
+  [
+   "xmalloc",
+   8
+  ],
+  [
+   "xrealloc",
+   7
+  ],
+  [
+   "error_at_line",
+   7
+  ],
+  [
+   "xstrdup",
+   7
+  ],
+  [
+   "xalloc_die",
+   7
+  ],
+  [
+   "last_component",
+   7
+  ],
+  [
+   "error",
+   7
+  ],
+  [
+   "gettime",
+   7
+  ],
+  [
+   "rpl_fcntl",
+   7
+  ],
+  [
+   "base_len",
+   7
+  ],
+  [
+   "xcalloc",
+   6
+  ],
+  [
+   "mdir_name",
+   6
+  ],
+  [
+   "strip_trailing_slashes",
+   6
+  ],
+  [
+   "xmemdup",
+   6
+  ],
+  [
+   "dir_len",
+   6
+  ],
+  [
+   "x2realloc",
+   6
+  ],
+  [
+   "xzalloc",
+   6
+  ],
+  [
+   "settime",
+   6
+  ],
+  [
+   "hash_remove",
+   5
+  ],
+  [
+   "hash_string",
+   5
+  ],
+  [
+   "mbscasecmp",
+   5
+  ],
+  [
+   "fpurge",
+   5
+  ],
+  [
+   "setlocale_null",
+   5
+  ],
+  [
+   "xstrtoull",
+   5
+  ],
+  [
+   "ximalloc",
+   5
+  ],
+  [
+   "xreallocarray",
+   5
+  ],
+  [
+   "ximemdup",
+   5
+  ],
+  [
+   "quote_n",
+   5
+  ],
+  [
+   "quote_n_mem",
+   5
+  ],
+  [
+   "xicalloc",
+   5
+  ],
+  [
+   "xizalloc",
+   5
+  ],
+  [
+   "xstrtoll",
+   5
+  ],
+  [
+   "setlocale_null_r",
+   5
+  ],
+  [
+   "mktime_z",
+   5
+  ],
+  [
+   "quote",
+   5
+  ],
+  [
+   "xstrtoimax",
+   5
+  ],
+  [
+   "xirealloc",
+   5
+  ],
+  [
+   "xstrtol",
+   5
+  ],
+  [
+   "xstrtoul",
+   5
+  ],
+  [
+   "tzfree",
+   5
+  ],
+  [
+   "ximemdup0",
+   5
+  ],
+  [
+   "tzalloc",
+   5
+  ],
+  [
+   "xpalloc",
+   5
+  ],
+  [
+   "xstrtoumax",
+   5
+  ],
+  [
+   "x2nrealloc",
+   5
+  ],
+  [
+   "quote_mem",
+   5
+  ],
+  [
+   "xireallocarray",
+   5
+  ],
+  [
+   "hash_free",
+   5
+  ],
+  [
+   "hash_xinsert",
+   5
+  ],
+  [
+   "wcsdup",
+   5
+  ],
+  [
+   "malloc",
+   4
+  ],
+  [
+   "strdup",
+   4
+  ],
+  [
+   "realloc",
+   4
+  ],
+  [
+   "calloc",
+   4
+  ],
+  [
+   "aligned_alloc",
+   4
+  ],
+  [
+   "mbsstr",
+   4
+  ],
+  [
+   "fopen",
+   4
+  ],
+  [
+   "mbslen",
+   4
+  ],
+  [
+   "free",
+   4
+  ],
+  [
+   "canonicalize_file_name",
+   4
+  ]
+ ],
+ "top_body1_names": [
+  [
+   "usage",
+   12
+  ],
+  [
+   "__builtin_va_arg",
+   10
+  ],
+  [
+   "__builtin_offsetof",
+   10
+  ],
+  [
+   "get_stat_atime_ns",
+   7
+  ],
+  [
+   "get_stat_ctime_ns",
+   7
+  ],
+  [
+   "get_stat_mtime_ns",
+   7
+  ],
+  [
+   "get_stat_atime",
+   7
+  ],
+  [
+   "get_stat_ctime",
+   7
+  ],
+  [
+   "get_stat_mtime",
+   7
+  ],
+  [
+   "make_timespec",
+   6
+  ],
+  [
+   "timespec_cmp",
+   6
+  ],
+  [
+   "timespec_sign",
+   6
+  ],
+  [
+   "timespectod",
+   6
+  ],
+  [
+   "xnrealloc",
+   6
+  ],
+  [
+   "get_stat_birthtime_ns",
+   4
+  ],
+  [
+   "get_stat_birthtime",
+   4
+  ],
+  [
+   "to_uchar",
+   3
+  ],
+  [
+   "set_binary_mode",
+   3
+  ],
+  [
+   "stat_time_normalize",
+   3
+  ],
+  [
+   "signal_handler",
+   3
+  ],
+  [
+   "handler",
+   3
+  ],
+  [
+   "version",
+   2
+  ],
+  [
+   "is_basic",
+   2
+  ],
+  [
+   "filename_completion_function",
+   2
+  ],
+  [
+   "restore_default_color",
+   2
+  ],
+  [
+   "beyond",
+   2
+  ],
+  [
+   "ptr_align",
+   2
+  ],
+  [
+   "rotr32",
+   2
+  ],
+  [
+   "rotr64",
+   2
+  ],
+  [
+   "lutimensat",
+   2
+  ],
+  [
+   "priv_set_remove_linkdir",
+   2
+  ],
+  [
+   "priv_set_restore_linkdir",
+   2
+  ],
+  [
+   "sighup_handler",
+   2
+  ],
+  [
+   "xnmalloc",
+   2
+  ],
+  [
+   "__list_add",
+   2
+  ],
+  [
+   "list_add",
+   2
+  ],
+  [
+   "list_add_tail",
+   2
+  ],
+  [
+   "__list_del",
+   2
+  ],
+  [
+   "list_del",
+   2
+  ],
+  [
+   "list_empty",
+   2
+  ]
+ ],
+ "degen_body_samples": [
+  {
+   "project": "base-passwd",
+   "function": "create_node",
+   "stmts": [
+    "<UnsupportedStmt: UNKNOWN,struct_node*,struct_node*>",
+    "<UnsupportedStmt: ['sizeOf', 'sizeof(struct_node)']>",
+    "xmalloc(sizeof(struct_node))",
+    "<UnsupportedStmt: ['cast', '(struct_node*)xmalloc(sizeof(struct_node))']>",
+    "newnode = (struct_node*)xmalloc(sizeof(struct_n...",
+    "<UnsupportedStmt: FIELD_IDENTIFIER,name,name>"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "copy_passwd",
+   "stmts": [
+    "<UnsupportedStmt: FIELD_IDENTIFIER,d,d>",
+    "<UnsupportedStmt: ['indirectFieldAccess', 'newnode-&gt;d']>",
+    "<UnsupportedStmt: FIELD_IDENTIFIER,pw,pw>",
+    "<UnsupportedStmt: ['fieldAccess', 'newnode-&gt;d.pw']>",
+    "<UnsupportedStmt: ['indirection', '*pw']>",
+    "newnode-&gt;d.pw = *pw"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "copy_shadow",
+   "stmts": [
+    "<UnsupportedStmt: FIELD_IDENTIFIER,d,d>",
+    "<UnsupportedStmt: ['indirectFieldAccess', 'newnode-&gt;d']>",
+    "<UnsupportedStmt: FIELD_IDENTIFIER,sp,sp>",
+    "<UnsupportedStmt: ['fieldAccess', 'newnode-&gt;d.sp']>",
+    "<UnsupportedStmt: ['indirection', '*sp']>",
+    "newnode-&gt;d.sp = *sp"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "keephome",
+   "stmts": [
+    "scan_infos()",
+    "return scan_infos(lst,id,0x0001);,returnscan_infos(lst,id,0x0001);"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "keepshell",
+   "stmts": [
+    "scan_infos()",
+    "return scan_infos(lst,id,0x0002);,returnscan_infos(lst,id,0x0002);"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "keepgecos",
+   "stmts": [
+    "scan_infos()",
+    "return scan_infos(lst,id,0x0004);,returnscan_infos(lst,id,0x0004);"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "noautoremove",
+   "stmts": [
+    "scan_infos()",
+    "return scan_infos(lst,id,0x0010);,returnscan_infos(lst,id,0x0010);"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "noautoadd",
+   "stmts": [
+    "scan_infos()",
+    "return scan_infos(lst,id,0x0020);,returnscan_infos(lst,id,0x0020);"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "usage",
+   "stmts": [
+    "<UnsupportedStmt: >",
+    "<UnsupportedStmt: >",
+    "<UnsupportedStmt: >"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "version",
+   "stmts": [
+    "printf()"
+   ]
+  },
+  {
+   "project": "base-passwd",
+   "function": "ask_debconf",
+   "stmts": [
+    "return 0;,return0;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "usage",
+   "stmts": [
+    "<UnsupportedStmt: >",
+    "<UnsupportedStmt: >",
+    "<UnsupportedStmt: >"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "is_basic",
+   "stmts": [
+    "<UnsupportedStmt: UNKNOWN,unsignedchar,unsignedchar>",
+    "<UnsupportedStmt: ['cast', '(unsignedchar)c']>",
+    "<UnsupportedStmt: ['arithmeticShiftRight', '(unsignedchar)c&gt;&gt;5']>",
+    "<UnsupportedStmt: ['indirectIndexAccess', 'is_basic_table[(unsignedchar)c&gt;&gt;5]']>",
+    "<UnsupportedStmt: UNKNOWN,unsignedchar,unsignedchar>",
+    "<UnsupportedStmt: ['cast', '(unsignedchar)c']>"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "sort_aliases",
+   "stmts": [
+    "<UnsupportedStmt: UNKNOWN,char**,char**>",
+    "<UnsupportedStmt: ['cast', '(char**)array']>",
+    "strvec_len((char**)array)",
+    "<UnsupportedStmt: ['sizeOf', 'sizeof(alias_t*)']>",
+    "<UnsupportedStmt: UNKNOWN,QSFUNC*,QSFUNC*>",
+    "<UnsupportedStmt: ['cast', '(QSFUNC*)qsort_alias_compare']>"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "_rl_vi_set_last",
+   "stmts": [
+    "_rl_vi_last_command = key",
+    "_rl_vi_last_repeat = repeat",
+    "_rl_vi_last_arg_sign = sign"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "_rl_vi_reset_last",
+   "stmts": [
+    "_rl_vi_last_command = 'i'",
+    "_rl_vi_last_repeat = 1",
+    "_rl_vi_last_arg_sign = 1",
+    "_rl_vi_last_motion = 0"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "cdxattr",
+   "stmts": [
+    "-1 - ",
+    "return -1;,return-1;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "resetxattr",
+   "stmts": [
+    "-1 - ",
+    "xattrfd = -1"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "really_add_history",
+   "stmts": [
+    "hist_last_line_added = 1",
+    "hist_last_line_pushed = 0",
+    "add_history(line)",
+    "<UnsupportedStmt: ['postIncrement', 'history_lines_this_session++']>"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "last_history_entry",
+   "stmts": [
+    "using_history()",
+    "previous_history()",
+    "he = previous_history()",
+    "using_history()",
+    "return he;,returnhe;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "sv_region_start_color",
+   "stmts": [
+    "_rl_reset_region_color()",
+    "return (_rl_reset_region_color(0,value));,return(_rl_reset_region_color(0,value));"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "sv_region_end_color",
+   "stmts": [
+    "_rl_reset_region_color()",
+    "return (_rl_reset_region_color(1,value));,return(_rl_reset_region_color(1,value));"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "display_shell_version",
+   "stmts": [
+    "rl_crlf()",
+    "show_shell_version(0)",
+    "putc()",
+    "fflush(rl_outstream)",
+    "rl_on_new_line()",
+    "rl_redisplay()"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "emacs_edit_and_execute_command",
+   "stmts": [
+    "edit_and_execute_command()",
+    "return (edit_and_execute_command(count,c,1,...,return(edit_and_execute_command(count,c,1,..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "find_cmd_end",
+   "stmts": [
+    "<UnsupportedStmt: ['or', '0x001|0x100']>",
+    "skip_to_delim()",
+    "e = skip_to_delim(rl_line_buffer,end,&quot;;|&amp;{(`...",
+    "return e;,returne;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "test_for_directory",
+   "stmts": [
+    "bash_tilde_expand()",
+    "fn = bash_tilde_expand(name,0)",
+    "file_isdir(fn)",
+    "r = file_isdir(fn)",
+    "sh_xfree((fn)",
+    "return (r);,return(r);"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_ignore_filenames",
+   "stmts": [
+    "_ignore_completion_names()",
+    "return 0;,return0;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_progcomp_ignore_filenames",
+   "stmts": [
+    "_ignore_completion_names()",
+    "return 0;,return0;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "return_zero",
+   "stmts": [
+    "return 0;,return0;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_ignore_everything",
+   "stmts": [
+    "_ignore_completion_names()",
+    "return 0;,return0;"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_username",
+   "stmts": [
+    "rl_completion_mode(bash_complete_username)",
+    "bash_complete_username_internal()",
+    "return bash_complete_username_internal(rl_comp...,returnbash_complete_username_internal(rl_comp..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_possible_username_completions",
+   "stmts": [
+    "bash_complete_username_internal('?')",
+    "return bash_complete_username_internal('?');,returnbash_complete_username_internal('?');"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_username_internal",
+   "stmts": [
+    "bash_specific_completion()",
+    "return bash_specific_completion(what_to_do,rl...,returnbash_specific_completion(what_to_do,rl..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_filename",
+   "stmts": [
+    "rl_completion_mode(bash_complete_filename)",
+    "bash_complete_filename_internal()",
+    "return bash_complete_filename_internal(rl_comp...,returnbash_complete_filename_internal(rl_comp..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_possible_filename_completions",
+   "stmts": [
+    "bash_complete_filename_internal('?')",
+    "return bash_complete_filename_internal('?');,returnbash_complete_filename_internal('?');"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_filename_internal",
+   "stmts": [
+    "orig_func = rl_completion_entry_function",
+    "orig_attempt_func = rl_attempted_completion_fun...",
+    "orig_ignore_func = rl_ignore_some_completions_f...",
+    "orig_rl_completer_word_break_characters = rl_co...",
+    "save_directory_hook()",
+    "orig_dir_func = save_directory_hook()"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_hostname",
+   "stmts": [
+    "rl_completion_mode(bash_complete_hostname)",
+    "bash_complete_hostname_internal()",
+    "return bash_complete_hostname_internal(rl_comp...,returnbash_complete_hostname_internal(rl_comp..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_possible_hostname_completions",
+   "stmts": [
+    "bash_complete_hostname_internal('?')",
+    "return bash_complete_hostname_internal('?');,returnbash_complete_hostname_internal('?');"
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_complete_variable",
+   "stmts": [
+    "rl_completion_mode(bash_complete_variable)",
+    "bash_complete_variable_internal()",
+    "return bash_complete_variable_internal(rl_comp...,returnbash_complete_variable_internal(rl_comp..."
+   ]
+  },
+  {
+   "project": "bash",
+   "function": "bash_possible_variable_completions",
+   "stmts": [
+    "bash_complete_variable_internal('?')",
+    "return bash_complete_variable_internal('?');,returnbash_complete_variable_internal('?');"
+   ]
+  }
+ ],
+ "marker_kinds": {
+  "Nop": 22176,
+  "UnsupportedStmt": 12192,
+  "Call": 2242,
+  "Assignment": 1397,
+  "Return": 1040,
+  "Compare": 177,
+  "BinOp": 108,
+  "Ternary": 25
+ }
+}

--- a/docs/joern_failures/cat1_inf_evals.json
+++ b/docs/joern_failures/cat1_inf_evals.json
@@ -1,0 +1,60 @@
+{
+ "total_evals": 225753,
+ "finite": 105236,
+ "inf": 120517,
+ "inf_by_opt": {
+  "O2": 34409,
+  "O0": 43643,
+  "O2-noinline": 42465
+ },
+ "inf_kind": {
+  "straightline": 24023,
+  "empty_proto": 96494
+ },
+ "inf_by_dec": {
+  "kuna": 22499,
+  "ida": 28381,
+  "phoenix": 18553,
+  "angr": 17933,
+  "ghidra": 28681,
+  "binja": 4470
+ },
+ "fin_by_dec": {
+  "kuna": 19375,
+  "ida": 23442,
+  "phoenix": 16758,
+  "angr": 16452,
+  "binja": 6138,
+  "ghidra": 23071
+ },
+ "inf_by_project": {
+  "sysvinit": 817,
+  "coreutils": 12542,
+  "diffutils": 474,
+  "zlib": 6136,
+  "shadow": 976,
+  "rsyslog": 617,
+  "e2fsprogs": 1823,
+  "gnutls": 5186,
+  "openssh-portable": 57111,
+  "libacl": 1438,
+  "bzip2": 784,
+  "bash": 8181,
+  "cronie": 2064,
+  "libexpat": 474,
+  "dpkg": 2901,
+  "base-passwd": 138,
+  "iproute2": 2345,
+  "findutils": 1775,
+  "libedit": 4707,
+  "gzip": 1192,
+  "libbsd": 260,
+  "kmod": 173,
+  "grep": 407,
+  "libselinux": 4053,
+  "tar": 3943
+ },
+ "distinct_only_inf": 14016,
+ "distinct_ever_finite": 14508,
+ "distinct_mixed": 0
+}

--- a/docs/joern_failures/cat1b_recoverable_evals.json
+++ b/docs/joern_failures/cat1b_recoverable_evals.json
@@ -1,0 +1,17 @@
+{
+ "degenerate_projfunc": 11023,
+ "recoverable_strict": 2579,
+ "recoverable_loose": 3394,
+ "inf_total": 120517,
+ "inf_recoverable_strict": 77236,
+ "inf_recoverable_loose": 92774,
+ "inf_rec_strict_by_dec": {
+  "kuna": 14449,
+  "ida": 18297,
+  "phoenix": 11791,
+  "ghidra": 18528,
+  "angr": 11364,
+  "binja": 2807
+ },
+ "current_finite": 105236
+}

--- a/docs/joern_failures/cat2_collisions.json
+++ b/docs/joern_failures/cat2_collisions.json
@@ -1,0 +1,1142 @@
+{
+ "true_collision_groups": 508,
+ "harmless_dup_groups": 5615,
+ "wrong_source_evals_upper": 11665,
+ "wrong_source_evals_finite": 8457,
+ "per_project": {
+  "diffutils": {
+   "collision_groups": 9,
+   "wrong_source_evals": 157
+  },
+  "openssh-portable": {
+   "collision_groups": 224,
+   "wrong_source_evals": 2493
+  },
+  "gnutls": {
+   "collision_groups": 57,
+   "wrong_source_evals": 836
+  },
+  "bzip2": {
+   "collision_groups": 7,
+   "wrong_source_evals": 38
+  },
+  "iproute2": {
+   "collision_groups": 6,
+   "wrong_source_evals": 32
+  },
+  "coreutils": {
+   "collision_groups": 81,
+   "wrong_source_evals": 4481
+  },
+  "shadow": {
+   "collision_groups": 51,
+   "wrong_source_evals": 2461
+  },
+  "libacl": {
+   "collision_groups": 22,
+   "wrong_source_evals": 148
+  },
+  "zlib": {
+   "collision_groups": 5,
+   "wrong_source_evals": 138
+  },
+  "dpkg": {
+   "collision_groups": 11,
+   "wrong_source_evals": 204
+  },
+  "sysvinit": {
+   "collision_groups": 16,
+   "wrong_source_evals": 449
+  },
+  "cronie": {
+   "collision_groups": 11,
+   "wrong_source_evals": 102
+  },
+  "bash": {
+   "collision_groups": 8,
+   "wrong_source_evals": 126
+  }
+ },
+ "worst_names": [
+  {
+   "project": "coreutils",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 108,
+   "skel_variants": 97,
+   "cached_nodes": 34,
+   "wrong_evals": 635
+  },
+  {
+   "project": "coreutils",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 108,
+   "skel_variants": 97,
+   "cached_nodes": 34,
+   "wrong_evals": 634
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 107,
+   "skel_variants": 54,
+   "cached_nodes": 4,
+   "wrong_evals": 623
+  },
+  {
+   "project": "coreutils",
+   "opt": "O2",
+   "func": "usage",
+   "binaries": 107,
+   "skel_variants": 58,
+   "cached_nodes": 4,
+   "wrong_evals": 621
+  },
+  {
+   "project": "coreutils",
+   "opt": "O2-noinline",
+   "func": "usage",
+   "binaries": 107,
+   "skel_variants": 54,
+   "cached_nodes": 4,
+   "wrong_evals": 617
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 108,
+   "skel_variants": 99,
+   "cached_nodes": 34,
+   "wrong_evals": 613
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 40,
+   "skel_variants": 38,
+   "cached_nodes": 56,
+   "wrong_evals": 234
+  },
+  {
+   "project": "shadow",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 40,
+   "skel_variants": 40,
+   "cached_nodes": 56,
+   "wrong_evals": 233
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 40,
+   "skel_variants": 39,
+   "cached_nodes": 56,
+   "wrong_evals": 233
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 35,
+   "skel_variants": 15,
+   "cached_nodes": 1,
+   "wrong_evals": 204
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "usage",
+   "binaries": 35,
+   "skel_variants": 13,
+   "cached_nodes": 1,
+   "wrong_evals": 204
+  },
+  {
+   "project": "shadow",
+   "opt": "O2",
+   "func": "usage",
+   "binaries": 33,
+   "skel_variants": 13,
+   "cached_nodes": 1,
+   "wrong_evals": 191
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "process_flags",
+   "binaries": 22,
+   "skel_variants": 18,
+   "cached_nodes": 163,
+   "wrong_evals": 126
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "process_flags",
+   "binaries": 22,
+   "skel_variants": 18,
+   "cached_nodes": 163,
+   "wrong_evals": 125
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "fail_exit",
+   "binaries": 17,
+   "skel_variants": 5,
+   "cached_nodes": 55,
+   "wrong_evals": 96
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "open_files",
+   "binaries": 14,
+   "skel_variants": 10,
+   "cached_nodes": 33,
+   "wrong_evals": 78
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "close_files",
+   "binaries": 14,
+   "skel_variants": 12,
+   "cached_nodes": 112,
+   "wrong_evals": 78
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 14,
+   "skel_variants": 14,
+   "cached_nodes": 39,
+   "wrong_evals": 78
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 14,
+   "skel_variants": 14,
+   "cached_nodes": 39,
+   "wrong_evals": 78
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 14,
+   "skel_variants": 14,
+   "cached_nodes": 39,
+   "wrong_evals": 78
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "open_files",
+   "binaries": 14,
+   "skel_variants": 13,
+   "cached_nodes": 33,
+   "wrong_evals": 71
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 12,
+   "skel_variants": 12,
+   "cached_nodes": 275,
+   "wrong_evals": 66
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "close_files",
+   "binaries": 14,
+   "skel_variants": 13,
+   "cached_nodes": 112,
+   "wrong_evals": 65
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 12,
+   "skel_variants": 12,
+   "cached_nodes": 275,
+   "wrong_evals": 64
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "check_perms",
+   "binaries": 11,
+   "skel_variants": 8,
+   "cached_nodes": 36,
+   "wrong_evals": 60
+  },
+  {
+   "project": "shadow",
+   "opt": "O2",
+   "func": "fail_exit",
+   "binaries": 12,
+   "skel_variants": 4,
+   "cached_nodes": 55,
+   "wrong_evals": 55
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "fail_exit",
+   "binaries": 12,
+   "skel_variants": 4,
+   "cached_nodes": 55,
+   "wrong_evals": 55
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 12,
+   "skel_variants": 12,
+   "cached_nodes": 275,
+   "wrong_evals": 53
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "sshfatal",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 49
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "cleanup_exit",
+   "binaries": 12,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 49
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 9,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 48
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 9,
+   "skel_variants": 9,
+   "cached_nodes": 91,
+   "wrong_evals": 48
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "tilde_expand_filename",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 48
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 9,
+   "skel_variants": 8,
+   "cached_nodes": 91,
+   "wrong_evals": 48
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O2-noinline",
+   "func": "usage",
+   "binaries": 9,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 48
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sshlogdie",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "xmalloc",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 5,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "xcalloc",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 9,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "xreallocarray",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 3,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "xrecallocarray",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 3,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "xvasprintf",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 5,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "cleanup_exit",
+   "binaries": 12,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 47
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "split_3",
+   "binaries": 9,
+   "skel_variants": 3,
+   "cached_nodes": 34,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "sshfatal",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 47
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "put_host_port",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "addargs",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "replacearg",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "tilde_expand_filename",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "vdollar_percent_expand",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 63,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "percent_expand",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 3,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "percent_dollar_expand",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 3,
+   "wrong_evals": 46
+  },
+  {
+   "project": "gnutls",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 9,
+   "skel_variants": 8,
+   "cached_nodes": 91,
+   "wrong_evals": 46
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "mktemp_proto",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 45
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "tilde_expand_filename",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 45
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "argv_assemble",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 44
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "child_set_env",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 44
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "opt_array_append2",
+   "binaries": 12,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 42
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "cleanup_exit",
+   "binaries": 11,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 42
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "output_file",
+   "binaries": 8,
+   "skel_variants": 3,
+   "cached_nodes": 1,
+   "wrong_evals": 41
+  },
+  {
+   "project": "coreutils",
+   "opt": "O2-noinline",
+   "func": "split_3",
+   "binaries": 8,
+   "skel_variants": 3,
+   "cached_nodes": 34,
+   "wrong_evals": 40
+  },
+  {
+   "project": "gnutls",
+   "opt": "O0",
+   "func": "process_options",
+   "binaries": 8,
+   "skel_variants": 8,
+   "cached_nodes": 1,
+   "wrong_evals": 38
+  },
+  {
+   "project": "gnutls",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 8,
+   "skel_variants": 6,
+   "cached_nodes": 1,
+   "wrong_evals": 38
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2-noinline",
+   "func": "usage",
+   "binaries": 8,
+   "skel_variants": 6,
+   "cached_nodes": 1,
+   "wrong_evals": 38
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2-noinline",
+   "func": "process_options",
+   "binaries": 8,
+   "skel_variants": 8,
+   "cached_nodes": 1,
+   "wrong_evals": 38
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2",
+   "func": "usage",
+   "binaries": 8,
+   "skel_variants": 6,
+   "cached_nodes": 1,
+   "wrong_evals": 37
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2",
+   "func": "process_options",
+   "binaries": 8,
+   "skel_variants": 8,
+   "cached_nodes": 1,
+   "wrong_evals": 36
+  },
+  {
+   "project": "sysvinit",
+   "opt": "O2",
+   "func": "usage",
+   "binaries": 7,
+   "skel_variants": 4,
+   "cached_nodes": 1,
+   "wrong_evals": 36
+  },
+  {
+   "project": "bash",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 7,
+   "skel_variants": 7,
+   "cached_nodes": 150,
+   "wrong_evals": 35
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "sshsk_load_resident",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 35
+  },
+  {
+   "project": "bash",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 7,
+   "skel_variants": 7,
+   "cached_nodes": 150,
+   "wrong_evals": 35
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "sshsk_enroll",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 35
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "sshsk_sign",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 35
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "sshsk_load_resident",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 35
+  },
+  {
+   "project": "bash",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 7,
+   "skel_variants": 7,
+   "cached_nodes": 150,
+   "wrong_evals": 35
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sshsk_enroll",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 34
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sshsk_sign",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 34
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sshsk_load_resident",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 34
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "sshsk_enroll",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 34
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "sshsk_sign",
+   "binaries": 9,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 34
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sys_tun_infilter",
+   "binaries": 10,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 32
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "sys_tun_outfilter",
+   "binaries": 10,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 32
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "check_flags",
+   "binaries": 6,
+   "skel_variants": 6,
+   "cached_nodes": 1,
+   "wrong_evals": 30
+  },
+  {
+   "project": "zlib",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 6,
+   "skel_variants": 2,
+   "cached_nodes": 53,
+   "wrong_evals": 30
+  },
+  {
+   "project": "zlib",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 6,
+   "skel_variants": 2,
+   "cached_nodes": 53,
+   "wrong_evals": 30
+  },
+  {
+   "project": "zlib",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 6,
+   "skel_variants": 2,
+   "cached_nodes": 53,
+   "wrong_evals": 30
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "check_perms",
+   "binaries": 6,
+   "skel_variants": 6,
+   "cached_nodes": 36,
+   "wrong_evals": 29
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "errno_unsupported",
+   "binaries": 6,
+   "skel_variants": 2,
+   "cached_nodes": 5,
+   "wrong_evals": 25
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "grp_update",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 2,
+   "wrong_evals": 24
+  },
+  {
+   "project": "zlib",
+   "opt": "O2",
+   "func": "inflateReset2",
+   "binaries": 5,
+   "skel_variants": 2,
+   "cached_nodes": 18,
+   "wrong_evals": 24
+  },
+  {
+   "project": "zlib",
+   "opt": "O2",
+   "func": "inflateSync",
+   "binaries": 5,
+   "skel_variants": 2,
+   "cached_nodes": 17,
+   "wrong_evals": 24
+  },
+  {
+   "project": "dpkg",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 5,
+   "skel_variants": 4,
+   "cached_nodes": 3,
+   "wrong_evals": 24
+  },
+  {
+   "project": "dpkg",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 5,
+   "skel_variants": 4,
+   "cached_nodes": 3,
+   "wrong_evals": 24
+  },
+  {
+   "project": "dpkg",
+   "opt": "O0",
+   "func": "printversion",
+   "binaries": 5,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 23
+  },
+  {
+   "project": "dpkg",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 1,
+   "wrong_evals": 23
+  },
+  {
+   "project": "dpkg",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 5,
+   "skel_variants": 4,
+   "cached_nodes": 3,
+   "wrong_evals": 23
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "grp_update",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 2,
+   "wrong_evals": 23
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "send_msg",
+   "binaries": 6,
+   "skel_variants": 4,
+   "cached_nodes": 2,
+   "wrong_evals": 22
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O0",
+   "func": "seed_rng",
+   "binaries": 8,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 22
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2",
+   "func": "send_msg",
+   "binaries": 6,
+   "skel_variants": 3,
+   "cached_nodes": 2,
+   "wrong_evals": 22
+  },
+  {
+   "project": "dpkg",
+   "opt": "O2",
+   "func": "printversion",
+   "binaries": 5,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 22
+  },
+  {
+   "project": "openssh-portable",
+   "opt": "O2-noinline",
+   "func": "send_msg",
+   "binaries": 6,
+   "skel_variants": 3,
+   "cached_nodes": 2,
+   "wrong_evals": 22
+  },
+  {
+   "project": "coreutils",
+   "opt": "O2-noinline",
+   "func": "cleanup",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 18,
+   "wrong_evals": 22
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "cleanup",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 18,
+   "wrong_evals": 21
+  },
+  {
+   "project": "gnutls",
+   "opt": "O2-noinline",
+   "func": "cmd_parser",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 49,
+   "wrong_evals": 21
+  },
+  {
+   "project": "dpkg",
+   "opt": "O2-noinline",
+   "func": "printversion",
+   "binaries": 5,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 21
+  },
+  {
+   "project": "gnutls",
+   "opt": "O0",
+   "func": "cmd_parser",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 49,
+   "wrong_evals": 20
+  },
+  {
+   "project": "shadow",
+   "opt": "O0",
+   "func": "catch_signals",
+   "binaries": 4,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 18
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2",
+   "func": "main",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 59,
+   "wrong_evals": 18
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2",
+   "func": "try_help",
+   "binaries": 4,
+   "skel_variants": 2,
+   "cached_nodes": 12,
+   "wrong_evals": 18
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2-noinline",
+   "func": "main",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 59,
+   "wrong_evals": 18
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2-noinline",
+   "func": "try_help",
+   "binaries": 4,
+   "skel_variants": 3,
+   "cached_nodes": 12,
+   "wrong_evals": 18
+  },
+  {
+   "project": "shadow",
+   "opt": "O2-noinline",
+   "func": "catch_signals",
+   "binaries": 4,
+   "skel_variants": 2,
+   "cached_nodes": 1,
+   "wrong_evals": 18
+  },
+  {
+   "project": "diffutils",
+   "opt": "O0",
+   "func": "try_help",
+   "binaries": 4,
+   "skel_variants": 3,
+   "cached_nodes": 12,
+   "wrong_evals": 17
+  },
+  {
+   "project": "diffutils",
+   "opt": "O0",
+   "func": "usage",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 7,
+   "wrong_evals": 17
+  },
+  {
+   "project": "diffutils",
+   "opt": "O0",
+   "func": "main",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 59,
+   "wrong_evals": 17
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "process_signals",
+   "binaries": 4,
+   "skel_variants": 2,
+   "cached_nodes": 8,
+   "wrong_evals": 17
+  },
+  {
+   "project": "coreutils",
+   "opt": "O0",
+   "func": "process_file",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 7,
+   "wrong_evals": 17
+  },
+  {
+   "project": "dpkg",
+   "opt": "O2",
+   "func": "usage",
+   "binaries": 5,
+   "skel_variants": 5,
+   "cached_nodes": 1,
+   "wrong_evals": 17
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2-noinline",
+   "func": "usage",
+   "binaries": 4,
+   "skel_variants": 4,
+   "cached_nodes": 7,
+   "wrong_evals": 17
+  },
+  {
+   "project": "diffutils",
+   "opt": "O2-noinline",
+   "func": "check_stdout",
+   "binaries": 4,
+   "skel_variants": 3,
+   "cached_nodes": 4,
+   "wrong_evals": 17
+  }
+ ]
+}

--- a/docs/joern_failures/cat3_binja_loading.json
+++ b/docs/joern_failures/cat3_binja_loading.json
@@ -1,0 +1,350 @@
+{
+ "by_opt": {
+  "O0": {
+   "functions": 24757,
+   "loading": 18018
+  },
+  "O2": {
+   "functions": 18167,
+   "loading": 14162
+  },
+  "O2-noinline": {
+   "functions": 23571,
+   "loading": 17809
+  }
+ },
+ "grand": {
+  "functions": 66495,
+  "loading": 49989,
+  "pct": 75.2
+ },
+ "o0_per_project": {
+  "gzip": {
+   "total": 150,
+   "loading": 0
+  },
+  "diffutils": {
+   "total": 172,
+   "loading": 85
+  },
+  "mirai": {
+   "total": 68,
+   "loading": 0
+  },
+  "openssh-portable": {
+   "total": 7554,
+   "loading": 7524
+  },
+  "gnutls": {
+   "total": 871,
+   "loading": 574
+  },
+  "bzip2": {
+   "total": 120,
+   "loading": 44
+  },
+  "libedit": {
+   "total": 513,
+   "loading": 467
+  },
+  "mydoom": {
+   "total": 168,
+   "loading": 0
+  },
+  "iproute2": {
+   "total": 762,
+   "loading": 757
+  },
+  "libexpat": {
+   "total": 58,
+   "loading": 13
+  },
+  "coreutils": {
+   "total": 2845,
+   "loading": 1448
+  },
+  "x0r-usb": {
+   "total": 34,
+   "loading": 0
+  },
+  "shadow": {
+   "total": 312,
+   "loading": 0
+  },
+  "cleanflight": {
+   "total": 1915,
+   "loading": 1911
+  },
+  "libacl": {
+   "total": 144,
+   "loading": 0
+  },
+  "zlib": {
+   "total": 779,
+   "loading": 0
+  },
+  "dpkg": {
+   "total": 354,
+   "loading": 238
+  },
+  "riot-os": {
+   "total": 66,
+   "loading": 0
+  },
+  "e2fsprogs": {
+   "total": 409,
+   "loading": 409
+  },
+  "sysvinit": {
+   "total": 195,
+   "loading": 0
+  },
+  "libselinux": {
+   "total": 418,
+   "loading": 0
+  },
+  "chibios": {
+   "total": 415,
+   "loading": 0
+  },
+  "mirai-win": {
+   "total": 54,
+   "loading": 0
+  },
+  "freertos": {
+   "total": 38,
+   "loading": 0
+  },
+  "tar": {
+   "total": 654,
+   "loading": 646
+  },
+  "base-passwd": {
+   "total": 48,
+   "loading": 0
+  },
+  "libbsd": {
+   "total": 67,
+   "loading": 0
+  },
+  "grep": {
+   "total": 109,
+   "loading": 100
+  },
+  "kmod": {
+   "total": 129,
+   "loading": 101
+  },
+  "crazyflie": {
+   "total": 179,
+   "loading": 1
+  },
+  "cronie": {
+   "total": 203,
+   "loading": 0
+  },
+  "libopencm3": {
+   "total": 1024,
+   "loading": 117
+  },
+  "nuttx": {
+   "total": 399,
+   "loading": 379
+  },
+  "minipig": {
+   "total": 74,
+   "loading": 0
+  },
+  "dexter": {
+   "total": 114,
+   "loading": 0
+  },
+  "betaflight": {
+   "total": 1737,
+   "loading": 1736
+  },
+  "bash": {
+   "total": 1153,
+   "loading": 1056
+  },
+  "findutils": {
+   "total": 313,
+   "loading": 274
+  },
+  "rsyslog": {
+   "total": 140,
+   "loading": 138
+  }
+ },
+ "full_loading_binaries": [
+  {
+   "opt": "O0",
+   "project": "openssh-portable",
+   "binary": "ssh",
+   "n": 742
+  },
+  {
+   "opt": "O0",
+   "project": "openssh-portable",
+   "binary": "scp",
+   "n": 399
+  },
+  {
+   "opt": "O0",
+   "project": "openssh-portable",
+   "binary": "ssh-add",
+   "n": 693
+  },
+  {
+   "opt": "O0",
+   "project": "openssh-portable",
+   "binary": "ssh-agent",
+   "n": 587
+  },
+  {
+   "opt": "O0",
+   "project": "openssh-portable",
+   "binary": "ssh-pkcs11-helper",
+   "n": 567
+  },
+  {
+   "opt": "O0",
+   "project": "iproute2",
+   "binary": "ip",
+   "n": 757
+  },
+  {
+   "opt": "O0",
+   "project": "coreutils",
+   "binary": "ls",
+   "n": 216
+  },
+  {
+   "opt": "O0",
+   "project": "dpkg",
+   "binary": "dpkg",
+   "n": 238
+  },
+  {
+   "opt": "O0",
+   "project": "e2fsprogs",
+   "binary": "e2fsck",
+   "n": 409
+  },
+  {
+   "opt": "O0",
+   "project": "crazyflie",
+   "binary": "CMSIS_DAP",
+   "n": 1
+  },
+  {
+   "opt": "O0",
+   "project": "bash",
+   "binary": "bash",
+   "n": 1053
+  },
+  {
+   "opt": "O2",
+   "project": "openssh-portable",
+   "binary": "ssh",
+   "n": 673
+  },
+  {
+   "opt": "O2",
+   "project": "openssh-portable",
+   "binary": "ssh-keysign",
+   "n": 628
+  },
+  {
+   "opt": "O2",
+   "project": "crazyflie",
+   "binary": "CMSIS_DAP",
+   "n": 1
+  },
+  {
+   "opt": "O2",
+   "project": "bash",
+   "binary": "bash",
+   "n": 965
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "openssh-portable",
+   "binary": "ssh",
+   "n": 735
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "openssh-portable",
+   "binary": "ssh-keysign",
+   "n": 826
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "openssh-portable",
+   "binary": "ssh-add",
+   "n": 658
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "openssh-portable",
+   "binary": "ssh-agent",
+   "n": 566
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "openssh-portable",
+   "binary": "ssh-pkcs11-helper",
+   "n": 544
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "iproute2",
+   "binary": "ip",
+   "n": 637
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "coreutils",
+   "binary": "[",
+   "n": 19
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "coreutils",
+   "binary": "who",
+   "n": 14
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "coreutils",
+   "binary": "rmdir",
+   "n": 7
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "cleanflight",
+   "binary": "cleanflight_DALRCF405",
+   "n": 1865
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "e2fsprogs",
+   "binary": "e2fsck",
+   "n": 379
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "crazyflie",
+   "binary": "CMSIS_DAP",
+   "n": 1
+  },
+  {
+   "opt": "O2-noinline",
+   "project": "bash",
+   "binary": "bash",
+   "n": 1025
+  }
+ ],
+ "num_full_loading_binaries": 28
+}

--- a/docs/joern_failures/cat4_and_recoverable.json
+++ b/docs/joern_failures/cat4_and_recoverable.json
@@ -1,0 +1,2470 @@
+{
+ "produced_nonloading": {
+  "angr": 35901,
+  "phoenix": 36843,
+  "ghidra": 52746,
+  "ida": 53253,
+  "binja": 10976,
+  "kuna": 42874
+ },
+ "loading": {
+  "binja": 37932
+ },
+ "src_missing": {
+  "angr": 991,
+  "phoenix": 991,
+  "ghidra": 954,
+  "ida": 963,
+  "binja": 326,
+  "kuna": 1000
+ },
+ "cat4_parsefail": {
+  "angr": 527,
+  "phoenix": 543,
+  "ghidra": 40,
+  "ida": 470,
+  "binja": 826
+ },
+ "cat4_samples": {
+  "angr": [
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "pqdownheap",
+    "cached_src_nodes": 17,
+    "snippet": "extern unsigned int g_4df200[1277633];\nextern char g_4dfaf4;\nextern char g_4dfb00;\n\nunsigned int [1277633] pqdownheap(unsigned long a0, unsigned int a1)\n{\n    unsigned int v0;  // [bp-0x24]\n    unsigned int i;  // [bp-0x10]\n    unsigned int v2[1277633];  // [bp-0xc]\n\n    v0 = a1;\n    v2 = (unsigned int [1277633])g_4df200[v0];\n    for (i = v0 * 2; i <= *((int *)&g_4dfaf4); i *= 2)\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "read_tree",
+    "cached_src_nodes": 21,
+    "snippet": "extern unsigned long long g_4e13e0;\nextern int g_4e13e8;\nextern char g_4e1400;\nextern unsigned int g_4e1500;\nextern unsigned int g_4e1580[4];\n\nunsigned int [4] read_tree(void)\n{\n    char v6;  // al\n    int iter;  // [bp-0x28]\n    unsigned int v1;  // [bp-0x24]\n    unsigned int v2;  // [bp-0x24]\n    unsigned int cur[4];  // [bp-0x20], Other Possible Types: int\n    unsigned int v4;  // [bp-0x1c]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "sdiff",
+    "func": "lf_skip",
+    "cached_src_nodes": 5,
+    "snippet": "void* [4] lf_skip(void* *p, unsigned long long a1)\n{\n    void* ptr[4];  // rax\n    unsigned long long i;  // [bp-0x18]\n\n    for (i = a1; i; ptr[1] = p[1] + 1)\n    {\n        p[1] = rawmemchr(p[1], 10);\n        if (p[1] == p[3])\n        {\n            ptr = sub_4042c0(p);\n            if (!ptr)\n                return ptr;\n        }"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "cmp",
+    "func": "file_position",
+    "cached_src_nodes": 3,
+    "snippet": "extern unsigned int g_4100b0[4];\nextern unsigned long long g_410200[4];\nextern char g_410215;\nextern unsigned long long g_410220[4];\n\nunsigned long long [4] file_position(unsigned int a0)\n{\n    if (*(&(&g_410215)[a0]) != 1)\n    {\n        *(&(&g_410215)[a0]) = 1;\n        g_410220[a0] = lseek(g_4100b0[a0], g_410200[a0], 1);\n    }\n    return g_410220[a0];\n}"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff3",
+    "func": "scan_diff_line",
+    "cached_src_nodes": 17,
+    "snippet": "typedef struct struct_0 {\n    char padding_0[1];\n    char field_1;\n    char field_2;\n    char field_3;\n    char field_4;\n} struct_0;\n\ntypedef struct FILE {\n} FILE;\n\nextern char g_41410b;\nextern char *g_424148;\nextern FILE *stderr;"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "add_change",
+    "cached_src_nodes": 1,
+    "snippet": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)\n{\n    unsigned long long ptr[5];  // [bp-0x10]\n\n    ptr = sub_41c945(48);\n    ptr[3] = a0;\n    ptr[4] = a1;\n    ptr[1] = a3;\n    ptr[2] = a2;\n    ptr[0] = a4;\n    return ptr;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "build_reverse_script",
+    "cached_src_nodes": 13,
+    "snippet": "typedef struct struct_0 {\n    char padding_0[200];\n    long long field_c8;\n    char padding_d0[72];\n    unsigned long long field_118;\n    char padding_120[216];\n    long long field_1f8;\n    char padding_200[72];\n    unsigned long long field_248;\n} struct_0;\n\nunsigned long long [5] build_reverse_script(struct_0 *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x50]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "build_script",
+    "cached_src_nodes": 13,
+    "snippet": "unsigned long long [5] build_script(unsigned long long *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x40]\n    unsigned long cur;  // [bp-0x38], Other Possible Types: unsigned long long\n    unsigned long iter;  // [bp-0x30], Other Possible Types: unsigned long long\n    unsigned long v3;  // [bp-0x28]\n    unsigned long v4;  // [bp-0x20]\n    unsigned long v5;  // [bp-0x18]\n    unsigned long v6;  // [bp-0x10]\n\n    v0 = NULL;\n    v3 = ptr[35];\n    v4 = ptr[73];\n    cur = ptr[25];"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "do_printf_spec",
+    "cached_src_nodes": 30,
+    "snippet": "typedef struct FILE {\n} FILE;\n\nchar [2] do_printf_spec(FILE *a0, char *a1, long long a2, long long a3, long long *a4)\n{\n    char ptr[2];  // rax\n    char p[2];  // rax\n    char addr[2];  // rax\n    char ptr3[2];  // rax\n    unsigned int v18;  // eax\n    unsigned long v19;  // rax\n    unsigned long long v20;  // rax\n    unsigned long long v21;  // rax\n    char v0;  // [bp-0x1088]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "scan_char_literal",
+    "cached_src_nodes": 14,
+    "snippet": "char [2] scan_char_literal(char *ptr, char *p)\n{\n    char v5[2];  // rbx\n    char v7[2];  // rax\n    char addr[2];  // rax\n    char v0;  // [bp-0x1e]\n    char v1;  // [bp-0x1d]\n    unsigned int v2;  // [bp-0x1c]\n    long long v3;  // [bp-0x18]\n\n    v5 = ptr + 1;\n    v1 = *(ptr);\n    switch (v1)\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "c_escape",
+    "cached_src_nodes": 18,
+    "snippet": "char [5] c_escape(char *a0)\n{\n    unsigned int flag;  // eax\n    unsigned int choice;  // eax\n    char ptr[5];  // rax\n    char p[5];  // rax\n    char addr[5];  // rax\n    char ptr5[5];  // rax\n    char v0;  // [bp-0x34]\n    char v1;  // [bp-0x33]\n    char v2;  // [bp-0x32]\n    char v3;  // [bp-0x31]\n    char iter[5];  // [bp-0x30]\n    unsigned long long node;  // [bp-0x28]"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "log_facility_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_471020[4];\nextern unsigned int g_471028[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_471020[2 * i]; i = sub_449b30(i, 1))\n        {\n            if (!strcasecmp(g_471020[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "log_facility_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_471020[4];\nextern unsigned int g_471028[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_471020[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "log_level_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_471100[4];\nextern unsigned int g_471108[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_471100[2 * i]; i = sub_449b30(i, 1))\n        {\n            if (!strcasecmp(g_471100[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "log_level_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_471100[4];\nextern unsigned int g_471108[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_471100[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "hpdelim2",
+    "cached_src_nodes": 1,
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (!ptr || !*(ptr))\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "hpdelim",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_4281f9(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "colon",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "iptos2str",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_4701c0[4];\nextern unsigned int g_4701c8[4];\nextern unsigned long long g_47128c[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_4701c0[2 * v0])\n        {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "chachapoly_new",
+    "cached_src_nodes": 12,
+    "snippet": "long long [2] chachapoly_new(long long a0, unsigned int a1)\n{\n    long long v2[2];  // rax\n    long long v3;  // rax\n    long long v4;  // rax\n    long long ptr[2];  // [bp-0x20]\n\n    if (a1 != 64)\n    {\n        v2 = NULL;\n    }\n    else\n    {\n        ptr = calloc(1, 16);"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "ssh_digest_alg_by_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned int g_470560[4];\nextern unsigned long long g_470568[4];\n\nunsigned int [4] ssh_digest_alg_by_name(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (g_470560[8 * v0] == 0xffffffff)\n        {\n            v2 = 0xffffffff;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "status_to_message",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_434740[4];\n\nunsigned long long [4] status_to_message(unsigned int a0)\n{\n    unsigned int v1;  // eax\n\n    v1 = a0;\n    if (8 < v1)\n        v1 = 8;\n    [D] PutI(904:F64x8)[t44,0] = t47()\n    [D] PutI(968:I8x8)[t44,0] = 0x01()\n    [D] PutI(904:F64x8)[t54,0] = t57()\n    [D] PutI(968:I8x8)[t54,0] = 0x01()\n    [D] PutI(904:F64x8)[t64,0] = t67()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_facility_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_435040[2 * i]; i = sub_42bbc0(i, 1))\n        {\n            if (!strcasecmp(g_435040[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_facility_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435040[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_level_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_435120[2 * i]; i = sub_42bbc0(i, 1))\n        {\n            if (!strcasecmp(g_435120[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_level_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435120[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "hpdelim2",
+    "cached_src_nodes": 1,
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (!ptr || !*(ptr))\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "hpdelim",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_41aada(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "colon",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "iptos2str",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_4347a0[4];\nextern unsigned int g_4347a8[4];\nextern unsigned long long g_43540c[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_4347a0[2 * v0])\n        {"
+   }
+  ],
+  "phoenix": [
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "pqdownheap",
+    "cached_src_nodes": 17,
+    "snippet": "extern unsigned int g_4df200[1277633];\nextern char g_4dfaf4;\nextern char g_4dfb00;\n\nunsigned int [1277633] pqdownheap(unsigned long a0, unsigned int a1)\n{\n    unsigned int v0;  // [bp-0x24]\n    unsigned int i;  // [bp-0x10]\n    unsigned int v2[1277633];  // [bp-0xc]\n\n    v0 = a1;\n    v2 = (unsigned int [1277633])g_4df200[v0];\n    for (i = v0 * 2; i <= *((int *)&g_4dfaf4); i *= 2)\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "read_tree",
+    "cached_src_nodes": 21,
+    "snippet": "extern unsigned long long g_4e13e0;\nextern int g_4e13e8;\nextern char g_4e1400;\nextern unsigned int g_4e1500;\nextern unsigned int g_4e1580[4];\n\nunsigned int [4] read_tree(void)\n{\n    char v6;  // al\n    int iter;  // [bp-0x28]\n    unsigned int v1;  // [bp-0x24]\n    unsigned int v2;  // [bp-0x24]\n    unsigned int cur[4];  // [bp-0x20], Other Possible Types: int\n    unsigned int v4;  // [bp-0x1c]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff3",
+    "func": "scan_diff_line",
+    "cached_src_nodes": 17,
+    "snippet": "typedef struct struct_0 {\n    char padding_0[1];\n    char field_1;\n    char field_2;\n    char field_3;\n    char field_4;\n} struct_0;\n\ntypedef struct FILE {\n} FILE;\n\nextern char g_41410b;\nextern char *g_424148;\nextern FILE *stderr;"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "add_change",
+    "cached_src_nodes": 1,
+    "snippet": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)\n{\n    unsigned long long ptr[5];  // [bp-0x10]\n\n    ptr = sub_41c945(48);\n    ptr[3] = a0;\n    ptr[4] = a1;\n    ptr[1] = a3;\n    ptr[2] = a2;\n    ptr[0] = a4;\n    return ptr;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "build_reverse_script",
+    "cached_src_nodes": 13,
+    "snippet": "typedef struct struct_0 {\n    char padding_0[200];\n    long long field_c8;\n    char padding_d0[72];\n    unsigned long long field_118;\n    char padding_120[216];\n    long long field_1f8;\n    char padding_200[72];\n    unsigned long long field_248;\n} struct_0;\n\nunsigned long long [5] build_reverse_script(struct_0 *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x50]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "build_script",
+    "cached_src_nodes": 13,
+    "snippet": "unsigned long long [5] build_script(unsigned long long *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x40]\n    unsigned long cur;  // [bp-0x38], Other Possible Types: unsigned long long\n    unsigned long iter;  // [bp-0x30], Other Possible Types: unsigned long long\n    unsigned long v3;  // [bp-0x28]\n    unsigned long v4;  // [bp-0x20]\n    unsigned long v5;  // [bp-0x18]\n    unsigned long v6;  // [bp-0x10]\n\n    v0 = NULL;\n    v3 = ptr[35];\n    v4 = ptr[73];\n    cur = ptr[25];"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "do_printf_spec",
+    "cached_src_nodes": 30,
+    "snippet": "typedef struct FILE {\n} FILE;\n\nchar [2] do_printf_spec(FILE *a0, char *a1, long long a2, long long a3, long long *a4)\n{\n    char ptr[2];  // rax\n    char p[2];  // rax\n    char addr[2];  // rax\n    char ptr3[2];  // rax\n    unsigned int v18;  // eax\n    unsigned long v19;  // rax\n    unsigned long long v20;  // rax\n    unsigned long long v21;  // rax\n    char v0;  // [bp-0x1088]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "scan_char_literal",
+    "cached_src_nodes": 14,
+    "snippet": "char [2] scan_char_literal(char *ptr, char *p)\n{\n    char v5[2];  // rbx\n    unsigned int v6;  // eax\n    char v7[2];  // rax\n    char addr[2];  // rax\n    char v0;  // [bp-0x1e]\n    char v1;  // [bp-0x1d]\n    unsigned int v2;  // [bp-0x1c]\n    long long v3;  // [bp-0x18]\n\n    v5 = ptr + 1;\n    v1 = *(ptr);\n    v6 = v1;"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "c_escape",
+    "cached_src_nodes": 18,
+    "snippet": "char [5] c_escape(char *a0)\n{\n    unsigned int flag;  // eax\n    unsigned int choice;  // eax\n    char ptr[5];  // rax\n    char p[5];  // rax\n    char addr[5];  // rax\n    char ptr5[5];  // rax\n    char v0;  // [bp-0x34]\n    char v1;  // [bp-0x33]\n    char v2;  // [bp-0x32]\n    char v3;  // [bp-0x31]\n    char iter[5];  // [bp-0x30]\n    unsigned long long node;  // [bp-0x28]"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "cmp",
+    "func": "file_position",
+    "cached_src_nodes": 3,
+    "snippet": "extern unsigned int g_4100b0[4];\nextern unsigned long long g_410200[4];\nextern char g_410215;\nextern unsigned long long g_410220[4];\n\nunsigned long long [4] file_position(unsigned int a0)\n{\n    if (*(&(&g_410215)[a0]) != 1)\n    {\n        *(&(&g_410215)[a0]) = 1;\n        g_410220[a0] = lseek(g_4100b0[a0], g_410200[a0], 1);\n    }\n    return g_410220[a0];\n}"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "sdiff",
+    "func": "lf_skip",
+    "cached_src_nodes": 5,
+    "snippet": "void* [4] lf_skip(void* *p, unsigned long long a1)\n{\n    void* ptr[4];  // rax\n    unsigned long long v0;  // [bp-0x18]\n\n    v0 = a1;\n    while (true)\n    {\n        if (!v0)\n            return ptr;\n        p[1] = rawmemchr(p[1], 10);\n        if (p[1] == p[3])\n        {\n            ptr = sub_4042c0(p);"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "log_facility_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_47a020[4];\nextern unsigned int g_47a028[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_47a020[2 * v0])\n        {\n            if (!strcasecmp(g_47a020[2 * v0], a0))"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "log_facility_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_47a020[4];\nextern unsigned int g_47a028[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_47a020[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "log_level_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_47a100[4];\nextern unsigned int g_47a108[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_47a100[2 * v0])\n        {\n            if (!strcasecmp(g_47a100[2 * v0], a0))"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "log_level_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_47a100[4];\nextern unsigned int g_47a108[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_47a100[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "hpdelim2",
+    "cached_src_nodes": 1,
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (ptr)\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "hpdelim",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_42f8ac(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "colon",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "iptos2str",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_479020[4];\nextern unsigned int g_479028[4];\nextern unsigned long long g_47a2ec[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_479020[2 * v0])\n        {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "chachapoly_new",
+    "cached_src_nodes": 12,
+    "snippet": "long long [2] chachapoly_new(long long a0, unsigned int a1)\n{\n    long long v2[2];  // rax\n    long long v3;  // rax\n    long long v4;  // rax\n    long long ptr[2];  // [bp-0x20]\n\n    if (a1 != 64)\n    {\n        v2 = NULL;\n    }\n    else\n    {\n        ptr = calloc(1, 16);"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "func": "ssh_digest_alg_by_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned int g_4793c0[4];\nextern unsigned long long g_4793c8[4];\n\nunsigned int [4] ssh_digest_alg_by_name(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (g_4793c0[8 * v0] == 0xffffffff)\n        {\n            v2 = 0xffffffff;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "status_to_message",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_434740[4];\n\nunsigned long long [4] status_to_message(unsigned int a0)\n{\n    unsigned int v1;  // eax\n\n    v1 = a0;\n    if (8 < v1)\n        v1 = 8;\n    [D] PutI(904:F64x8)[t44,0] = t47()\n    [D] PutI(968:I8x8)[t44,0] = 0x01()\n    [D] PutI(904:F64x8)[t54,0] = t57()\n    [D] PutI(968:I8x8)[t54,0] = 0x01()\n    [D] PutI(904:F64x8)[t64,0] = t67()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_facility_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_435040[2 * v0])\n        {\n            if (!strcasecmp(g_435040[2 * v0], a0))"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_facility_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435040[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_level_number",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_435120[2 * v0])\n        {\n            if (!strcasecmp(g_435120[2 * v0], a0))"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "log_level_name",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435120[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "hpdelim2",
+    "cached_src_nodes": 1,
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (ptr)\n    {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "hpdelim",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_41aada(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "colon",
+    "cached_src_nodes": 1,
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "iptos2str",
+    "cached_src_nodes": 1,
+    "snippet": "extern unsigned long long g_4347a0[4];\nextern unsigned int g_4347a8[4];\nextern unsigned long long g_43540c[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_4347a0[2 * v0])\n        {"
+   }
+  ],
+  "ghidra": [
+   {
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "func": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  uint uVar1;\n  int iVar2;\n  time_t tVar3;\n  long lVar4;\n  void *__dest;\n  undefined1 auVar5 [16];\n  undefined4 local_24;\n  undefined4 uStack_c;\n  \n  tVar3 = time((time_t *)0x0);"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "stat",
+    "func": "neg_to_zero",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] neg_to_zero(undefined8 param_1,long param_2)\n\n{\n  undefined1 auVar1 [16];\n  \n  if (param_2 < 0) {\n    param_1 = 0;\n    param_2 = 0;\n  }\n  auVar1._8_8_ = param_2;\n  auVar1._0_8_ = param_1;\n  return auVar1;\n}"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "dir",
+    "func": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "dir",
+    "func": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "ls",
+    "func": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "ls",
+    "func": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "make-prime-list",
+    "func": "binvert",
+    "cached_src_nodes": 4,
+    "snippet": "\nundefined1  [16] binvert(ulong param_1,long param_2)\n\n{\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  undefined1 auVar3 [16];\n  undefined1 auVar4 [16];\n  undefined1 auVar5 [16];\n  ulong uVar6;\n  ulong uVar7;\n  ulong uVar8;\n  long lVar9;\n  ulong local_38;"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "vdir",
+    "func": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "vdir",
+    "func": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "tar",
+    "binary": "tar",
+    "func": "decode_timespec",
+    "cached_src_nodes": 42,
+    "snippet": "\nundefined1  [16] decode_timespec(char *param_1,char **param_2,char param_3)\n\n{\n  undefined1 auVar1 [16];\n  int *piVar2;\n  uintmax_t uVar3;\n  bool bVar4;\n  bool local_42;\n  int local_40;\n  int local_3c;\n  uintmax_t local_38;\n  char *local_30;\n  "
+   },
+   {
+    "opt": "O2",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "concat",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] concat(char *param_1,char *param_2,char *param_3)\n\n{\n  size_t sVar1;\n  size_t sVar2;\n  size_t sVar3;\n  undefined1 auVar4 [16];\n  \n  sVar1 = strlen(param_1);\n  sVar2 = strlen(param_2);\n  sVar3 = strlen(param_3);\n  auVar4._0_8_ = FUN_00116a40(sVar1 + sVar2 + 1 + sVar3);\n  __sprintf_chk(auVar4._0_8_,1,0xffffffffffffffff,\"%s%s%s\",param_1,param_2,param_3);"
+   },
+   {
+    "opt": "O2",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "func": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  int iVar1;\n  time_t tVar2;\n  long lVar3;\n  void *__dest;\n  long lVar4;\n  int iVar5;\n  ulong __size;\n  void *pvVar6;\n  undefined1 auVar7 [16];\n  "
+   },
+   {
+    "opt": "O2",
+    "project": "libexpat",
+    "binary": "xmlwf",
+    "func": "metaLocation",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] metaLocation(undefined8 *param_1)\n\n{\n  undefined8 uVar1;\n  undefined1 auVar2 [16];\n  undefined4 uVar3;\n  long lVar4;\n  undefined8 uVar5;\n  undefined8 uVar6;\n  undefined8 uVar7;\n  \n  lVar4 = XML_GetBase();\n  uVar1 = *(undefined8 *)*param_1;"
+   },
+   {
+    "opt": "O2",
+    "project": "coreutils",
+    "binary": "true",
+    "func": "main",
+    "cached_src_nodes": 34,
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2,ulong param_3,ulong param_4)\n\n{\n  char *__s1;\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  int iVar3;\n  \n  if (param_1 != 2) {\n    auVar1._8_8_ = 0;\n    auVar1._0_8_ = param_3;\n    return auVar1 << 0x40;\n  }"
+   },
+   {
+    "opt": "O2",
+    "project": "coreutils",
+    "binary": "false",
+    "func": "main",
+    "cached_src_nodes": 34,
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2,undefined8 param_3,undefined8 param_4)\n\n{\n  char *__s1;\n  int iVar1;\n  undefined1 auVar2 [16];\n  undefined1 auVar3 [16];\n  \n  if (param_1 != 2) {\n    auVar2._8_8_ = param_3;\n    auVar2._0_8_ = 1;\n    return auVar2;\n  }"
+   },
+   {
+    "opt": "O2",
+    "project": "shadow",
+    "binary": "passwd",
+    "func": "main",
+    "cached_src_nodes": 56,
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2)\n\n{\n  undefined1 auVar1 [16];\n  FILE *__stream;\n  undefined8 *puVar2;\n  char cVar3;\n  __uid_t _Var4;\n  int iVar5;\n  __uid_t _Var6;\n  undefined8 *puVar7;\n  long lVar8;\n  char *pcVar9;"
+   },
+   {
+    "opt": "O2",
+    "project": "libselinux",
+    "binary": "libselinux.so",
+    "func": "regex_arch_string",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] regex_arch_string(undefined8 param_1,undefined8 param_2,undefined8 param_3)\n\n{\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  \n  if (*PTR_DAT_0012c820 != '\\0') {\n    auVar1._8_8_ = param_3;\n    auVar1._0_8_ = PTR_DAT_0012c820;\n    return auVar1;\n  }\n  __snprintf_chk(&DAT_0012dc20,0x20,1,0x20,\"%zu-%zu-%s\",8,8);\n  PTR_DAT_0012c820 = &DAT_0012dc20;"
+   },
+   {
+    "opt": "O2",
+    "project": "tar",
+    "binary": "tar",
+    "func": "tar_checksum",
+    "cached_src_nodes": 15,
+    "snippet": "\nundefined1  [16] tar_checksum(byte *param_1,byte param_2)\n\n{\n  byte bVar1;\n  int iVar2;\n  int iVar3;\n  byte *pbVar4;\n  int iVar5;\n  undefined8 uVar6;\n  undefined1 auVar7 [16];\n  undefined1 auVar8 [16];\n  undefined1 auVar9 [16];\n  "
+   },
+   {
+    "opt": "O2",
+    "project": "tar",
+    "binary": "tar",
+    "func": "decode_timespec",
+    "cached_src_nodes": 42,
+    "snippet": "\nundefined1  [16] decode_timespec(char *param_1,char **param_2,char param_3)\n\n{\n  char cVar1;\n  int iVar2;\n  int iVar3;\n  int *piVar4;\n  uintmax_t uVar5;\n  long lVar6;\n  char *pcVar7;\n  int iVar8;\n  uint uVar9;\n  int iVar10;"
+   },
+   {
+    "opt": "O2",
+    "project": "cronie",
+    "binary": "crond",
+    "func": "load_user",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1 (*) [16]\nload_user(int param_1,undefined8 param_2,undefined8 param_3,char *param_4,char *param_5)\n\n{\n  void *pvVar1;\n  undefined8 *puVar2;\n  undefined1 *puVar3;\n  int iVar4;\n  __pid_t _Var5;\n  FILE *__stream;\n  int *piVar6;\n  undefined1 (*__ptr) [16];\n  char *pcVar7;"
+   },
+   {
+    "opt": "O2",
+    "project": "cronie",
+    "binary": "cronnext",
+    "func": "load_user",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1 (*) [16]\nload_user(int param_1,undefined8 param_2,undefined8 param_3,char *param_4,char *param_5)\n\n{\n  void *pvVar1;\n  undefined8 *puVar2;\n  undefined1 *puVar3;\n  int iVar4;\n  __pid_t _Var5;\n  FILE *__stream;\n  int *piVar6;\n  undefined1 (*__ptr) [16];\n  char *pcVar7;"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "concat",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] concat(char *param_1,char *param_2,char *param_3)\n\n{\n  size_t sVar1;\n  size_t sVar2;\n  size_t sVar3;\n  undefined1 auVar4 [16];\n  \n  sVar1 = strlen(param_1);\n  sVar2 = strlen(param_2);\n  sVar3 = strlen(param_3);\n  auVar4._0_8_ = FUN_00115f50(sVar1 + sVar2 + 1 + sVar3);\n  __sprintf_chk(auVar4._0_8_,1,0xffffffffffffffff,\"%s%s%s\",param_1,param_2,param_3);"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "func": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  int iVar1;\n  time_t tVar2;\n  long lVar3;\n  void *__dest;\n  long lVar4;\n  int iVar5;\n  ulong __size;\n  void *pvVar6;\n  undefined1 auVar7 [16];\n  "
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "iproute2",
+    "binary": "ip",
+    "func": "tnl_print_stats",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1  [16] tnl_print_stats(undefined8 *param_1)\n\n{\n  undefined8 uVar1;\n  undefined1 auVar2 [16];\n  undefined8 uVar3;\n  \n  __printf_chk(1,&DAT_00184f09,_SL_);\n  __printf_chk(1,\"RX: Packets    Bytes        Errors CsumErrs OutOfSeq Mcasts%s\",_SL_);\n  __printf_chk(1,\"    %-10lld %-12lld %-6lld %-8lld %-8lld %-8lld%s\",*param_1,param_1[2],param_1[4],\n               param_1[0xd],param_1[0xe],param_1[8],_SL_);\n  __printf_chk(1,\"TX: Packets    Bytes        Errors DeadLoop NoRoute  NoBufs%s\",_SL_);\n  uVar1 = param_1[7];"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "iproute2",
+    "binary": "ip",
+    "func": "xfrm_stats_print",
+    "cached_src_nodes": 5,
+    "snippet": "\nundefined1  [16] xfrm_stats_print(undefined4 *param_1,FILE *param_2,char *param_3)\n\n{\n  undefined1 auVar1 [16];\n  undefined *puVar2;\n  \n  fputs(param_3,param_2);\n  __fprintf_chk(param_2,1,\"stats:%s\",_SL_);\n  fputs(param_3,param_2);\n  puVar2 = _SL_;\n  __fprintf_chk(param_2,1,\"  replay-window %u replay %u failed %u%s\",*param_1,param_1[1],param_1[2])\n  ;\n  auVar1._8_8_ = 0x13314d;"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "libexpat",
+    "binary": "xmlwf",
+    "func": "metaLocation",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] metaLocation(undefined8 *param_1)\n\n{\n  undefined8 uVar1;\n  undefined1 auVar2 [16];\n  undefined4 uVar3;\n  long lVar4;\n  undefined8 uVar5;\n  undefined8 uVar6;\n  undefined8 uVar7;\n  \n  lVar4 = XML_GetBase();\n  uVar1 = *(undefined8 *)*param_1;"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "true",
+    "func": "main",
+    "cached_src_nodes": 34,
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2,ulong param_3,ulong param_4)\n\n{\n  char *__s1;\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  int iVar3;\n  \n  if (param_1 != 2) {\n    auVar1._8_8_ = 0;\n    auVar1._0_8_ = param_3;\n    return auVar1 << 0x40;\n  }"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "stat",
+    "func": "neg_to_zero",
+    "cached_src_nodes": 3,
+    "snippet": "\nundefined1  [16] neg_to_zero(long param_1,long param_2)\n\n{\n  long lVar1;\n  long lVar2;\n  undefined1 auVar3 [16];\n  \n  lVar2 = 0;\n  lVar1 = lVar2;\n  if (-1 < param_2) {\n    lVar2 = param_2;\n    lVar1 = param_1;\n  }"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "sort",
+    "func": "key_init",
+    "cached_src_nodes": 1,
+    "snippet": "\nundefined1 (*) [16] key_init(undefined1 (*param_1) [16])\n\n{\n  *(undefined8 *)param_1[4] = 0;\n  param_1[1] = (undefined1  [16])0x0;\n  *param_1 = (undefined1  [16])0x0;\n  *(undefined8 *)param_1[1] = 0xffffffffffffffff;\n  param_1[2] = (undefined1  [16])0x0;\n  param_1[3] = (undefined1  [16])0x0;\n  return param_1;\n}\n\n"
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "dir",
+    "func": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "snippet": "\n/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */\n\nundefined1  [16] dev_ino_pop(void)\n\n{\n  long lVar1;\n  \n  lVar1 = DAT_001270f8;\n  if (0xf < (ulong)(DAT_001270f8 - _DAT_001270f0)) {\n    DAT_001270f8 = DAT_001270f8 + -0x10;\n    return *(undefined1 (*) [16])(lVar1 + -0x10);\n  }\n                    /* WARNING: Subroutine does not return */"
+   }
+  ],
+  "ida": [
+   {
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "func": "_el_fn_complete",
+    "cached_src_nodes": 1,
+    "snippet": "long long el_fn_complete(long long a1)\n{\n  return fn_complete(a1, 0, 0, U\" \\t\\n\\\"\\\\'`@$><=;|&{(\", 0, 0, 0x64u, 0, 0, 0, 0);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "func": "_rl_abort_internal",
+    "cached_src_nodes": 1,
+    "snippet": "void rl_abort_internal()\n{\n  el_beep(qword_478E0);\n  longjmp(env, 1);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "func": "_rl_qsort_string_compare",
+    "cached_src_nodes": 1,
+    "snippet": "int rl_qsort_string_compare(const char **a1, const char **a2)\n{\n  return strcoll(*a1, *a2);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "func": "_rl_erase_entire_line",
+    "cached_src_nodes": 1,
+    "snippet": "void rl_erase_entire_line()\n{\n  ;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "iproute2",
+    "binary": "ip",
+    "func": "__print_rta_gateway",
+    "cached_src_nodes": 1,
+    "snippet": "long long _print_rta_gateway(FILE *a1, unsigned char a2, const char *a3)\n{\n  unsigned int v4; // eax\n\n  if ( (unsigned char)is_json_context(a1) )\n    return sub_19642(2, \"gateway\", 0, a3);\n  fprintf(a1, \"via \");\n  v4 = ifa_family_color(a2);\n  return print_color_string(1, v4, 0, \"%s \", a3);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "make-prime-list",
+    "func": "print_wide_uint",
+    "cached_src_nodes": 9,
+    "snippet": "int print_wide_uint(unsigned __int128 a1, int a2, unsigned int a3)\n{\n  unsigned int v6; // [rsp+20h] [rbp-10h]\n\n  v6 = 7;\n  if ( *((long long *)&a1 + 1) | (unsigned long long)a1 ^ a1 & 0xFFFFFFF )\n  {\n    if ( a1 >> 56 != 0 )\n      printf(\"(\");\n    print_wide_uint(a1 >> 28, a1 >> 28 >> 64, (unsigned int)(a2 + 1), a3, a1 >> 28, a1 >> 28 >> 64);\n    if ( a1 >> 56 != 0 )\n      printf(\")\\n%*s\", a2 + 3, (const char *)&unk_200A);\n    printf(\" << %d | \", 28);\n  }"
+   },
+   {
+    "opt": "O0",
+    "project": "libbsd",
+    "binary": "libbsd.so.0.11",
+    "func": "__fdnlist",
+    "cached_src_nodes": 59,
+    "snippet": "// bad sp value at call has been detected, the output may be wrong!\nlong long _fdnlist(int a1, const char **a2)\n{\n  int v3; // eax\n  unsigned int v4; // [rsp+18h] [rbp-6138h]\n  unsigned int nbytes; // [rsp+1Ch] [rbp-6134h]\n  int nbytes_4; // [rsp+20h] [rbp-6130h]\n  int i; // [rsp+24h] [rbp-612Ch]\n  int v8; // [rsp+28h] [rbp-6128h]\n  unsigned int size; // [rsp+2Ch] [rbp-6124h]\n  unsigned int size_4; // [rsp+30h] [rbp-6120h]\n  int v11; // [rsp+34h] [rbp-611Ch]\n  const char **j; // [rsp+38h] [rbp-6118h]\n  const char **k; // [rsp+38h] [rbp-6118h]"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_getenv",
+    "cached_src_nodes": 1,
+    "snippet": "char *getenv(const char *name)\n{\n  return (char *)getenv(name);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_internal_char_cleanup",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_internal_char_cleanup()\n{\n  long long result; // rax\n\n  if ( rl_keep_mark_active )\n  {\n    rl_keep_mark_active = 0;\n  }\n  else if ( (unsigned int)rl_mark_active_p() )\n  {\n    rl_deactivate_mark();\n  }\n  if ( !rl_editing_mode && rl_keymap == &vi_movement_keymap )\n    rl_vi_check();"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_init_line_state",
+    "cached_src_nodes": 1,
+    "snippet": "char *rl_init_line_state()\n{\n  char *result; // rax\n\n  rl_mark = 0;\n  rl_end = 0;\n  rl_point = 0;\n  qword_17BD38 = rl_line_buffer;\n  result = rl_line_buffer;\n  *rl_line_buffer = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_set_the_line",
+    "cached_src_nodes": 1,
+    "snippet": "char *rl_set_the_line()\n{\n  qword_17BD38 = rl_line_buffer;\n  return rl_line_buffer;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_keyseq_cxt_alloc",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_keyseq_cxt_alloc()\n{\n  long long result; // rax\n\n  result = xmalloc(48);\n  *(int *)(result + 8) = 0;\n  *(int *)(result + 4) = *(int *)(result + 8);\n  *(int *)result = *(int *)(result + 4);\n  *(int *)(result + 12) = 0;\n  *(long long *)(result + 32) = rl_kscxt;\n  *(int *)(result + 40) = 42;\n  return result;\n}\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_keyseq_cxt_dispose",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_keyseq_cxt_dispose(long long a1)\n{\n  return xfree(a1);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_keyseq_chain_dispose",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_keyseq_chain_dispose()\n{\n  long long result; // rax\n  long long v1; // [rsp+8h] [rbp-8h]\n\n  while ( 1 )\n  {\n    result = rl_kscxt;\n    if ( !rl_kscxt )\n      break;\n    v1 = rl_kscxt;\n    rl_kscxt = *(long long *)(rl_kscxt + 32);\n    rl_keyseq_cxt_dispose(v1);\n  }"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_dispatch_callback",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_dispatch_callback(long long a1)\n{\n  unsigned int v2; // [rsp+18h] [rbp-8h]\n  int v3; // [rsp+1Ch] [rbp-4h]\n\n  if ( (*(int *)a1 & 1) != 0 )\n  {\n    v2 = *(int *)(a1 + 40);\n  }\n  else\n  {\n    v3 = sub_F818C(*(int *)(a1 + 12));\n    if ( v3 < 0 )\n      rl_abort_internal();"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_dispatch",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_dispatch(unsigned int a1, long long a2)\n{\n  rl_dispatching_keymap = a2;\n  return rl_dispatch_subseq(a1, a2, 0);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_dispatch_subseq",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_dispatch_subseq(int a1, long long a2, unsigned int a3)\n{\n  unsigned int v3; // ebx\n  int v4; // eax\n  int v6; // eax\n  unsigned int v7; // eax\n  int v8; // eax\n  unsigned int v9; // eax\n  unsigned int v10; // eax\n  int v11; // eax\n  int v12; // eax\n  int v13; // edx\n  long long v14; // rdx\n  const char *v15; // r12"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_init_executing_keyseq",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_init_executing_keyseq()\n{\n  long long result; // rax\n\n  rl_key_sequence_length = 0;\n  result = rl_executing_keyseq;\n  *(char *)rl_executing_keyseq = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_term_executing_keyseq",
+    "cached_src_nodes": 1,
+    "snippet": "char *rl_term_executing_keyseq()\n{\n  char *result; // rax\n\n  result = (char *)(rl_executing_keyseq + rl_key_sequence_length);\n  *result = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_end_executing_keyseq",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_end_executing_keyseq()\n{\n  long long result; // rax\n\n  result = (unsigned int)rl_key_sequence_length;\n  if ( rl_key_sequence_length > 0 )\n  {\n    result = rl_executing_keyseq + --rl_key_sequence_length;\n    *(char *)result = 0;\n  }\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_add_executing_keyseq",
+    "cached_src_nodes": 1,
+    "snippet": "char *rl_add_executing_keyseq(char a1)\n{\n  int v1; // eax\n  char *result; // rax\n\n  if ( rl_key_sequence_length + 2 >= rl_executing_keyseq_size )\n  {\n    rl_executing_keyseq_size += 16;\n    rl_executing_keyseq = xrealloc(rl_executing_keyseq, rl_executing_keyseq_size);\n  }\n  v1 = rl_key_sequence_length++;\n  result = (char *)(rl_executing_keyseq + v1);\n  *result = a1;\n  return result;"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_del_executing_keyseq",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_del_executing_keyseq()\n{\n  long long result; // rax\n\n  result = (unsigned int)rl_key_sequence_length;\n  if ( rl_key_sequence_length > 0 )\n    return (unsigned int)--rl_key_sequence_length;\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_initialize_line",
+    "cached_src_nodes": 4,
+    "snippet": "unsigned long long rl_vi_initialize_line()\n{\n  int i; // ebx\n  unsigned long long result; // rax\n\n  for ( i = 0; i < 26; ++i )\n    dword_17BDE0[i] = -1;\n  result = rl_readline_state & 0xFFFFFFFFFFBFFFFFLL;\n  rl_readline_state &= ~0x400000uLL;\n  return result;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_reset_last",
+    "cached_src_nodes": 1,
+    "snippet": "void rl_vi_reset_last()\n{\n  rl_vi_last_command = 105;\n  dword_16CC9C = 1;\n  dword_16CCA0 = 1;\n  dword_17BD8C = 0;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_set_last",
+    "cached_src_nodes": 1,
+    "snippet": "long long rl_vi_set_last(int a1, int a2, unsigned int a3)\n{\n  rl_vi_last_command = a1;\n  dword_16CC9C = a2;\n  dword_16CCA0 = a3;\n  return a3;\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_textmod_command",
+    "cached_src_nodes": 3,
+    "snippet": "long long rl_vi_textmod_command(int a1)\n{\n  return a1 && strchr(\"_*\\\\AaIiCcDdPpYyRrSsXx~\", a1);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_motion_command",
+    "cached_src_nodes": 3,
+    "snippet": "long long rl_vi_motion_command(int a1)\n{\n  return a1 && strchr(\" hl^$0ftFT;,%wbeWBE|`\", a1);\n}\n\n"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_done_inserting",
+    "cached_src_nodes": 19,
+    "snippet": "long long rl_vi_done_inserting()\n{\n  long long result; // rax\n\n  if ( dword_17BD6C )\n  {\n    rl_end_undo_group();\n    dword_17BD6C = 0;\n    if ( dword_17BDC4 == 82 )\n      sub_FAFF2();\n    else\n      sub_FB08C(*(int **)rl_undo_list);\n    if ( rl_undo_group_level <= 0 )\n      goto LABEL_15;"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_domove_motion_cleanup",
+    "cached_src_nodes": 55,
+    "snippet": "long long rl_vi_domove_motion_cleanup(int a1, long long a2)\n{\n  bool v2; // al\n  bool v4; // al\n  int v6; // [rsp+18h] [rbp-8h]\n\n  rl_end = *(int *)(a2 + 24);\n  rl_line_buffer[rl_end] = 0;\n  rl_fix_point(0);\n  if ( rl_mark == rl_point )\n  {\n    if ( ((*__ctype_b_loc())[(unsigned char)*(int *)(a2 + 28)] & 0x200) != 0 )\n      v2 = toupper((unsigned char)*(int *)(a2 + 28)) == 67;\n    else"
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "func": "_rl_vi_domove_callback",
+    "cached_src_nodes": 3,
+    "snippet": "long long rl_vi_domove_callback(long long a1)\n{\n  int v2; // [rsp+18h] [rbp-8h]\n\n  v2 = sub_FC029();\n  *(int *)(a1 + 32) = v2;\n  return v2 < 0 || (unsigned int)sub_FBDB1(a1) != 0;\n}\n\n"
+   }
+  ],
+  "binja": [
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "rpl_fcntl",
+    "cached_src_nodes": 1,
+    "snippet": "uint64_t rpl_fcntl(int32_t arg1, int32_t arg2, char arg3 @ rax)\n\n{\n    int64_t rdx;\n    int64_t var_a8 = rdx;\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg3 != 0)\n    {\n        int128_t zmm0;"
+   },
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "open_safer",
+    "cached_src_nodes": 1,
+    "snippet": "uint64_t open_safer(char* arg1, int32_t arg2, char arg3 @ rax)\n\n{\n    int64_t rdx;\n    int64_t var_a8 = rdx;\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg3 != 0)\n    {\n        int128_t zmm0;"
+   },
+   {
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "func": "openat_safer",
+    "cached_src_nodes": 1,
+    "snippet": "uint64_t openat_safer(int32_t arg1, char* arg2, int32_t arg3, char arg4 @ rax)\n\n{\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg4 != 0)\n    {\n        int128_t zmm0;\n        int128_t var_88_1 = zmm0;\n        int128_t zmm1;"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "print_context_script",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t* print_context_script(int64_t* arg1, char arg2)\n\n{\n    if ((data_2d1ec != 0 || (data_2d1ec == 0 && data_2d280 != 0)))\n    {\n        sub_8c9d(arg1);\n    }\n    if ((data_2d1ec == 0 && data_2d280 == 0))\n    {\n        for (int64_t* var_10_1 = arg1; var_10_1 != 0; var_10_1 = *(int64_t*)var_10_1)\n        {\n            var_10_1[5] = 0;\n        }\n    }"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "find_function",
+    "cached_src_nodes": 7,
+    "snippet": "char* find_function(void* arg1, int64_t arg2)\n\n{\n    int64_t var_28 = arg2;\n    int64_t rax_1 = data_2d1b0;\n    data_2d1b0 = var_28;\n    char* rax_18;\n    while (true)\n    {\n        var_28 = (var_28 - 1);\n        if (var_28 < rax_1)\n        {\n            if (data_2d1b8 == 0x7fffffffffffffff)\n            {"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "compare_names_for_qsort",
+    "cached_src_nodes": 4,
+    "snippet": "uint64_t compare_names_for_qsort(int64_t* arg1, int64_t* arg2)\n\n{\n    char* rax_3 = *(int64_t*)arg1;\n    char* rax_5 = *(int64_t*)arg2;\n    int32_t rax_8;\n    uint64_t rax_9;\n    if (data_2d660 != 0)\n    {\n        rax_8 = sub_c084(rax_3, rax_5);\n        if (rax_8 != 0)\n        {\n            rax_9 = ((uint64_t)rax_8);\n        }"
+   },
+   {
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "func": "print_ed_script",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t* print_ed_script(int64_t* arg1)\n\n{\n    return sub_1245b(arg1, sub_12449, sub_cbb5);\n}\n"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "key_print_wrapper",
+    "cached_src_nodes": 3,
+    "snippet": "int64_t key_print_wrapper(int32_t* arg1, void* arg2)\n\n{\n    void* rax_1;\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "keygrab_ssh2",
+    "cached_src_nodes": 12,
+    "snippet": "int64_t keygrab_ssh2(void* arg1)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char const* const var_68 = \"sntrup761x25519-sha512@openssh.c\u2026\";\n    char const* const var_60 = \"ssh-ed25519-cert-v01@openssh.com\u2026\";\n    char const* const var_58 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_50 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_48 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_40 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_38 = \"none,zlib@openssh.com\";\n    char const* const var_30 = \"none,zlib@openssh.com\";\n    void* const var_28 = &data_7b444;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "keyprint",
+    "cached_src_nodes": 14,
+    "snippet": "int64_t keyprint(void* arg1, int32_t* arg2)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char* rax_4;\n    if (*(int64_t*)((char*)arg1 + 0x38) == 0)\n    {\n        rax_4 = *(int64_t*)((char*)arg1 + 0x28);\n    }\n    else\n    {\n        rax_4 = *(int64_t*)((char*)arg1 + 0x38);\n    }"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "ssh_init",
+    "cached_src_nodes": 13,
+    "snippet": "uint64_t ssh_init(int32_t*** arg1, int32_t arg2, char** arg3)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char const* const var_68 = \"sntrup761x25519-sha512@openssh.c\u2026\";\n    char const* const var_60 = \"ssh-ed25519-cert-v01@openssh.com\u2026\";\n    char const* const var_58 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_50 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_48 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_40 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_38 = \"none,zlib@openssh.com\";\n    char const* const var_30 = \"none,zlib@openssh.com\";\n    void* const var_28 = &data_7c36c;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "_ssh_verify_host_key",
+    "cached_src_nodes": 6,
+    "snippet": "int64_t _ssh_verify_host_key(int32_t* arg1, void* arg2)\n\n{\n    void* var_30 = sub_1269b(arg1);\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "_ssh_host_key_sign",
+    "cached_src_nodes": 1,
+    "snippet": "uint64_t _ssh_host_key_sign(void* arg1, int32_t* arg2, int64_t arg3, int64_t* arg4, \n    int64_t* arg5, int64_t arg6, uint64_t arg7, char* arg8)\n\n{\n    int64_t var_20 = arg3;\n    uint64_t rax_3;\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "func": "kexgex_hash",
+    "cached_src_nodes": 1,
+    "snippet": "uint64_t kexgex_hash(int32_t arg1, int64_t* arg2, int64_t* arg3, int64_t* arg4, \n    int64_t* arg5, int64_t* arg6, int32_t arg7, int32_t arg8, int32_t arg9, \n    int64_t arg10, int64_t arg11, int64_t arg12, int64_t arg13, int64_t arg14, \n    uint64_t arg15, int64_t arg16, int64_t* arg17)\n\nLoading...\n"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sshd",
+    "func": "grace_alarm_handler",
+    "cached_src_nodes": 3,
+    "snippet": "int64_t grace_alarm_handler() __noreturn\n\n{\n    int32_t rdi;\n    int32_t var_1c = rdi;\n    if (getpgid(0) == getpid())\n    {\n        sub_b4fca(0xf, 1);\n        kill(0, 0xf);\n    }\n    uint64_t var_38 = ((uint64_t)sub_9a061(data_141ef0));\n    int64_t var_40 = sub_99f12(data_141ef0);\n    sub_95692(\"sshd.c\", \"grace_alarm_handler\", 0x172, 0, 2, 0, 0, \"Timeout before authentication fo\u2026\");\n    /* no return */"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sshd",
+    "func": "main",
+    "cached_src_nodes": 275,
+    "snippet": "int32_t main(int32_t argc, char** argv, char** envp) __noreturn\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int64_t var_30 = rax;\n    int32_t var_174 = 1;\n    int32_t var_170 = 0xffffffff;\n    int32_t var_16c = 0xffffffff;\n    int32_t var_168 = 0xffffffff;\n    char* var_120 = nullptr;\n    int32_t var_d0 = 0xffffffff;\n    int32_t var_cc = 0xffffffff;\n    int64_t* var_118 = nullptr;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "attrib_to_stat",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t attrib_to_stat(int32_t* arg1, void* arg2)\n\n{\n    memset(arg2, 0, 0x90);\n    if ((*(int32_t*)arg1 & 1) != 0)\n    {\n        *(int64_t*)((char*)arg2 + 0x30) = *(int64_t*)((char*)arg1 + 8);\n    }\n    if ((*(int32_t*)arg1 & 2) != 0)\n    {\n        *(int32_t*)((char*)arg2 + 0x1c) = arg1[4];\n        *(int32_t*)((char*)arg2 + 0x20) = arg1[5];\n    }\n    if ((*(int32_t*)arg1 & 4) != 0)"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "func": "fx2txt",
+    "cached_src_nodes": 1,
+    "snippet": "void* const fx2txt(int32_t arg1)\n\n{\n    void* const rax_4;\n    if (arg1 > 8)\n    {\n        rax_4 = \"Unknown status\";\n    }\n    else\n    {\n        switch (arg1)\n        {\n            case 0:\n            {"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "func": "sdirent_comp",
+    "cached_src_nodes": 17,
+    "snippet": "uint64_t sdirent_comp(int64_t* arg1, int64_t* arg2)\n\n{\n    int64_t* rax_1 = *(int64_t*)arg1;\n    int64_t* rax_3 = *(int64_t*)arg2;\n    int32_t rax_6;\n    if ((data_4b324 & 0x40) == 0)\n    {\n        rax_6 = 1;\n    }\n    else\n    {\n        rax_6 = -1;\n    }"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "func": "parse_args",
+    "cached_src_nodes": 85,
+    "snippet": "uint64_t parse_args(int64_t* arg1, int32_t* arg2, int32_t* arg3, int32_t* arg4, \n    int32_t* arg5, int32_t* arg6, int32_t* arg7, int32_t* arg8, int32_t* arg9, \n    int32_t* arg10, int32_t* arg11, int64_t* arg12, int64_t* arg13, \n    int64_t* arg14)\n\nLoading...\n"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "func": "connect_to_server",
+    "cached_src_nodes": 11,
+    "snippet": "int64_t connect_to_server(char* arg1, char** arg2, int32_t* arg3, int32_t* arg4)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int32_t var_18;\n    if (socketpair(1, 1, 0, &var_18) == 0xffffffff)\n    {\n        char* var_50 = strerror(*(int32_t*)__errno_location());\n        sub_23b81(\"sftp.c\", \"connect_to_server\", 0x938, 0, 1, 0, 0, \"socketpair: %s\");\n        /* no return */\n    }\n    *(int32_t*)arg4 = var_18;\n    *(int32_t*)arg3 = *(int32_t*)arg4;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keysign",
+    "func": "kex_default_pk_alg",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t kex_default_pk_alg()\n\n{\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;\n    int512_t zmm10;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "func": "sshbuf_alloc",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t sshbuf_alloc(void* arg1)\n\n{\n    int512_t zmm0;\n    zmm0 = 0;\n    int512_t zmm1;\n    zmm1 = 0;\n    int512_t zmm2;\n    zmm2 = 0;\n    int512_t zmm3;\n    zmm3 = 0;\n    int512_t zmm4;\n    zmm4 = 0;\n    int512_t zmm5;"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keygen",
+    "func": "known_hosts_find_delete",
+    "cached_src_nodes": 29,
+    "snippet": "int64_t known_hosts_find_delete(int64_t* arg1, int64_t* arg2)\n\n{\n    int64_t var_28 = 0;\n    int64_t var_20 = 0;\n    int32_t rax_2;\n    if (data_b124c != 0)\n    {\n        rax_2 = 1;\n    }\n    else\n    {\n        rax_2 = data_b1010;\n    }"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keygen",
+    "func": "cert_ext_cmp",
+    "cached_src_nodes": 15,
+    "snippet": "uint64_t cert_ext_cmp(int64_t* arg1, int64_t* arg2)\n\n{\n    uint64_t rax_8;\n    if (arg1[2] == arg2[2])\n    {\n        int32_t rax_12;\n        char rdx_3;\n        rax_12 = strcmp(*(int64_t*)arg1, *(int64_t*)arg2);\n        if (rax_12 != 0)\n        {\n            rax_8 = ((uint64_t)rax_12);\n        }\n        else"
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keygen",
+    "func": "finalise_cert_exts",
+    "cached_src_nodes": 20,
+    "snippet": "int64_t finalise_cert_exts()\n\n{\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;\n    int512_t zmm10;"
+   },
+   {
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "certtool",
+    "func": "tls_log_func",
+    "cached_src_nodes": 1,
+    "snippet": "int64_t tls_log_func(int32_t arg1, int64_t arg2)\n\n{\n    return fprintf(stderr, \"|<%d>| %s\", ((uint64_t)arg1), arg2);\n}\n"
+   },
+   {
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "certtool",
+    "func": "cmd_parser",
+    "cached_src_nodes": 49,
+    "snippet": "int64_t cmd_parser(int32_t arg1, char** arg2)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int32_t var_104 = 0;\n    sub_20172(arg1, arg2);\n    if (data_57bee == 0)\n    {\n        data_56520 = stderr;\n    }\n    else\n    {\n        data_56520 = stdout;"
+   },
+   {
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "gnutls-cli",
+    "func": "try_save_ocsp_status",
+    "cached_src_nodes": 25,
+    "snippet": "int64_t try_save_ocsp_status(int64_t arg1)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int32_t var_5c = 0;\n    gnutls_certificate_get_peers(arg1, &var_5c, &var_5c);\n    if (var_5c == 0)\n    {\n        fprintf(stderr, \"no certificates sent by server, \u2026\", \"no certificates sent by server, \u2026\");\n    }\n    else\n    {\n        int32_t var_58_1;"
+   },
+   {
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "gnutls-cli",
+    "func": "main",
+    "cached_src_nodes": 91,
+    "snippet": "int32_t main(int32_t argc, char** argv, char** envp)\n\n{\n    int64_t var_1008;\n    int64_t var_1008_1 = var_1008;\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int32_t var_1260 = 0;\n    int32_t var_125c = 0;\n    int32_t var_1258 = 0x40;\n    FILE* var_1238 = nullptr;\n    FILE* var_1230 = nullptr;\n    FILE* var_1228 = nullptr;\n    sub_cc3f(argc, argv);"
+   }
+  ]
+ },
+ "recoverable_degenerate_count": 2579,
+ "recoverable_by_project": {
+  "e2fsprogs": 112,
+  "iproute2": 104,
+  "bzip2": 28,
+  "dpkg": 67,
+  "grep": 16,
+  "diffutils": 7,
+  "gzip": 36,
+  "zlib": 59,
+  "coreutils": 85,
+  "gnutls": 74,
+  "openssh-portable": 654,
+  "bash": 673,
+  "libedit": 174,
+  "tar": 156,
+  "libacl": 50,
+  "cronie": 34,
+  "sysvinit": 11,
+  "libselinux": 184,
+  "rsyslog": 12,
+  "findutils": 29,
+  "shadow": 4,
+  "libexpat": 6,
+  "kmod": 1,
+  "base-passwd": 1,
+  "libbsd": 2
+ },
+ "recoverable_worst": [
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass1",
+   "cached_nodes": 1,
+   "ghidra_branches": 394
+  },
+  {
+   "project": "iproute2",
+   "func": "iplink_parse",
+   "cached_nodes": 1,
+   "ghidra_branches": 337
+  },
+  {
+   "project": "bzip2",
+   "func": "BZ2_compressBlock",
+   "cached_nodes": 1,
+   "ghidra_branches": 259
+  },
+  {
+   "project": "iproute2",
+   "func": "print_route",
+   "cached_nodes": 1,
+   "ghidra_branches": 256
+  },
+  {
+   "project": "dpkg",
+   "func": "tarobject",
+   "cached_nodes": 1,
+   "ghidra_branches": 200
+  },
+  {
+   "project": "grep",
+   "func": "kwsprep",
+   "cached_nodes": 1,
+   "ghidra_branches": 198
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "check_super_block",
+   "cached_nodes": 1,
+   "ghidra_branches": 190
+  },
+  {
+   "project": "bzip2",
+   "func": "BZ2_bzDecompress",
+   "cached_nodes": 1,
+   "ghidra_branches": 180
+  },
+  {
+   "project": "iproute2",
+   "func": "do_iplink",
+   "cached_nodes": 1,
+   "ghidra_branches": 170
+  },
+  {
+   "project": "diffutils",
+   "func": "diff_2_files",
+   "cached_nodes": 1,
+   "ghidra_branches": 169
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass5",
+   "cached_nodes": 1,
+   "ghidra_branches": 169
+  },
+  {
+   "project": "gzip",
+   "func": "printf_parse",
+   "cached_nodes": 1,
+   "ghidra_branches": 169
+  },
+  {
+   "project": "iproute2",
+   "func": "print_linkinfo",
+   "cached_nodes": 1,
+   "ghidra_branches": 168
+  },
+  {
+   "project": "zlib",
+   "func": "deflate",
+   "cached_nodes": 1,
+   "ghidra_branches": 166
+  },
+  {
+   "project": "coreutils",
+   "func": "chown_files",
+   "cached_nodes": 1,
+   "ghidra_branches": 151
+  },
+  {
+   "project": "gnutls",
+   "func": "process_options",
+   "cached_nodes": 1,
+   "ghidra_branches": 150
+  },
+  {
+   "project": "openssh-portable",
+   "func": "muxclient",
+   "cached_nodes": 1,
+   "ghidra_branches": 149
+  },
+  {
+   "project": "diffutils",
+   "func": "read_files",
+   "cached_nodes": 1,
+   "ghidra_branches": 145
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_krl_to_blob",
+   "cached_nodes": 1,
+   "ghidra_branches": 143
+  },
+  {
+   "project": "bash",
+   "func": "glob_filename",
+   "cached_nodes": 1,
+   "ghidra_branches": 139
+  },
+  {
+   "project": "openssh-portable",
+   "func": "dump_client_config",
+   "cached_nodes": 1,
+   "ghidra_branches": 135
+  },
+  {
+   "project": "libedit",
+   "func": "re_refresh",
+   "cached_nodes": 1,
+   "ghidra_branches": 130
+  },
+  {
+   "project": "dpkg",
+   "func": "depisok",
+   "cached_nodes": 1,
+   "ghidra_branches": 130
+  },
+  {
+   "project": "bash",
+   "func": "execute_command_internal",
+   "cached_nodes": 1,
+   "ghidra_branches": 129
+  },
+  {
+   "project": "bash",
+   "func": "brace_expand",
+   "cached_nodes": 1,
+   "ghidra_branches": 129
+  },
+  {
+   "project": "openssh-portable",
+   "func": "copy_set_server_options",
+   "cached_nodes": 1,
+   "ghidra_branches": 128
+  },
+  {
+   "project": "tar",
+   "func": "read_and",
+   "cached_nodes": 1,
+   "ghidra_branches": 126
+  },
+  {
+   "project": "libacl",
+   "func": "__acl_to_any_text",
+   "cached_nodes": 1,
+   "ghidra_branches": 125
+  },
+  {
+   "project": "libacl",
+   "func": "do_set",
+   "cached_nodes": 1,
+   "ghidra_branches": 122
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_rehash_dir",
+   "cached_nodes": 1,
+   "ghidra_branches": 122
+  },
+  {
+   "project": "coreutils",
+   "func": "find_mount_point",
+   "cached_nodes": 1,
+   "ghidra_branches": 121
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_krl_from_blob",
+   "cached_nodes": 1,
+   "ghidra_branches": 119
+  },
+  {
+   "project": "zlib",
+   "func": "inflateBack",
+   "cached_nodes": 1,
+   "ghidra_branches": 116
+  },
+  {
+   "project": "bash",
+   "func": "wait_for",
+   "cached_nodes": 1,
+   "ghidra_branches": 115
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "print_e2fsck_message",
+   "cached_nodes": 1,
+   "ghidra_branches": 114
+  },
+  {
+   "project": "openssh-portable",
+   "func": "dump_config",
+   "cached_nodes": 1,
+   "ghidra_branches": 112
+  },
+  {
+   "project": "bash",
+   "func": "command_word_completion_function",
+   "cached_nodes": 1,
+   "ghidra_branches": 110
+  },
+  {
+   "project": "bash",
+   "func": "glob_vector",
+   "cached_nodes": 1,
+   "ghidra_branches": 110
+  },
+  {
+   "project": "bash",
+   "func": "sh_modcase",
+   "cached_nodes": 1,
+   "ghidra_branches": 110
+  },
+  {
+   "project": "openssh-portable",
+   "func": "sftp_server_main",
+   "cached_nodes": 1,
+   "ghidra_branches": 109
+  },
+  {
+   "project": "dpkg",
+   "func": "removal_bulk",
+   "cached_nodes": 1,
+   "ghidra_branches": 104
+  },
+  {
+   "project": "bash",
+   "func": "list_string",
+   "cached_nodes": 1,
+   "ghidra_branches": 104
+  },
+  {
+   "project": "libedit",
+   "func": "history_w",
+   "cached_nodes": 1,
+   "ghidra_branches": 101
+  },
+  {
+   "project": "libedit",
+   "func": "history",
+   "cached_nodes": 1,
+   "ghidra_branches": 101
+  },
+  {
+   "project": "libacl",
+   "func": "acl_from_text",
+   "cached_nodes": 1,
+   "ghidra_branches": 101
+  },
+  {
+   "project": "gnutls",
+   "func": "cfg_load",
+   "cached_nodes": 1,
+   "ghidra_branches": 100
+  },
+  {
+   "project": "tar",
+   "func": "open_archive",
+   "cached_nodes": 1,
+   "ghidra_branches": 100
+  },
+  {
+   "project": "openssh-portable",
+   "func": "session_input_channel_req",
+   "cached_nodes": 1,
+   "ghidra_branches": 98
+  },
+  {
+   "project": "cronie",
+   "func": "load_entry",
+   "cached_nodes": 1,
+   "ghidra_branches": 98
+  },
+  {
+   "project": "libedit",
+   "func": "ce_inc_search",
+   "cached_nodes": 1,
+   "ghidra_branches": 96
+  },
+  {
+   "project": "openssh-portable",
+   "func": "kex_input_kexinit",
+   "cached_nodes": 1,
+   "ghidra_branches": 95
+  },
+  {
+   "project": "bash",
+   "func": "skip_to_delim",
+   "cached_nodes": 1,
+   "ghidra_branches": 95
+  },
+  {
+   "project": "openssh-portable",
+   "func": "fill_default_server_options",
+   "cached_nodes": 1,
+   "ghidra_branches": 94
+  },
+  {
+   "project": "libedit",
+   "func": "tok_line",
+   "cached_nodes": 1,
+   "ghidra_branches": 92
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "fix_problem",
+   "cached_nodes": 1,
+   "ghidra_branches": 92
+  },
+  {
+   "project": "libedit",
+   "func": "tok_wline",
+   "cached_nodes": 1,
+   "ghidra_branches": 90
+  },
+  {
+   "project": "libedit",
+   "func": "unvis",
+   "cached_nodes": 1,
+   "ghidra_branches": 90
+  },
+  {
+   "project": "libedit",
+   "func": "terminal_echotc",
+   "cached_nodes": 1,
+   "ghidra_branches": 89
+  },
+  {
+   "project": "bash",
+   "func": "initialize_shell_variables",
+   "cached_nodes": 1,
+   "ghidra_branches": 89
+  },
+  {
+   "project": "openssh-portable",
+   "func": "fill_default_options",
+   "cached_nodes": 1,
+   "ghidra_branches": 88
+  },
+  {
+   "project": "iproute2",
+   "func": "lwt_parse_encap",
+   "cached_nodes": 1,
+   "ghidra_branches": 88
+  },
+  {
+   "project": "openssh-portable",
+   "func": "user_key_allowed",
+   "cached_nodes": 1,
+   "ghidra_branches": 86
+  },
+  {
+   "project": "openssh-portable",
+   "func": "client_loop",
+   "cached_nodes": 1,
+   "ghidra_branches": 86
+  },
+  {
+   "project": "bash",
+   "func": "stop_pipeline",
+   "cached_nodes": 1,
+   "ghidra_branches": 86
+  },
+  {
+   "project": "libedit",
+   "func": "fn_complete2",
+   "cached_nodes": 1,
+   "ghidra_branches": 85
+  },
+  {
+   "project": "tar",
+   "func": "diff_archive",
+   "cached_nodes": 1,
+   "ghidra_branches": 85
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_packet_read_poll2",
+   "cached_nodes": 1,
+   "ghidra_branches": 84
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass1_dupblocks",
+   "cached_nodes": 1,
+   "ghidra_branches": 83
+  },
+  {
+   "project": "bash",
+   "func": "unary_test",
+   "cached_nodes": 1,
+   "ghidra_branches": 83
+  },
+  {
+   "project": "iproute2",
+   "func": "lwt_print_encap",
+   "cached_nodes": 1,
+   "ghidra_branches": 81
+  },
+  {
+   "project": "iproute2",
+   "func": "do_xfrm_policy",
+   "cached_nodes": 1,
+   "ghidra_branches": 80
+  },
+  {
+   "project": "openssh-portable",
+   "func": "krl_dump",
+   "cached_nodes": 1,
+   "ghidra_branches": 78
+  },
+  {
+   "project": "bash",
+   "func": "assign_compound_array_list",
+   "cached_nodes": 1,
+   "ghidra_branches": 78
+  },
+  {
+   "project": "openssh-portable",
+   "func": "pkcs11_add_provider",
+   "cached_nodes": 1,
+   "ghidra_branches": 77
+  },
+  {
+   "project": "iproute2",
+   "func": "xfrm_selector_parse",
+   "cached_nodes": 1,
+   "ghidra_branches": 77
+  },
+  {
+   "project": "iproute2",
+   "func": "do_ipmonitor",
+   "cached_nodes": 1,
+   "ghidra_branches": 76
+  },
+  {
+   "project": "iproute2",
+   "func": "xfrm_xfrma_print",
+   "cached_nodes": 1,
+   "ghidra_branches": 76
+  },
+  {
+   "project": "libacl",
+   "func": "parse_acl_cmd",
+   "cached_nodes": 1,
+   "ghidra_branches": 76
+  },
+  {
+   "project": "bash",
+   "func": "gen_compspec_completions",
+   "cached_nodes": 1,
+   "ghidra_branches": 76
+  },
+  {
+   "project": "gnutls",
+   "func": "print_list",
+   "cached_nodes": 1,
+   "ghidra_branches": 74
+  },
+  {
+   "project": "sysvinit",
+   "func": "detect_consoles",
+   "cached_nodes": 1,
+   "ghidra_branches": 74
+  },
+  {
+   "project": "bash",
+   "func": "rl_vi_match",
+   "cached_nodes": 1,
+   "ghidra_branches": 74
+  },
+  {
+   "project": "bash",
+   "func": "rl_filename_completion_function",
+   "cached_nodes": 1,
+   "ghidra_branches": 74
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_userauth2",
+   "cached_nodes": 1,
+   "ghidra_branches": 73
+  },
+  {
+   "project": "libacl",
+   "func": "read_acl_comments",
+   "cached_nodes": 1,
+   "ghidra_branches": 72
+  },
+  {
+   "project": "bash",
+   "func": "expand_string_dollar_quote",
+   "cached_nodes": 1,
+   "ghidra_branches": 72
+  },
+  {
+   "project": "grep",
+   "func": "EGexecute",
+   "cached_nodes": 1,
+   "ghidra_branches": 71
+  },
+  {
+   "project": "openssh-portable",
+   "func": "do_crossload",
+   "cached_nodes": 1,
+   "ghidra_branches": 69
+  },
+  {
+   "project": "bash",
+   "func": "alias_expand",
+   "cached_nodes": 1,
+   "ghidra_branches": 69
+  },
+  {
+   "project": "iproute2",
+   "func": "do_netns",
+   "cached_nodes": 1,
+   "ghidra_branches": 68
+  },
+  {
+   "project": "gnutls",
+   "func": "socket_open2",
+   "cached_nodes": 1,
+   "ghidra_branches": 67
+  },
+  {
+   "project": "gzip",
+   "func": "deflate",
+   "cached_nodes": 1,
+   "ghidra_branches": 66
+  },
+  {
+   "project": "openssh-portable",
+   "func": "parse_forward",
+   "cached_nodes": 1,
+   "ghidra_branches": 66
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_process_bad_inode",
+   "cached_nodes": 1,
+   "ghidra_branches": 66
+  },
+  {
+   "project": "openssh-portable",
+   "func": "channel_prepare_poll",
+   "cached_nodes": 1,
+   "ghidra_branches": 65
+  },
+  {
+   "project": "tar",
+   "func": "purge_directory",
+   "cached_nodes": 1,
+   "ghidra_branches": 65
+  },
+  {
+   "project": "bash",
+   "func": "char_is_quoted",
+   "cached_nodes": 1,
+   "ghidra_branches": 65
+  },
+  {
+   "project": "bash",
+   "func": "pat_subst",
+   "cached_nodes": 1,
+   "ghidra_branches": 65
+  },
+  {
+   "project": "bash",
+   "func": "rl_display_match_list",
+   "cached_nodes": 1,
+   "ghidra_branches": 65
+  },
+  {
+   "project": "bash",
+   "func": "quote_string_for_globbing",
+   "cached_nodes": 1,
+   "ghidra_branches": 64
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_err",
+   "cached_nodes": 1,
+   "ghidra_branches": 63
+  },
+  {
+   "project": "openssh-portable",
+   "func": "getrrsetbyname",
+   "cached_nodes": 1,
+   "ghidra_branches": 63
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass4",
+   "cached_nodes": 1,
+   "ghidra_branches": 63
+  },
+  {
+   "project": "tar",
+   "func": "read_directory_file",
+   "cached_nodes": 1,
+   "ghidra_branches": 62
+  },
+  {
+   "project": "bash",
+   "func": "get_word_from_string",
+   "cached_nodes": 1,
+   "ghidra_branches": 62
+  },
+  {
+   "project": "iproute2",
+   "func": "do_ipnh",
+   "cached_nodes": 1,
+   "ghidra_branches": 61
+  },
+  {
+   "project": "openssh-portable",
+   "func": "kex_exchange_identification",
+   "cached_nodes": 1,
+   "ghidra_branches": 60
+  },
+  {
+   "project": "libedit",
+   "func": "el_wgets",
+   "cached_nodes": 1,
+   "ghidra_branches": 60
+  },
+  {
+   "project": "bash",
+   "func": "skip_to_histexp",
+   "cached_nodes": 1,
+   "ghidra_branches": 60
+  },
+  {
+   "project": "openssh-portable",
+   "func": "do_upload",
+   "cached_nodes": 1,
+   "ghidra_branches": 59
+  },
+  {
+   "project": "cronie",
+   "func": "load_env",
+   "cached_nodes": 1,
+   "ghidra_branches": 59
+  },
+  {
+   "project": "openssh-portable",
+   "func": "sftp_realpath",
+   "cached_nodes": 1,
+   "ghidra_branches": 58
+  },
+  {
+   "project": "iproute2",
+   "func": "print_rule",
+   "cached_nodes": 1,
+   "ghidra_branches": 58
+  },
+  {
+   "project": "tar",
+   "func": "sys_exec_command",
+   "cached_nodes": 1,
+   "ghidra_branches": 58
+  },
+  {
+   "project": "openssh-portable",
+   "func": "hostfile_replace_entries",
+   "cached_nodes": 1,
+   "ghidra_branches": 57
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_get_lost_and_found",
+   "cached_nodes": 1,
+   "ghidra_branches": 57
+  },
+  {
+   "project": "openssh-portable",
+   "func": "hostkeys_foreach_file",
+   "cached_nodes": 1,
+   "ghidra_branches": 56
+  },
+  {
+   "project": "gnutls",
+   "func": "print_info",
+   "cached_nodes": 1,
+   "ghidra_branches": 56
+  },
+  {
+   "project": "iproute2",
+   "func": "do_iproute",
+   "cached_nodes": 1,
+   "ghidra_branches": 56
+  },
+  {
+   "project": "iproute2",
+   "func": "do_iptunnel",
+   "cached_nodes": 1,
+   "ghidra_branches": 56
+  },
+  {
+   "project": "openssh-portable",
+   "func": "prime_test",
+   "cached_nodes": 1,
+   "ghidra_branches": 55
+  },
+  {
+   "project": "tar",
+   "func": "extract_archive",
+   "cached_nodes": 1,
+   "ghidra_branches": 55
+  },
+  {
+   "project": "bash",
+   "func": "split_at_delims",
+   "cached_nodes": 1,
+   "ghidra_branches": 55
+  },
+  {
+   "project": "libedit",
+   "func": "map_bind",
+   "cached_nodes": 1,
+   "ghidra_branches": 54
+  },
+  {
+   "project": "iproute2",
+   "func": "do_ioam6",
+   "cached_nodes": 1,
+   "ghidra_branches": 54
+  },
+  {
+   "project": "cronie",
+   "func": "load_database",
+   "cached_nodes": 1,
+   "ghidra_branches": 54
+  },
+  {
+   "project": "gzip",
+   "func": "unlzw",
+   "cached_nodes": 1,
+   "ghidra_branches": 53
+  },
+  {
+   "project": "bash",
+   "func": "_rl_dispatch_subseq",
+   "cached_nodes": 1,
+   "ghidra_branches": 53
+  },
+  {
+   "project": "iproute2",
+   "func": "print_neigh",
+   "cached_nodes": 1,
+   "ghidra_branches": 52
+  },
+  {
+   "project": "bash",
+   "func": "fmtulong",
+   "cached_nodes": 1,
+   "ghidra_branches": 52
+  },
+  {
+   "project": "bash",
+   "func": "fmtumax",
+   "cached_nodes": 1,
+   "ghidra_branches": 52
+  },
+  {
+   "project": "openssh-portable",
+   "func": "subprocess",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "openssh-portable",
+   "func": "scan_scaled",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "openssh-portable",
+   "func": "channel_output_poll",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "gnutls",
+   "func": "pin_callback",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass3",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "tar",
+   "func": "delete_archive_members",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "bash",
+   "func": "xdupmbstowcs",
+   "cached_nodes": 1,
+   "ghidra_branches": 51
+  },
+  {
+   "project": "gzip",
+   "func": "unpack",
+   "cached_nodes": 1,
+   "ghidra_branches": 50
+  },
+  {
+   "project": "libselinux",
+   "func": "getseuserbyname",
+   "cached_nodes": 1,
+   "ghidra_branches": 50
+  },
+  {
+   "project": "libedit",
+   "func": "el_wset",
+   "cached_nodes": 1,
+   "ghidra_branches": 49
+  },
+  {
+   "project": "zlib",
+   "func": "inflate_table",
+   "cached_nodes": 1,
+   "ghidra_branches": 49
+  },
+  {
+   "project": "openssh-portable",
+   "func": "do_copy",
+   "cached_nodes": 1,
+   "ghidra_branches": 48
+  },
+  {
+   "project": "openssh-portable",
+   "func": "dump_cfg_fmtint",
+   "cached_nodes": 1,
+   "ghidra_branches": 48
+  },
+  {
+   "project": "bash",
+   "func": "spname",
+   "cached_nodes": 1,
+   "ghidra_branches": 48
+  },
+  {
+   "project": "openssh-portable",
+   "func": "channel_proxy_downstream",
+   "cached_nodes": 1,
+   "ghidra_branches": 47
+  },
+  {
+   "project": "iproute2",
+   "func": "print_addrinfo",
+   "cached_nodes": 1,
+   "ghidra_branches": 47
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "add_encrypted_file",
+   "cached_nodes": 1,
+   "ghidra_branches": 47
+  },
+  {
+   "project": "tar",
+   "func": "transform_name_fp",
+   "cached_nodes": 1,
+   "ghidra_branches": 47
+  },
+  {
+   "project": "tar",
+   "func": "update_archive",
+   "cached_nodes": 1,
+   "ghidra_branches": 47
+  },
+  {
+   "project": "openssh-portable",
+   "func": "vis",
+   "cached_nodes": 1,
+   "ghidra_branches": 46
+  },
+  {
+   "project": "libselinux",
+   "func": "selinux_mkload_policy",
+   "cached_nodes": 1,
+   "ghidra_branches": 46
+  },
+  {
+   "project": "gzip",
+   "func": "unlzh",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "gzip",
+   "func": "unzip",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "openssh-portable",
+   "func": "do_get_users_groups_by_id",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_check_ext3_journal",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "bash",
+   "func": "assoc_to_kvpair",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "bash",
+   "func": "assoc_to_assign",
+   "cached_nodes": 1,
+   "ghidra_branches": 45
+  },
+  {
+   "project": "openssh-portable",
+   "func": "read_passphrase",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "openssh-portable",
+   "func": "client_x11_get_proto",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "gnutls",
+   "func": "get_other_name_set",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "sysvinit",
+   "func": "wall",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "libselinux",
+   "func": "selabel_x_init",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "tar",
+   "func": "gnu_flush_write",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "tar",
+   "func": "collect_and_sort_names",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "bash",
+   "func": "make_variable_value",
+   "cached_nodes": 1,
+   "ghidra_branches": 44
+  },
+  {
+   "project": "openssh-portable",
+   "func": "strmode",
+   "cached_nodes": 1,
+   "ghidra_branches": 43
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "region_allocate",
+   "cached_nodes": 1,
+   "ghidra_branches": 43
+  },
+  {
+   "project": "grep",
+   "func": "kwsincr",
+   "cached_nodes": 1,
+   "ghidra_branches": 43
+  },
+  {
+   "project": "bash",
+   "func": "_rl_find_completion_word",
+   "cached_nodes": 1,
+   "ghidra_branches": 43
+  },
+  {
+   "project": "openssh-portable",
+   "func": "BSDgetopt",
+   "cached_nodes": 1,
+   "ghidra_branches": 42
+  },
+  {
+   "project": "openssh-portable",
+   "func": "server_loop2",
+   "cached_nodes": 1,
+   "ghidra_branches": 42
+  },
+  {
+   "project": "openssh-portable",
+   "func": "gen_candidates",
+   "cached_nodes": 1,
+   "ghidra_branches": 42
+  },
+  {
+   "project": "zlib",
+   "func": "inflate_fast",
+   "cached_nodes": 1,
+   "ghidra_branches": 42
+  },
+  {
+   "project": "bash",
+   "func": "make_child",
+   "cached_nodes": 1,
+   "ghidra_branches": 41
+  },
+  {
+   "project": "bash",
+   "func": "rl_vi_bword",
+   "cached_nodes": 1,
+   "ghidra_branches": 41
+  },
+  {
+   "project": "libedit",
+   "func": "el_set",
+   "cached_nodes": 1,
+   "ghidra_branches": 40
+  },
+  {
+   "project": "dpkg",
+   "func": "process_queue",
+   "cached_nodes": 1,
+   "ghidra_branches": 40
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "check_resize_inode",
+   "cached_nodes": 1,
+   "ghidra_branches": 40
+  },
+  {
+   "project": "libselinux",
+   "func": "selabel_db_init",
+   "cached_nodes": 1,
+   "ghidra_branches": 40
+  },
+  {
+   "project": "tar",
+   "func": "sys_child_open_for_compress",
+   "cached_nodes": 1,
+   "ghidra_branches": 40
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_ecdsa_sk_verify",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_packet_send2_wrapped",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "openssh-portable",
+   "func": "ssh_krl_revoke_cert_by_key_id",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "iproute2",
+   "func": "xfrm_policy_print",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "bash",
+   "func": "decode_signal",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "bash",
+   "func": "unquoted_glob_pattern_p",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "bash",
+   "func": "bash_default_completion",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "bash",
+   "func": "redirection_error",
+   "cached_nodes": 1,
+   "ghidra_branches": 39
+  },
+  {
+   "project": "openssh-portable",
+   "func": "channel_post_open",
+   "cached_nodes": 1,
+   "ghidra_branches": 38
+  },
+  {
+   "project": "iproute2",
+   "func": "do_ipstats",
+   "cached_nodes": 1,
+   "ghidra_branches": 38
+  },
+  {
+   "project": "tar",
+   "func": "xattrs_xattrs_get",
+   "cached_nodes": 1,
+   "ghidra_branches": 38
+  },
+  {
+   "project": "bash",
+   "func": "command_substitute",
+   "cached_nodes": 1,
+   "ghidra_branches": 38
+  },
+  {
+   "project": "bash",
+   "func": "assign_array_element",
+   "cached_nodes": 1,
+   "ghidra_branches": 38
+  },
+  {
+   "project": "openssh-portable",
+   "func": "allowed_user",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  },
+  {
+   "project": "e2fsprogs",
+   "func": "e2fsck_pass2",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  },
+  {
+   "project": "bash",
+   "func": "bind_variable",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  },
+  {
+   "project": "bash",
+   "func": "unclosed_pair",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  },
+  {
+   "project": "bash",
+   "func": "parse_and_execute",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  },
+  {
+   "project": "bash",
+   "func": "sh_physpath",
+   "cached_nodes": 1,
+   "ghidra_branches": 37
+  }
+ ]
+}

--- a/docs/joern_failures/cat4_final.json
+++ b/docs/joern_failures/cat4_final.json
@@ -1,0 +1,34 @@
+{
+ "cat4_total": {
+  "angr": 525,
+  "phoenix": 541,
+  "ghidra": 40,
+  "ida": 452,
+  "binja": 826
+ },
+ "construct": {
+  "angr": {
+   "aggregate/array_return_type": 524,
+   "empty_or_oneliner": 1
+  },
+  "phoenix": {
+   "aggregate/array_return_type": 540,
+   "empty_or_oneliner": 1
+  },
+  "ghidra": {
+   "aggregate/array_return_type": 36,
+   "other": 4
+  },
+  "ida": {
+   "empty_or_oneliner": 75,
+   "other": 377
+  },
+  "binja": {
+   "register_annotation(@reg)": 182,
+   "other": 538,
+   "empty_or_oneliner": 105,
+   "aggregate/array_return_type": 1
+  },
+  "kuna": {}
+ }
+}

--- a/docs/joern_failures/cat4_refined.json
+++ b/docs/joern_failures/cat4_refined.json
@@ -1,0 +1,263 @@
+{
+ "cat4_refined": {
+  "angr": 525,
+  "phoenix": 541,
+  "ghidra": 40,
+  "ida": 452,
+  "binja": 826
+ },
+ "underscore_fp": {
+  "ida": 18,
+  "angr": 2,
+  "phoenix": 2
+ },
+ "cat4_construct": {
+  "angr": {
+   "other": 282,
+   "aggregate/array_return_type": 237,
+   "empty_or_oneliner": 6
+  },
+  "phoenix": {
+   "other": 291,
+   "aggregate/array_return_type": 244,
+   "empty_or_oneliner": 6
+  },
+  "ghidra": {
+   "aggregate/array_return_type": 33,
+   "other": 7
+  },
+  "ida": {
+   "empty_or_oneliner": 75,
+   "other": 377
+  },
+  "binja": {
+   "binja_reg_annotation(@reg)": 183,
+   "other": 537,
+   "empty_or_oneliner": 105,
+   "aggregate/array_return_type": 1
+  },
+  "kuna": {}
+ },
+ "samples": {
+  "angr": [
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "pqdownheap",
+    "construct": "other",
+    "sig": "extern unsigned int g_4df200[1277633];"
+   },
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "read_tree",
+    "construct": "other",
+    "sig": "extern unsigned long long g_4e13e0;"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "sdiff",
+    "func": "lf_skip",
+    "construct": "aggregate/array_return_type",
+    "sig": "void* [4] lf_skip(void* *p, unsigned long long a1)"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "cmp",
+    "func": "file_position",
+    "construct": "other",
+    "sig": "extern unsigned int g_4100b0[4];"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff3",
+    "func": "scan_diff_line",
+    "construct": "other",
+    "sig": "typedef struct struct_0 {"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "add_change",
+    "construct": "aggregate/array_return_type",
+    "sig": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)"
+   }
+  ],
+  "phoenix": [
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "pqdownheap",
+    "construct": "other",
+    "sig": "extern unsigned int g_4df200[1277633];"
+   },
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "read_tree",
+    "construct": "other",
+    "sig": "extern unsigned long long g_4e13e0;"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff3",
+    "func": "scan_diff_line",
+    "construct": "other",
+    "sig": "typedef struct struct_0 {"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "add_change",
+    "construct": "aggregate/array_return_type",
+    "sig": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "build_reverse_script",
+    "construct": "other",
+    "sig": "typedef struct struct_0 {"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "build_script",
+    "construct": "aggregate/array_return_type",
+    "sig": "unsigned long long [5] build_script(unsigned long long *ptr)"
+   }
+  ],
+  "ghidra": [
+   {
+    "proj": "gnutls",
+    "bin": "gnutls-serv",
+    "func": "wrap_db_fetch",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)"
+   },
+   {
+    "proj": "coreutils",
+    "bin": "stat",
+    "func": "neg_to_zero",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] neg_to_zero(undefined8 param_1,long param_2)"
+   },
+   {
+    "proj": "coreutils",
+    "bin": "dir",
+    "func": "dev_ino_pop",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] dev_ino_pop(void)"
+   },
+   {
+    "proj": "coreutils",
+    "bin": "dir",
+    "func": "get_stat_btime",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] get_stat_btime(undefined8 param_1)"
+   },
+   {
+    "proj": "coreutils",
+    "bin": "ls",
+    "func": "dev_ino_pop",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] dev_ino_pop(void)"
+   },
+   {
+    "proj": "coreutils",
+    "bin": "ls",
+    "func": "get_stat_btime",
+    "construct": "aggregate/array_return_type",
+    "sig": "undefined1  [16] get_stat_btime(undefined8 param_1)"
+   }
+  ],
+  "ida": [
+   {
+    "proj": "coreutils",
+    "bin": "make-prime-list",
+    "func": "print_wide_uint",
+    "construct": "other",
+    "sig": "int print_wide_uint(unsigned __int128 a1, int a2, unsigned int a3)"
+   },
+   {
+    "proj": "libbsd",
+    "bin": "libbsd.so.0.11",
+    "func": "__fdnlist",
+    "construct": "other",
+    "sig": "// bad sp value at call has been detected, the output may be wrong!"
+   },
+   {
+    "proj": "bash",
+    "bin": "bash",
+    "func": "_rl_internal_char_cleanup",
+    "construct": "other",
+    "sig": "long long rl_internal_char_cleanup()"
+   },
+   {
+    "proj": "bash",
+    "bin": "bash",
+    "func": "_rl_init_line_state",
+    "construct": "other",
+    "sig": "char *rl_init_line_state()"
+   },
+   {
+    "proj": "bash",
+    "bin": "bash",
+    "func": "_rl_keyseq_cxt_alloc",
+    "construct": "other",
+    "sig": "long long rl_keyseq_cxt_alloc()"
+   },
+   {
+    "proj": "bash",
+    "bin": "bash",
+    "func": "_rl_keyseq_chain_dispose",
+    "construct": "other",
+    "sig": "long long rl_keyseq_chain_dispose()"
+   }
+  ],
+  "binja": [
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "rpl_fcntl",
+    "construct": "binja_reg_annotation(@reg)",
+    "sig": "uint64_t rpl_fcntl(int32_t arg1, int32_t arg2, char arg3 @ rax)"
+   },
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "open_safer",
+    "construct": "binja_reg_annotation(@reg)",
+    "sig": "uint64_t open_safer(char* arg1, int32_t arg2, char arg3 @ rax)"
+   },
+   {
+    "proj": "gzip",
+    "bin": "gzip",
+    "func": "openat_safer",
+    "construct": "binja_reg_annotation(@reg)",
+    "sig": "uint64_t openat_safer(int32_t arg1, char* arg2, int32_t arg3, char arg4 @ rax)"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "print_context_script",
+    "construct": "other",
+    "sig": "int64_t* print_context_script(int64_t* arg1, char arg2)"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "find_function",
+    "construct": "other",
+    "sig": "char* find_function(void* arg1, int64_t arg2)"
+   },
+   {
+    "proj": "diffutils",
+    "bin": "diff",
+    "func": "compare_names_for_qsort",
+    "construct": "other",
+    "sig": "uint64_t compare_names_for_qsort(int64_t* arg1, int64_t* arg2)"
+   }
+  ]
+ }
+}

--- a/docs/joern_failures/cat5_source_parse.json
+++ b/docs/joern_failures/cat5_source_parse.json
@@ -1,0 +1,350 @@
+{
+ "probed": 49,
+ "exceptions": [],
+ "empty": [],
+ "results": [
+  {
+   "file": "libwc_avx2_a-wc_avx2.i",
+   "size": 1453656,
+   "funcs": 143,
+   "degen_in_file": 125,
+   "err": null
+  },
+  {
+   "file": "crontab.i",
+   "size": 179913,
+   "funcs": 72,
+   "degen_in_file": 58,
+   "err": null
+  },
+  {
+   "file": "bzip2.i",
+   "size": 211212,
+   "funcs": 68,
+   "degen_in_file": 36,
+   "err": null
+  },
+  {
+   "file": "libcksum_pclmul_a-cksum_pclmul.i",
+   "size": 1456815,
+   "funcs": 140,
+   "degen_in_file": 122,
+   "err": null
+  },
+  {
+   "file": "update-passwd.i",
+   "size": 185570,
+   "funcs": 48,
+   "degen_in_file": 11,
+   "err": null
+  },
+  {
+   "file": "bzlib.i",
+   "size": 127186,
+   "funcs": 48,
+   "degen_in_file": 14,
+   "err": null
+  },
+  {
+   "file": "y.tab.i",
+   "size": 490799,
+   "funcs": 1405,
+   "degen_in_file": 1403,
+   "err": null
+  },
+  {
+   "file": "cron.i",
+   "size": 172424,
+   "funcs": 68,
+   "degen_in_file": 59,
+   "err": null
+  },
+  {
+   "file": "util.i",
+   "size": 235187,
+   "funcs": 121,
+   "degen_in_file": 93,
+   "err": null
+  },
+  {
+   "file": "diff.i",
+   "size": 258270,
+   "funcs": 148,
+   "degen_in_file": 131,
+   "err": null
+  },
+  {
+   "file": "unpack.i",
+   "size": 258411,
+   "funcs": 406,
+   "degen_in_file": 381,
+   "err": null
+  },
+  {
+   "file": "archives.i",
+   "size": 242400,
+   "funcs": 408,
+   "degen_in_file": 378,
+   "err": null
+  },
+  {
+   "file": "subst.i",
+   "size": 559704,
+   "funcs": 1160,
+   "degen_in_file": 1019,
+   "err": null
+  },
+  {
+   "file": "unix.i",
+   "size": 390757,
+   "funcs": 987,
+   "degen_in_file": 936,
+   "err": null
+  },
+  {
+   "file": "pass1.i",
+   "size": 389963,
+   "funcs": 961,
+   "degen_in_file": 886,
+   "err": null
+  },
+  {
+   "file": "pred.i",
+   "size": 443355,
+   "funcs": 232,
+   "degen_in_file": 189,
+   "err": null
+  },
+  {
+   "file": "pcresearch.i",
+   "size": 243917,
+   "funcs": 101,
+   "degen_in_file": 92,
+   "err": null
+  },
+  {
+   "file": "parser.i",
+   "size": 514255,
+   "funcs": 310,
+   "degen_in_file": 240,
+   "err": null
+  },
+  {
+   "file": "grep.i",
+   "size": 364323,
+   "funcs": 252,
+   "degen_in_file": 172,
+   "err": null
+  },
+  {
+   "file": "cli.i",
+   "size": 502939,
+   "funcs": 1278,
+   "degen_in_file": 1231,
+   "err": null
+  },
+  {
+   "file": "certtool.i",
+   "size": 546106,
+   "funcs": 1323,
+   "degen_in_file": 1255,
+   "err": null
+  },
+  {
+   "file": "gzip.i",
+   "size": 239527,
+   "funcs": 139,
+   "degen_in_file": 112,
+   "err": null
+  },
+  {
+   "file": "libgzip_a-printf-frexpl.i",
+   "size": 168312,
+   "funcs": 1,
+   "degen_in_file": 0,
+   "err": null
+  },
+  {
+   "file": "iproute_lwtunnel.i",
+   "size": 362476,
+   "funcs": 458,
+   "degen_in_file": 401,
+   "err": null
+  },
+  {
+   "file": "depmod.i",
+   "size": 298532,
+   "funcs": 248,
+   "degen_in_file": 174,
+   "err": null
+  },
+  {
+   "file": "getfacl.i",
+   "size": 151265,
+   "funcs": 62,
+   "degen_in_file": 49,
+   "err": null
+  },
+  {
+   "file": "ipaddress.i",
+   "size": 357344,
+   "funcs": 431,
+   "degen_in_file": 377,
+   "err": null
+  },
+  {
+   "file": "modprobe.i",
+   "size": 190476,
+   "funcs": 111,
+   "degen_in_file": 93,
+   "err": null
+  },
+  {
+   "file": "setfacl.i",
+   "size": 142413,
+   "funcs": 53,
+   "degen_in_file": 47,
+   "err": null
+  },
+  {
+   "file": "getentropy.i",
+   "size": 234561,
+   "funcs": 48,
+   "degen_in_file": 42,
+   "err": null
+  },
+  {
+   "file": "arc4random.i",
+   "size": 193150,
+   "funcs": 56,
+   "degen_in_file": 46,
+   "err": null
+  },
+  {
+   "file": "xmlwf-xmlfile.i",
+   "size": 106886,
+   "funcs": 72,
+   "degen_in_file": 66,
+   "err": null
+  },
+  {
+   "file": "readline.i",
+   "size": 267565,
+   "funcs": 305,
+   "degen_in_file": 249,
+   "err": null
+  },
+  {
+   "file": "xmlwf-xmlwf.i",
+   "size": 156079,
+   "funcs": 115,
+   "degen_in_file": 94,
+   "err": null
+  },
+  {
+   "file": "terminal.i",
+   "size": 231409,
+   "funcs": 188,
+   "degen_in_file": 158,
+   "err": null
+  },
+  {
+   "file": "selinux_restorecon.i",
+   "size": 305501,
+   "funcs": 241,
+   "degen_in_file": 211,
+   "err": null
+  },
+  {
+   "file": "label_file.i",
+   "size": 260875,
+   "funcs": 232,
+   "degen_in_file": 196,
+   "err": null
+  },
+  {
+   "file": "ssh-keygen.i",
+   "size": 972910,
+   "funcs": 545,
+   "degen_in_file": 483,
+   "err": null
+  },
+  {
+   "file": "sshkey.i",
+   "size": 939066,
+   "funcs": 421,
+   "degen_in_file": 329,
+   "err": null
+  },
+  {
+   "file": "rsyslogd-rsyslogd.i",
+   "size": 376206,
+   "funcs": 598,
+   "degen_in_file": 562,
+   "err": null
+  },
+  {
+   "file": "last.i",
+   "size": 192008,
+   "funcs": 12,
+   "degen_in_file": 5,
+   "err": null
+  },
+  {
+   "file": "usermod.i",
+   "size": 297841,
+   "funcs": 241,
+   "degen_in_file": 222,
+   "err": null
+  },
+  {
+   "file": "useradd.i",
+   "size": 304886,
+   "funcs": 252,
+   "degen_in_file": 226,
+   "err": null
+  },
+  {
+   "file": "rsyslogd-omfwd.i",
+   "size": 400795,
+   "funcs": 536,
+   "degen_in_file": 500,
+   "err": null
+  },
+  {
+   "file": "init.i",
+   "size": 246728,
+   "funcs": 55,
+   "degen_in_file": 11,
+   "err": null
+  },
+  {
+   "file": "tar.i",
+   "size": 355659,
+   "funcs": 491,
+   "degen_in_file": 441,
+   "err": null
+  },
+  {
+   "file": "extract.i",
+   "size": 319154,
+   "funcs": 427,
+   "degen_in_file": 382,
+   "err": null
+  },
+  {
+   "file": "crc32.i",
+   "size": 165809,
+   "funcs": 95,
+   "degen_in_file": 90,
+   "err": null
+  },
+  {
+   "file": "deflate.i",
+   "size": 131355,
+   "funcs": 109,
+   "degen_in_file": 83,
+   "err": null
+  }
+ ]
+}

--- a/docs/joern_failures/catalog.json
+++ b/docs/joern_failures/catalog.json
@@ -1,0 +1,4924 @@
+{
+ "meta": {
+  "results_tree": "results/full_run",
+  "ged_new_json": "results/full_run/ged_new.json",
+  "ged_src_pkls": "results/full_run/ged_src/<project>.pkl",
+  "decompilers": [
+   "angr",
+   "phoenix",
+   "ghidra",
+   "ida",
+   "binja",
+   "kuna"
+  ],
+  "opt_levels": [
+   "O0",
+   "O2",
+   "O2-noinline"
+  ],
+  "ged_projects_count": 25,
+  "note": "ged_new covers the 25 x86 sailr projects only (cps/malware have no source CFGs).",
+  "total_ged_evals": 225753,
+  "finite_real_ged_evals": 105236,
+  "inf_degenerate_evals": 120517
+ },
+ "category_totals": {
+  "cat1_degenerate_source": {
+   "distinct_source_functions": 17745,
+   "distinct_degenerate": 11023,
+   "pct_degenerate": 62.1,
+   "distinct_empty_prototype": 9060,
+   "distinct_straightline_body": 1963,
+   "inf_evals_total": 120517,
+   "inf_evals_empty_proto": 96494,
+   "inf_evals_straightline": 24023,
+   "inf_by_opt": {
+    "O2": 34409,
+    "O0": 43643,
+    "O2-noinline": 42465
+   },
+   "inf_by_dec": {
+    "kuna": 22499,
+    "ida": 28381,
+    "phoenix": 18553,
+    "angr": 17933,
+    "ghidra": 28681,
+    "binja": 4470
+   },
+   "inf_by_project": {
+    "sysvinit": 817,
+    "coreutils": 12542,
+    "diffutils": 474,
+    "zlib": 6136,
+    "shadow": 976,
+    "rsyslog": 617,
+    "e2fsprogs": 1823,
+    "gnutls": 5186,
+    "openssh-portable": 57111,
+    "libacl": 1438,
+    "bzip2": 784,
+    "bash": 8181,
+    "cronie": 2064,
+    "libexpat": 474,
+    "dpkg": 2901,
+    "base-passwd": 138,
+    "iproute2": 2345,
+    "findutils": 1775,
+    "libedit": 4707,
+    "gzip": 1192,
+    "libbsd": 260,
+    "kmod": 173,
+    "grep": 407,
+    "libselinux": 4053,
+    "tar": 3943
+   }
+  },
+  "cat1b_recoverable_via_merge_fix": {
+   "note": "Degenerate cached CFGs whose REAL body exists in a captured .i but was clobbered by the nondeterministic last-writer-wins merge (proto stub wins). PROVEN: zlib deflate=1 node cached / 176 fresh; e2fsck_pass1=1/443.",
+   "recoverable_projfunc_strict_ge2branches": 2579,
+   "recoverable_projfunc_loose": 3394,
+   "inf_evals_recoverable_strict": 77236,
+   "inf_evals_recoverable_loose": 92774,
+   "pct_of_inf_recoverable_strict": 64.1,
+   "pct_of_inf_recoverable_loose": 77.0,
+   "current_finite_evals": 105236,
+   "coverage_gain_pct_if_fixed_loose": 88.2,
+   "recoverable_by_project": {
+    "e2fsprogs": 112,
+    "iproute2": 104,
+    "bzip2": 28,
+    "dpkg": 67,
+    "grep": 16,
+    "diffutils": 7,
+    "gzip": 36,
+    "zlib": 59,
+    "coreutils": 85,
+    "gnutls": 74,
+    "openssh-portable": 654,
+    "bash": 673,
+    "libedit": 174,
+    "tar": 156,
+    "libacl": 50,
+    "cronie": 34,
+    "sysvinit": 11,
+    "libselinux": 184,
+    "rsyslog": 12,
+    "findutils": 29,
+    "shadow": 4,
+    "libexpat": 6,
+    "kmod": 1,
+    "base-passwd": 1,
+    "libbsd": 2
+   }
+  },
+  "cat2_name_collision_wrong_source": {
+   "true_collision_groups_opt_proj_func": 508,
+   "harmless_dup_groups": 5615,
+   "wrong_source_evals_upper_bound": 11665,
+   "wrong_source_evals_finite": 8457,
+   "per_project": {
+    "diffutils": {
+     "collision_groups": 9,
+     "wrong_source_evals": 157
+    },
+    "openssh-portable": {
+     "collision_groups": 224,
+     "wrong_source_evals": 2493
+    },
+    "gnutls": {
+     "collision_groups": 57,
+     "wrong_source_evals": 836
+    },
+    "bzip2": {
+     "collision_groups": 7,
+     "wrong_source_evals": 38
+    },
+    "iproute2": {
+     "collision_groups": 6,
+     "wrong_source_evals": 32
+    },
+    "coreutils": {
+     "collision_groups": 81,
+     "wrong_source_evals": 4481
+    },
+    "shadow": {
+     "collision_groups": 51,
+     "wrong_source_evals": 2461
+    },
+    "libacl": {
+     "collision_groups": 22,
+     "wrong_source_evals": 148
+    },
+    "zlib": {
+     "collision_groups": 5,
+     "wrong_source_evals": 138
+    },
+    "dpkg": {
+     "collision_groups": 11,
+     "wrong_source_evals": 204
+    },
+    "sysvinit": {
+     "collision_groups": 16,
+     "wrong_source_evals": 449
+    },
+    "cronie": {
+     "collision_groups": 11,
+     "wrong_source_evals": 102
+    },
+    "bash": {
+     "collision_groups": 8,
+     "wrong_source_evals": 126
+    }
+   }
+  },
+  "cat3_binja_loading_placeholder": {
+   "by_opt": {
+    "O0": {
+     "functions": 24757,
+     "loading": 18018
+    },
+    "O2": {
+     "functions": 18167,
+     "loading": 14162
+    },
+    "O2-noinline": {
+     "functions": 23571,
+     "loading": 17809
+    }
+   },
+   "all_opts": {
+    "functions": 66495,
+    "loading": 49989,
+    "pct": 75.2
+   },
+   "num_100pct_loading_binaries": 28,
+   "o0_per_project": {
+    "gzip": {
+     "total": 150,
+     "loading": 0
+    },
+    "diffutils": {
+     "total": 172,
+     "loading": 85
+    },
+    "mirai": {
+     "total": 68,
+     "loading": 0
+    },
+    "openssh-portable": {
+     "total": 7554,
+     "loading": 7524
+    },
+    "gnutls": {
+     "total": 871,
+     "loading": 574
+    },
+    "bzip2": {
+     "total": 120,
+     "loading": 44
+    },
+    "libedit": {
+     "total": 513,
+     "loading": 467
+    },
+    "mydoom": {
+     "total": 168,
+     "loading": 0
+    },
+    "iproute2": {
+     "total": 762,
+     "loading": 757
+    },
+    "libexpat": {
+     "total": 58,
+     "loading": 13
+    },
+    "coreutils": {
+     "total": 2845,
+     "loading": 1448
+    },
+    "x0r-usb": {
+     "total": 34,
+     "loading": 0
+    },
+    "shadow": {
+     "total": 312,
+     "loading": 0
+    },
+    "cleanflight": {
+     "total": 1915,
+     "loading": 1911
+    },
+    "libacl": {
+     "total": 144,
+     "loading": 0
+    },
+    "zlib": {
+     "total": 779,
+     "loading": 0
+    },
+    "dpkg": {
+     "total": 354,
+     "loading": 238
+    },
+    "riot-os": {
+     "total": 66,
+     "loading": 0
+    },
+    "e2fsprogs": {
+     "total": 409,
+     "loading": 409
+    },
+    "sysvinit": {
+     "total": 195,
+     "loading": 0
+    },
+    "libselinux": {
+     "total": 418,
+     "loading": 0
+    },
+    "chibios": {
+     "total": 415,
+     "loading": 0
+    },
+    "mirai-win": {
+     "total": 54,
+     "loading": 0
+    },
+    "freertos": {
+     "total": 38,
+     "loading": 0
+    },
+    "tar": {
+     "total": 654,
+     "loading": 646
+    },
+    "base-passwd": {
+     "total": 48,
+     "loading": 0
+    },
+    "libbsd": {
+     "total": 67,
+     "loading": 0
+    },
+    "grep": {
+     "total": 109,
+     "loading": 100
+    },
+    "kmod": {
+     "total": 129,
+     "loading": 101
+    },
+    "crazyflie": {
+     "total": 179,
+     "loading": 1
+    },
+    "cronie": {
+     "total": 203,
+     "loading": 0
+    },
+    "libopencm3": {
+     "total": 1024,
+     "loading": 117
+    },
+    "nuttx": {
+     "total": 399,
+     "loading": 379
+    },
+    "minipig": {
+     "total": 74,
+     "loading": 0
+    },
+    "dexter": {
+     "total": 114,
+     "loading": 0
+    },
+    "betaflight": {
+     "total": 1737,
+     "loading": 1736
+    },
+    "bash": {
+     "total": 1153,
+     "loading": 1056
+    },
+    "findutils": {
+     "total": 313,
+     "loading": 274
+    },
+    "rsyslog": {
+     "total": 140,
+     "loading": 138
+    }
+   }
+  },
+  "cat4_decompiled_parse_failure": {
+   "note": "Decompiler produced a real (non-Loading) function body but Joern returned no CFG for it (source CFG present). Per-function (Joern recovers neighbors).",
+   "per_dec_total": {
+    "angr": 525,
+    "phoenix": 541,
+    "ghidra": 40,
+    "ida": 452,
+    "binja": 826
+   },
+   "per_dec_construct": {
+    "angr": {
+     "aggregate/array_return_type": 524,
+     "empty_or_oneliner": 1
+    },
+    "phoenix": {
+     "aggregate/array_return_type": 540,
+     "empty_or_oneliner": 1
+    },
+    "ghidra": {
+     "aggregate/array_return_type": 36,
+     "other": 4
+    },
+    "ida": {
+     "empty_or_oneliner": 75,
+     "other": 377
+    },
+    "binja": {
+     "register_annotation(@reg)": 182,
+     "other": 538,
+     "empty_or_oneliner": 105,
+     "aggregate/array_return_type": 1
+    },
+    "kuna": {}
+   },
+   "breakers": {
+    "angr_phoenix_ghidra": "aggregate/array return type rendered as 'T [N] name(...)' (ghidra: 'undefined1 [16]') -> Joern parses nothing. CONFIRMED.",
+    "binja": "'arg @ rax' register annotations in the signature -> Joern parses nothing (CONFIRMED); plus ~538 'other' that parse fine ALONE but are dropped in the whole-file parse (error-recovery cascade among @reg-malformed neighbors).",
+    "ida": "'__int128' params/returns -> Joern parses nothing (CONFIRMED); plus multi-underscore name-normalization mismatches and whole-file effects.",
+    "kuna": "0 -- kuna output is Joern-clean."
+   }
+  },
+  "cat5_source_parse_failure": {
+   "note": "Probe of largest .i per project. Header-stripping already fixed the old timeouts.",
+   "probed": 49,
+   "exceptions": [],
+   "empty_returns": []
+  }
+ },
+ "examples": {
+  "cat1_empty_prototype_top_names": [
+   {
+    "function": "xmalloc",
+    "n_projects": 8
+   },
+   {
+    "function": "xrealloc",
+    "n_projects": 7
+   },
+   {
+    "function": "error_at_line",
+    "n_projects": 7
+   },
+   {
+    "function": "xstrdup",
+    "n_projects": 7
+   },
+   {
+    "function": "xalloc_die",
+    "n_projects": 7
+   },
+   {
+    "function": "last_component",
+    "n_projects": 7
+   },
+   {
+    "function": "error",
+    "n_projects": 7
+   },
+   {
+    "function": "gettime",
+    "n_projects": 7
+   },
+   {
+    "function": "rpl_fcntl",
+    "n_projects": 7
+   },
+   {
+    "function": "base_len",
+    "n_projects": 7
+   },
+   {
+    "function": "xcalloc",
+    "n_projects": 6
+   },
+   {
+    "function": "mdir_name",
+    "n_projects": 6
+   },
+   {
+    "function": "strip_trailing_slashes",
+    "n_projects": 6
+   },
+   {
+    "function": "xmemdup",
+    "n_projects": 6
+   },
+   {
+    "function": "dir_len",
+    "n_projects": 6
+   },
+   {
+    "function": "x2realloc",
+    "n_projects": 6
+   },
+   {
+    "function": "xzalloc",
+    "n_projects": 6
+   },
+   {
+    "function": "settime",
+    "n_projects": 6
+   },
+   {
+    "function": "hash_remove",
+    "n_projects": 5
+   },
+   {
+    "function": "hash_string",
+    "n_projects": 5
+   },
+   {
+    "function": "mbscasecmp",
+    "n_projects": 5
+   },
+   {
+    "function": "fpurge",
+    "n_projects": 5
+   },
+   {
+    "function": "setlocale_null",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtoull",
+    "n_projects": 5
+   },
+   {
+    "function": "ximalloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xreallocarray",
+    "n_projects": 5
+   },
+   {
+    "function": "ximemdup",
+    "n_projects": 5
+   },
+   {
+    "function": "quote_n",
+    "n_projects": 5
+   },
+   {
+    "function": "quote_n_mem",
+    "n_projects": 5
+   },
+   {
+    "function": "xicalloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xizalloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtoll",
+    "n_projects": 5
+   },
+   {
+    "function": "setlocale_null_r",
+    "n_projects": 5
+   },
+   {
+    "function": "mktime_z",
+    "n_projects": 5
+   },
+   {
+    "function": "quote",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtoimax",
+    "n_projects": 5
+   },
+   {
+    "function": "xirealloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtol",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtoul",
+    "n_projects": 5
+   },
+   {
+    "function": "tzfree",
+    "n_projects": 5
+   },
+   {
+    "function": "ximemdup0",
+    "n_projects": 5
+   },
+   {
+    "function": "tzalloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xpalloc",
+    "n_projects": 5
+   },
+   {
+    "function": "xstrtoumax",
+    "n_projects": 5
+   },
+   {
+    "function": "x2nrealloc",
+    "n_projects": 5
+   },
+   {
+    "function": "quote_mem",
+    "n_projects": 5
+   },
+   {
+    "function": "xireallocarray",
+    "n_projects": 5
+   },
+   {
+    "function": "hash_free",
+    "n_projects": 5
+   },
+   {
+    "function": "hash_xinsert",
+    "n_projects": 5
+   },
+   {
+    "function": "wcsdup",
+    "n_projects": 5
+   },
+   {
+    "function": "malloc",
+    "n_projects": 4
+   },
+   {
+    "function": "strdup",
+    "n_projects": 4
+   },
+   {
+    "function": "realloc",
+    "n_projects": 4
+   },
+   {
+    "function": "calloc",
+    "n_projects": 4
+   },
+   {
+    "function": "aligned_alloc",
+    "n_projects": 4
+   },
+   {
+    "function": "mbsstr",
+    "n_projects": 4
+   },
+   {
+    "function": "fopen",
+    "n_projects": 4
+   },
+   {
+    "function": "mbslen",
+    "n_projects": 4
+   },
+   {
+    "function": "free",
+    "n_projects": 4
+   },
+   {
+    "function": "canonicalize_file_name",
+    "n_projects": 4
+   }
+  ],
+  "cat1_straightline_body_samples": [
+   {
+    "project": "base-passwd",
+    "function": "create_node",
+    "stmts": [
+     "<UnsupportedStmt: UNKNOWN,struct_node*,struct_node*>",
+     "<UnsupportedStmt: ['sizeOf', 'sizeof(struct_node)']>",
+     "xmalloc(sizeof(struct_node))",
+     "<UnsupportedStmt: ['cast', '(struct_node*)xmalloc(sizeof(struct_node))']>",
+     "newnode = (struct_node*)xmalloc(sizeof(struct_n...",
+     "<UnsupportedStmt: FIELD_IDENTIFIER,name,name>"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "copy_passwd",
+    "stmts": [
+     "<UnsupportedStmt: FIELD_IDENTIFIER,d,d>",
+     "<UnsupportedStmt: ['indirectFieldAccess', 'newnode-&gt;d']>",
+     "<UnsupportedStmt: FIELD_IDENTIFIER,pw,pw>",
+     "<UnsupportedStmt: ['fieldAccess', 'newnode-&gt;d.pw']>",
+     "<UnsupportedStmt: ['indirection', '*pw']>",
+     "newnode-&gt;d.pw = *pw"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "copy_shadow",
+    "stmts": [
+     "<UnsupportedStmt: FIELD_IDENTIFIER,d,d>",
+     "<UnsupportedStmt: ['indirectFieldAccess', 'newnode-&gt;d']>",
+     "<UnsupportedStmt: FIELD_IDENTIFIER,sp,sp>",
+     "<UnsupportedStmt: ['fieldAccess', 'newnode-&gt;d.sp']>",
+     "<UnsupportedStmt: ['indirection', '*sp']>",
+     "newnode-&gt;d.sp = *sp"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "keephome",
+    "stmts": [
+     "scan_infos()",
+     "return scan_infos(lst,id,0x0001);,returnscan_infos(lst,id,0x0001);"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "keepshell",
+    "stmts": [
+     "scan_infos()",
+     "return scan_infos(lst,id,0x0002);,returnscan_infos(lst,id,0x0002);"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "keepgecos",
+    "stmts": [
+     "scan_infos()",
+     "return scan_infos(lst,id,0x0004);,returnscan_infos(lst,id,0x0004);"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "noautoremove",
+    "stmts": [
+     "scan_infos()",
+     "return scan_infos(lst,id,0x0010);,returnscan_infos(lst,id,0x0010);"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "noautoadd",
+    "stmts": [
+     "scan_infos()",
+     "return scan_infos(lst,id,0x0020);,returnscan_infos(lst,id,0x0020);"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "usage",
+    "stmts": [
+     "<UnsupportedStmt: >",
+     "<UnsupportedStmt: >",
+     "<UnsupportedStmt: >"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "version",
+    "stmts": [
+     "printf()"
+    ]
+   },
+   {
+    "project": "base-passwd",
+    "function": "ask_debconf",
+    "stmts": [
+     "return 0;,return0;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "usage",
+    "stmts": [
+     "<UnsupportedStmt: >",
+     "<UnsupportedStmt: >",
+     "<UnsupportedStmt: >"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "is_basic",
+    "stmts": [
+     "<UnsupportedStmt: UNKNOWN,unsignedchar,unsignedchar>",
+     "<UnsupportedStmt: ['cast', '(unsignedchar)c']>",
+     "<UnsupportedStmt: ['arithmeticShiftRight', '(unsignedchar)c&gt;&gt;5']>",
+     "<UnsupportedStmt: ['indirectIndexAccess', 'is_basic_table[(unsignedchar)c&gt;&gt;5]']>",
+     "<UnsupportedStmt: UNKNOWN,unsignedchar,unsignedchar>",
+     "<UnsupportedStmt: ['cast', '(unsignedchar)c']>"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "sort_aliases",
+    "stmts": [
+     "<UnsupportedStmt: UNKNOWN,char**,char**>",
+     "<UnsupportedStmt: ['cast', '(char**)array']>",
+     "strvec_len((char**)array)",
+     "<UnsupportedStmt: ['sizeOf', 'sizeof(alias_t*)']>",
+     "<UnsupportedStmt: UNKNOWN,QSFUNC*,QSFUNC*>",
+     "<UnsupportedStmt: ['cast', '(QSFUNC*)qsort_alias_compare']>"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "_rl_vi_set_last",
+    "stmts": [
+     "_rl_vi_last_command = key",
+     "_rl_vi_last_repeat = repeat",
+     "_rl_vi_last_arg_sign = sign"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "_rl_vi_reset_last",
+    "stmts": [
+     "_rl_vi_last_command = 'i'",
+     "_rl_vi_last_repeat = 1",
+     "_rl_vi_last_arg_sign = 1",
+     "_rl_vi_last_motion = 0"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "cdxattr",
+    "stmts": [
+     "-1 - ",
+     "return -1;,return-1;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "resetxattr",
+    "stmts": [
+     "-1 - ",
+     "xattrfd = -1"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "really_add_history",
+    "stmts": [
+     "hist_last_line_added = 1",
+     "hist_last_line_pushed = 0",
+     "add_history(line)",
+     "<UnsupportedStmt: ['postIncrement', 'history_lines_this_session++']>"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "last_history_entry",
+    "stmts": [
+     "using_history()",
+     "previous_history()",
+     "he = previous_history()",
+     "using_history()",
+     "return he;,returnhe;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "sv_region_start_color",
+    "stmts": [
+     "_rl_reset_region_color()",
+     "return (_rl_reset_region_color(0,value));,return(_rl_reset_region_color(0,value));"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "sv_region_end_color",
+    "stmts": [
+     "_rl_reset_region_color()",
+     "return (_rl_reset_region_color(1,value));,return(_rl_reset_region_color(1,value));"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "display_shell_version",
+    "stmts": [
+     "rl_crlf()",
+     "show_shell_version(0)",
+     "putc()",
+     "fflush(rl_outstream)",
+     "rl_on_new_line()",
+     "rl_redisplay()"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "emacs_edit_and_execute_command",
+    "stmts": [
+     "edit_and_execute_command()",
+     "return (edit_and_execute_command(count,c,1,...,return(edit_and_execute_command(count,c,1,..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "find_cmd_end",
+    "stmts": [
+     "<UnsupportedStmt: ['or', '0x001|0x100']>",
+     "skip_to_delim()",
+     "e = skip_to_delim(rl_line_buffer,end,&quot;;|&amp;{(`...",
+     "return e;,returne;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "test_for_directory",
+    "stmts": [
+     "bash_tilde_expand()",
+     "fn = bash_tilde_expand(name,0)",
+     "file_isdir(fn)",
+     "r = file_isdir(fn)",
+     "sh_xfree((fn)",
+     "return (r);,return(r);"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_ignore_filenames",
+    "stmts": [
+     "_ignore_completion_names()",
+     "return 0;,return0;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_progcomp_ignore_filenames",
+    "stmts": [
+     "_ignore_completion_names()",
+     "return 0;,return0;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "return_zero",
+    "stmts": [
+     "return 0;,return0;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_ignore_everything",
+    "stmts": [
+     "_ignore_completion_names()",
+     "return 0;,return0;"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_username",
+    "stmts": [
+     "rl_completion_mode(bash_complete_username)",
+     "bash_complete_username_internal()",
+     "return bash_complete_username_internal(rl_comp...,returnbash_complete_username_internal(rl_comp..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_possible_username_completions",
+    "stmts": [
+     "bash_complete_username_internal('?')",
+     "return bash_complete_username_internal('?');,returnbash_complete_username_internal('?');"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_username_internal",
+    "stmts": [
+     "bash_specific_completion()",
+     "return bash_specific_completion(what_to_do,rl...,returnbash_specific_completion(what_to_do,rl..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_filename",
+    "stmts": [
+     "rl_completion_mode(bash_complete_filename)",
+     "bash_complete_filename_internal()",
+     "return bash_complete_filename_internal(rl_comp...,returnbash_complete_filename_internal(rl_comp..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_possible_filename_completions",
+    "stmts": [
+     "bash_complete_filename_internal('?')",
+     "return bash_complete_filename_internal('?');,returnbash_complete_filename_internal('?');"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_filename_internal",
+    "stmts": [
+     "orig_func = rl_completion_entry_function",
+     "orig_attempt_func = rl_attempted_completion_fun...",
+     "orig_ignore_func = rl_ignore_some_completions_f...",
+     "orig_rl_completer_word_break_characters = rl_co...",
+     "save_directory_hook()",
+     "orig_dir_func = save_directory_hook()"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_hostname",
+    "stmts": [
+     "rl_completion_mode(bash_complete_hostname)",
+     "bash_complete_hostname_internal()",
+     "return bash_complete_hostname_internal(rl_comp...,returnbash_complete_hostname_internal(rl_comp..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_possible_hostname_completions",
+    "stmts": [
+     "bash_complete_hostname_internal('?')",
+     "return bash_complete_hostname_internal('?');,returnbash_complete_hostname_internal('?');"
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_complete_variable",
+    "stmts": [
+     "rl_completion_mode(bash_complete_variable)",
+     "bash_complete_variable_internal()",
+     "return bash_complete_variable_internal(rl_comp...,returnbash_complete_variable_internal(rl_comp..."
+    ]
+   },
+   {
+    "project": "bash",
+    "function": "bash_possible_variable_completions",
+    "stmts": [
+     "bash_complete_variable_internal('?')",
+     "return bash_complete_variable_internal('?');,returnbash_complete_variable_internal('?');"
+    ]
+   }
+  ],
+  "cat1b_recoverable_worst": [
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_pass1",
+    "cached_nodes": 1,
+    "ghidra_branches": 394,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "iplink_parse",
+    "cached_nodes": 1,
+    "ghidra_branches": 337,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bzip2",
+    "func": "BZ2_compressBlock",
+    "cached_nodes": 1,
+    "ghidra_branches": 259,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "print_route",
+    "cached_nodes": 1,
+    "ghidra_branches": 256,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "dpkg",
+    "func": "tarobject",
+    "cached_nodes": 1,
+    "ghidra_branches": 200,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "grep",
+    "func": "kwsprep",
+    "cached_nodes": 1,
+    "ghidra_branches": 198,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "check_super_block",
+    "cached_nodes": 1,
+    "ghidra_branches": 190,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bzip2",
+    "func": "BZ2_bzDecompress",
+    "cached_nodes": 1,
+    "ghidra_branches": 180,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_iplink",
+    "cached_nodes": 1,
+    "ghidra_branches": 170,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "diffutils",
+    "func": "diff_2_files",
+    "cached_nodes": 1,
+    "ghidra_branches": 169,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_pass5",
+    "cached_nodes": 1,
+    "ghidra_branches": 169,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gzip",
+    "func": "printf_parse",
+    "cached_nodes": 1,
+    "ghidra_branches": 169,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "print_linkinfo",
+    "cached_nodes": 1,
+    "ghidra_branches": 168,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "zlib",
+    "func": "deflate",
+    "cached_nodes": 1,
+    "ghidra_branches": 166,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "coreutils",
+    "func": "chown_files",
+    "cached_nodes": 1,
+    "ghidra_branches": 151,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "process_options",
+    "cached_nodes": 1,
+    "ghidra_branches": 150,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "muxclient",
+    "cached_nodes": 1,
+    "ghidra_branches": 149,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "diffutils",
+    "func": "read_files",
+    "cached_nodes": 1,
+    "ghidra_branches": 145,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "ssh_krl_to_blob",
+    "cached_nodes": 1,
+    "ghidra_branches": 143,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "glob_filename",
+    "cached_nodes": 1,
+    "ghidra_branches": 139,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "dump_client_config",
+    "cached_nodes": 1,
+    "ghidra_branches": 135,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "re_refresh",
+    "cached_nodes": 1,
+    "ghidra_branches": 130,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "dpkg",
+    "func": "depisok",
+    "cached_nodes": 1,
+    "ghidra_branches": 130,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "execute_command_internal",
+    "cached_nodes": 1,
+    "ghidra_branches": 129,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "brace_expand",
+    "cached_nodes": 1,
+    "ghidra_branches": 129,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "copy_set_server_options",
+    "cached_nodes": 1,
+    "ghidra_branches": 128,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "read_and",
+    "cached_nodes": 1,
+    "ghidra_branches": 126,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libacl",
+    "func": "__acl_to_any_text",
+    "cached_nodes": 1,
+    "ghidra_branches": 125,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libacl",
+    "func": "do_set",
+    "cached_nodes": 1,
+    "ghidra_branches": 122,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_rehash_dir",
+    "cached_nodes": 1,
+    "ghidra_branches": 122,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "coreutils",
+    "func": "find_mount_point",
+    "cached_nodes": 1,
+    "ghidra_branches": 121,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "ssh_krl_from_blob",
+    "cached_nodes": 1,
+    "ghidra_branches": 119,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "zlib",
+    "func": "inflateBack",
+    "cached_nodes": 1,
+    "ghidra_branches": 116,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "wait_for",
+    "cached_nodes": 1,
+    "ghidra_branches": 115,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "print_e2fsck_message",
+    "cached_nodes": 1,
+    "ghidra_branches": 114,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "dump_config",
+    "cached_nodes": 1,
+    "ghidra_branches": 112,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "command_word_completion_function",
+    "cached_nodes": 1,
+    "ghidra_branches": 110,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "glob_vector",
+    "cached_nodes": 1,
+    "ghidra_branches": 110,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "sh_modcase",
+    "cached_nodes": 1,
+    "ghidra_branches": 110,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "sftp_server_main",
+    "cached_nodes": 1,
+    "ghidra_branches": 109,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "dpkg",
+    "func": "removal_bulk",
+    "cached_nodes": 1,
+    "ghidra_branches": 104,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "list_string",
+    "cached_nodes": 1,
+    "ghidra_branches": 104,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "history_w",
+    "cached_nodes": 1,
+    "ghidra_branches": 101,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "history",
+    "cached_nodes": 1,
+    "ghidra_branches": 101,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libacl",
+    "func": "acl_from_text",
+    "cached_nodes": 1,
+    "ghidra_branches": 101,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "cfg_load",
+    "cached_nodes": 1,
+    "ghidra_branches": 100,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "open_archive",
+    "cached_nodes": 1,
+    "ghidra_branches": 100,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "session_input_channel_req",
+    "cached_nodes": 1,
+    "ghidra_branches": 98,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "cronie",
+    "func": "load_entry",
+    "cached_nodes": 1,
+    "ghidra_branches": 98,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "ce_inc_search",
+    "cached_nodes": 1,
+    "ghidra_branches": 96,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "kex_input_kexinit",
+    "cached_nodes": 1,
+    "ghidra_branches": 95,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "skip_to_delim",
+    "cached_nodes": 1,
+    "ghidra_branches": 95,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "fill_default_server_options",
+    "cached_nodes": 1,
+    "ghidra_branches": 94,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "tok_line",
+    "cached_nodes": 1,
+    "ghidra_branches": 92,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "fix_problem",
+    "cached_nodes": 1,
+    "ghidra_branches": 92,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "tok_wline",
+    "cached_nodes": 1,
+    "ghidra_branches": 90,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "unvis",
+    "cached_nodes": 1,
+    "ghidra_branches": 90,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "terminal_echotc",
+    "cached_nodes": 1,
+    "ghidra_branches": 89,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "initialize_shell_variables",
+    "cached_nodes": 1,
+    "ghidra_branches": 89,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "fill_default_options",
+    "cached_nodes": 1,
+    "ghidra_branches": 88,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "lwt_parse_encap",
+    "cached_nodes": 1,
+    "ghidra_branches": 88,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "user_key_allowed",
+    "cached_nodes": 1,
+    "ghidra_branches": 86,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "client_loop",
+    "cached_nodes": 1,
+    "ghidra_branches": 86,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "stop_pipeline",
+    "cached_nodes": 1,
+    "ghidra_branches": 86,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "fn_complete2",
+    "cached_nodes": 1,
+    "ghidra_branches": 85,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "diff_archive",
+    "cached_nodes": 1,
+    "ghidra_branches": 85,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "ssh_packet_read_poll2",
+    "cached_nodes": 1,
+    "ghidra_branches": 84,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_pass1_dupblocks",
+    "cached_nodes": 1,
+    "ghidra_branches": 83,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "unary_test",
+    "cached_nodes": 1,
+    "ghidra_branches": 83,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "lwt_print_encap",
+    "cached_nodes": 1,
+    "ghidra_branches": 81,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_xfrm_policy",
+    "cached_nodes": 1,
+    "ghidra_branches": 80,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "krl_dump",
+    "cached_nodes": 1,
+    "ghidra_branches": 78,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "assign_compound_array_list",
+    "cached_nodes": 1,
+    "ghidra_branches": 78,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "pkcs11_add_provider",
+    "cached_nodes": 1,
+    "ghidra_branches": 77,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "xfrm_selector_parse",
+    "cached_nodes": 1,
+    "ghidra_branches": 77,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_ipmonitor",
+    "cached_nodes": 1,
+    "ghidra_branches": 76,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "xfrm_xfrma_print",
+    "cached_nodes": 1,
+    "ghidra_branches": 76,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libacl",
+    "func": "parse_acl_cmd",
+    "cached_nodes": 1,
+    "ghidra_branches": 76,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "gen_compspec_completions",
+    "cached_nodes": 1,
+    "ghidra_branches": 76,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "print_list",
+    "cached_nodes": 1,
+    "ghidra_branches": 74,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "sysvinit",
+    "func": "detect_consoles",
+    "cached_nodes": 1,
+    "ghidra_branches": 74,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "rl_vi_match",
+    "cached_nodes": 1,
+    "ghidra_branches": 74,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "rl_filename_completion_function",
+    "cached_nodes": 1,
+    "ghidra_branches": 74,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "ssh_userauth2",
+    "cached_nodes": 1,
+    "ghidra_branches": 73,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libacl",
+    "func": "read_acl_comments",
+    "cached_nodes": 1,
+    "ghidra_branches": 72,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "expand_string_dollar_quote",
+    "cached_nodes": 1,
+    "ghidra_branches": 72,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "grep",
+    "func": "EGexecute",
+    "cached_nodes": 1,
+    "ghidra_branches": 71,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "do_crossload",
+    "cached_nodes": 1,
+    "ghidra_branches": 69,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "alias_expand",
+    "cached_nodes": 1,
+    "ghidra_branches": 69,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_netns",
+    "cached_nodes": 1,
+    "ghidra_branches": 68,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "socket_open2",
+    "cached_nodes": 1,
+    "ghidra_branches": 67,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gzip",
+    "func": "deflate",
+    "cached_nodes": 1,
+    "ghidra_branches": 66,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "parse_forward",
+    "cached_nodes": 1,
+    "ghidra_branches": 66,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_process_bad_inode",
+    "cached_nodes": 1,
+    "ghidra_branches": 66,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "channel_prepare_poll",
+    "cached_nodes": 1,
+    "ghidra_branches": 65,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "purge_directory",
+    "cached_nodes": 1,
+    "ghidra_branches": 65,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "char_is_quoted",
+    "cached_nodes": 1,
+    "ghidra_branches": 65,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "pat_subst",
+    "cached_nodes": 1,
+    "ghidra_branches": 65,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "rl_display_match_list",
+    "cached_nodes": 1,
+    "ghidra_branches": 65,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "quote_string_for_globbing",
+    "cached_nodes": 1,
+    "ghidra_branches": 64,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "ssh_err",
+    "cached_nodes": 1,
+    "ghidra_branches": 63,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "getrrsetbyname",
+    "cached_nodes": 1,
+    "ghidra_branches": 63,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_pass4",
+    "cached_nodes": 1,
+    "ghidra_branches": 63,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "read_directory_file",
+    "cached_nodes": 1,
+    "ghidra_branches": 62,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "get_word_from_string",
+    "cached_nodes": 1,
+    "ghidra_branches": 62,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_ipnh",
+    "cached_nodes": 1,
+    "ghidra_branches": 61,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "kex_exchange_identification",
+    "cached_nodes": 1,
+    "ghidra_branches": 60,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "el_wgets",
+    "cached_nodes": 1,
+    "ghidra_branches": 60,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "skip_to_histexp",
+    "cached_nodes": 1,
+    "ghidra_branches": 60,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "do_upload",
+    "cached_nodes": 1,
+    "ghidra_branches": 59,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "cronie",
+    "func": "load_env",
+    "cached_nodes": 1,
+    "ghidra_branches": 59,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "sftp_realpath",
+    "cached_nodes": 1,
+    "ghidra_branches": 58,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "print_rule",
+    "cached_nodes": 1,
+    "ghidra_branches": 58,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "sys_exec_command",
+    "cached_nodes": 1,
+    "ghidra_branches": 58,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "hostfile_replace_entries",
+    "cached_nodes": 1,
+    "ghidra_branches": 57,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_get_lost_and_found",
+    "cached_nodes": 1,
+    "ghidra_branches": 57,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "hostkeys_foreach_file",
+    "cached_nodes": 1,
+    "ghidra_branches": 56,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "print_info",
+    "cached_nodes": 1,
+    "ghidra_branches": 56,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_iproute",
+    "cached_nodes": 1,
+    "ghidra_branches": 56,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_iptunnel",
+    "cached_nodes": 1,
+    "ghidra_branches": 56,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "prime_test",
+    "cached_nodes": 1,
+    "ghidra_branches": 55,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "extract_archive",
+    "cached_nodes": 1,
+    "ghidra_branches": 55,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "split_at_delims",
+    "cached_nodes": 1,
+    "ghidra_branches": 55,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "map_bind",
+    "cached_nodes": 1,
+    "ghidra_branches": 54,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "do_ioam6",
+    "cached_nodes": 1,
+    "ghidra_branches": 54,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "cronie",
+    "func": "load_database",
+    "cached_nodes": 1,
+    "ghidra_branches": 54,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gzip",
+    "func": "unlzw",
+    "cached_nodes": 1,
+    "ghidra_branches": 53,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "_rl_dispatch_subseq",
+    "cached_nodes": 1,
+    "ghidra_branches": 53,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "print_neigh",
+    "cached_nodes": 1,
+    "ghidra_branches": 52,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "fmtulong",
+    "cached_nodes": 1,
+    "ghidra_branches": 52,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "fmtumax",
+    "cached_nodes": 1,
+    "ghidra_branches": 52,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "subprocess",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "scan_scaled",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "channel_output_poll",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gnutls",
+    "func": "pin_callback",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "e2fsck_pass3",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "delete_archive_members",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "xdupmbstowcs",
+    "cached_nodes": 1,
+    "ghidra_branches": 51,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "gzip",
+    "func": "unpack",
+    "cached_nodes": 1,
+    "ghidra_branches": 50,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libselinux",
+    "func": "getseuserbyname",
+    "cached_nodes": 1,
+    "ghidra_branches": 50,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "libedit",
+    "func": "el_wset",
+    "cached_nodes": 1,
+    "ghidra_branches": 49,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "zlib",
+    "func": "inflate_table",
+    "cached_nodes": 1,
+    "ghidra_branches": 49,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "do_copy",
+    "cached_nodes": 1,
+    "ghidra_branches": 48,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "dump_cfg_fmtint",
+    "cached_nodes": 1,
+    "ghidra_branches": 48,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "bash",
+    "func": "spname",
+    "cached_nodes": 1,
+    "ghidra_branches": 48,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "openssh-portable",
+    "func": "channel_proxy_downstream",
+    "cached_nodes": 1,
+    "ghidra_branches": 47,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "iproute2",
+    "func": "print_addrinfo",
+    "cached_nodes": 1,
+    "ghidra_branches": 47,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "e2fsprogs",
+    "func": "add_encrypted_file",
+    "cached_nodes": 1,
+    "ghidra_branches": 47,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "transform_name_fp",
+    "cached_nodes": 1,
+    "ghidra_branches": 47,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   },
+   {
+    "project": "tar",
+    "func": "update_archive",
+    "cached_nodes": 1,
+    "ghidra_branches": 47,
+    "note_cached_degenerate_but_ghidra_body_large": true
+   }
+  ],
+  "cat2_worst_colliding_names": [
+   {
+    "project": "coreutils",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 108,
+    "skel_variants": 97,
+    "cached_nodes": 34,
+    "wrong_evals": 635
+   },
+   {
+    "project": "coreutils",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 108,
+    "skel_variants": 97,
+    "cached_nodes": 34,
+    "wrong_evals": 634
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 107,
+    "skel_variants": 54,
+    "cached_nodes": 4,
+    "wrong_evals": 623
+   },
+   {
+    "project": "coreutils",
+    "opt": "O2",
+    "func": "usage",
+    "binaries": 107,
+    "skel_variants": 58,
+    "cached_nodes": 4,
+    "wrong_evals": 621
+   },
+   {
+    "project": "coreutils",
+    "opt": "O2-noinline",
+    "func": "usage",
+    "binaries": 107,
+    "skel_variants": 54,
+    "cached_nodes": 4,
+    "wrong_evals": 617
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 108,
+    "skel_variants": 99,
+    "cached_nodes": 34,
+    "wrong_evals": 613
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 40,
+    "skel_variants": 38,
+    "cached_nodes": 56,
+    "wrong_evals": 234
+   },
+   {
+    "project": "shadow",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 40,
+    "skel_variants": 40,
+    "cached_nodes": 56,
+    "wrong_evals": 233
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 40,
+    "skel_variants": 39,
+    "cached_nodes": 56,
+    "wrong_evals": 233
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 35,
+    "skel_variants": 15,
+    "cached_nodes": 1,
+    "wrong_evals": 204
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "usage",
+    "binaries": 35,
+    "skel_variants": 13,
+    "cached_nodes": 1,
+    "wrong_evals": 204
+   },
+   {
+    "project": "shadow",
+    "opt": "O2",
+    "func": "usage",
+    "binaries": 33,
+    "skel_variants": 13,
+    "cached_nodes": 1,
+    "wrong_evals": 191
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "process_flags",
+    "binaries": 22,
+    "skel_variants": 18,
+    "cached_nodes": 163,
+    "wrong_evals": 126
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "process_flags",
+    "binaries": 22,
+    "skel_variants": 18,
+    "cached_nodes": 163,
+    "wrong_evals": 125
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "fail_exit",
+    "binaries": 17,
+    "skel_variants": 5,
+    "cached_nodes": 55,
+    "wrong_evals": 96
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "open_files",
+    "binaries": 14,
+    "skel_variants": 10,
+    "cached_nodes": 33,
+    "wrong_evals": 78
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "close_files",
+    "binaries": 14,
+    "skel_variants": 12,
+    "cached_nodes": 112,
+    "wrong_evals": 78
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 14,
+    "skel_variants": 14,
+    "cached_nodes": 39,
+    "wrong_evals": 78
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 14,
+    "skel_variants": 14,
+    "cached_nodes": 39,
+    "wrong_evals": 78
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 14,
+    "skel_variants": 14,
+    "cached_nodes": 39,
+    "wrong_evals": 78
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "open_files",
+    "binaries": 14,
+    "skel_variants": 13,
+    "cached_nodes": 33,
+    "wrong_evals": 71
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 12,
+    "skel_variants": 12,
+    "cached_nodes": 275,
+    "wrong_evals": 66
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "close_files",
+    "binaries": 14,
+    "skel_variants": 13,
+    "cached_nodes": 112,
+    "wrong_evals": 65
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 12,
+    "skel_variants": 12,
+    "cached_nodes": 275,
+    "wrong_evals": 64
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "check_perms",
+    "binaries": 11,
+    "skel_variants": 8,
+    "cached_nodes": 36,
+    "wrong_evals": 60
+   },
+   {
+    "project": "shadow",
+    "opt": "O2",
+    "func": "fail_exit",
+    "binaries": 12,
+    "skel_variants": 4,
+    "cached_nodes": 55,
+    "wrong_evals": 55
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "fail_exit",
+    "binaries": 12,
+    "skel_variants": 4,
+    "cached_nodes": 55,
+    "wrong_evals": 55
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 12,
+    "skel_variants": 12,
+    "cached_nodes": 275,
+    "wrong_evals": 53
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "sshfatal",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 49
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "cleanup_exit",
+    "binaries": 12,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 49
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 9,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 48
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 9,
+    "skel_variants": 9,
+    "cached_nodes": 91,
+    "wrong_evals": 48
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "tilde_expand_filename",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 48
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 9,
+    "skel_variants": 8,
+    "cached_nodes": 91,
+    "wrong_evals": 48
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O2-noinline",
+    "func": "usage",
+    "binaries": 9,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 48
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sshlogdie",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "xmalloc",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 5,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "xcalloc",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 9,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "xreallocarray",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 3,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "xrecallocarray",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 3,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "xvasprintf",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 5,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "cleanup_exit",
+    "binaries": 12,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 47
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "split_3",
+    "binaries": 9,
+    "skel_variants": 3,
+    "cached_nodes": 34,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "sshfatal",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 47
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "put_host_port",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "addargs",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "replacearg",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "tilde_expand_filename",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "vdollar_percent_expand",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 63,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "percent_expand",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 3,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "percent_dollar_expand",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 3,
+    "wrong_evals": 46
+   },
+   {
+    "project": "gnutls",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 9,
+    "skel_variants": 8,
+    "cached_nodes": 91,
+    "wrong_evals": 46
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "mktemp_proto",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 45
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "tilde_expand_filename",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 45
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "argv_assemble",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 44
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "child_set_env",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 44
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "opt_array_append2",
+    "binaries": 12,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 42
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "cleanup_exit",
+    "binaries": 11,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 42
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "output_file",
+    "binaries": 8,
+    "skel_variants": 3,
+    "cached_nodes": 1,
+    "wrong_evals": 41
+   },
+   {
+    "project": "coreutils",
+    "opt": "O2-noinline",
+    "func": "split_3",
+    "binaries": 8,
+    "skel_variants": 3,
+    "cached_nodes": 34,
+    "wrong_evals": 40
+   },
+   {
+    "project": "gnutls",
+    "opt": "O0",
+    "func": "process_options",
+    "binaries": 8,
+    "skel_variants": 8,
+    "cached_nodes": 1,
+    "wrong_evals": 38
+   },
+   {
+    "project": "gnutls",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 8,
+    "skel_variants": 6,
+    "cached_nodes": 1,
+    "wrong_evals": 38
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2-noinline",
+    "func": "usage",
+    "binaries": 8,
+    "skel_variants": 6,
+    "cached_nodes": 1,
+    "wrong_evals": 38
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2-noinline",
+    "func": "process_options",
+    "binaries": 8,
+    "skel_variants": 8,
+    "cached_nodes": 1,
+    "wrong_evals": 38
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2",
+    "func": "usage",
+    "binaries": 8,
+    "skel_variants": 6,
+    "cached_nodes": 1,
+    "wrong_evals": 37
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2",
+    "func": "process_options",
+    "binaries": 8,
+    "skel_variants": 8,
+    "cached_nodes": 1,
+    "wrong_evals": 36
+   },
+   {
+    "project": "sysvinit",
+    "opt": "O2",
+    "func": "usage",
+    "binaries": 7,
+    "skel_variants": 4,
+    "cached_nodes": 1,
+    "wrong_evals": 36
+   },
+   {
+    "project": "bash",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 7,
+    "skel_variants": 7,
+    "cached_nodes": 150,
+    "wrong_evals": 35
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "sshsk_load_resident",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 35
+   },
+   {
+    "project": "bash",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 7,
+    "skel_variants": 7,
+    "cached_nodes": 150,
+    "wrong_evals": 35
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "sshsk_enroll",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 35
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "sshsk_sign",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 35
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "sshsk_load_resident",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 35
+   },
+   {
+    "project": "bash",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 7,
+    "skel_variants": 7,
+    "cached_nodes": 150,
+    "wrong_evals": 35
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sshsk_enroll",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 34
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sshsk_sign",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 34
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sshsk_load_resident",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 34
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "sshsk_enroll",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 34
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "sshsk_sign",
+    "binaries": 9,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 34
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sys_tun_infilter",
+    "binaries": 10,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 32
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "sys_tun_outfilter",
+    "binaries": 10,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 32
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "check_flags",
+    "binaries": 6,
+    "skel_variants": 6,
+    "cached_nodes": 1,
+    "wrong_evals": 30
+   },
+   {
+    "project": "zlib",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 6,
+    "skel_variants": 2,
+    "cached_nodes": 53,
+    "wrong_evals": 30
+   },
+   {
+    "project": "zlib",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 6,
+    "skel_variants": 2,
+    "cached_nodes": 53,
+    "wrong_evals": 30
+   },
+   {
+    "project": "zlib",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 6,
+    "skel_variants": 2,
+    "cached_nodes": 53,
+    "wrong_evals": 30
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "check_perms",
+    "binaries": 6,
+    "skel_variants": 6,
+    "cached_nodes": 36,
+    "wrong_evals": 29
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "errno_unsupported",
+    "binaries": 6,
+    "skel_variants": 2,
+    "cached_nodes": 5,
+    "wrong_evals": 25
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "grp_update",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 2,
+    "wrong_evals": 24
+   },
+   {
+    "project": "zlib",
+    "opt": "O2",
+    "func": "inflateReset2",
+    "binaries": 5,
+    "skel_variants": 2,
+    "cached_nodes": 18,
+    "wrong_evals": 24
+   },
+   {
+    "project": "zlib",
+    "opt": "O2",
+    "func": "inflateSync",
+    "binaries": 5,
+    "skel_variants": 2,
+    "cached_nodes": 17,
+    "wrong_evals": 24
+   },
+   {
+    "project": "dpkg",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 5,
+    "skel_variants": 4,
+    "cached_nodes": 3,
+    "wrong_evals": 24
+   },
+   {
+    "project": "dpkg",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 5,
+    "skel_variants": 4,
+    "cached_nodes": 3,
+    "wrong_evals": 24
+   },
+   {
+    "project": "dpkg",
+    "opt": "O0",
+    "func": "printversion",
+    "binaries": 5,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 23
+   },
+   {
+    "project": "dpkg",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 1,
+    "wrong_evals": 23
+   },
+   {
+    "project": "dpkg",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 5,
+    "skel_variants": 4,
+    "cached_nodes": 3,
+    "wrong_evals": 23
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "grp_update",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 2,
+    "wrong_evals": 23
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "send_msg",
+    "binaries": 6,
+    "skel_variants": 4,
+    "cached_nodes": 2,
+    "wrong_evals": 22
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O0",
+    "func": "seed_rng",
+    "binaries": 8,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 22
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2",
+    "func": "send_msg",
+    "binaries": 6,
+    "skel_variants": 3,
+    "cached_nodes": 2,
+    "wrong_evals": 22
+   },
+   {
+    "project": "dpkg",
+    "opt": "O2",
+    "func": "printversion",
+    "binaries": 5,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 22
+   },
+   {
+    "project": "openssh-portable",
+    "opt": "O2-noinline",
+    "func": "send_msg",
+    "binaries": 6,
+    "skel_variants": 3,
+    "cached_nodes": 2,
+    "wrong_evals": 22
+   },
+   {
+    "project": "coreutils",
+    "opt": "O2-noinline",
+    "func": "cleanup",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 18,
+    "wrong_evals": 22
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "cleanup",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 18,
+    "wrong_evals": 21
+   },
+   {
+    "project": "gnutls",
+    "opt": "O2-noinline",
+    "func": "cmd_parser",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 49,
+    "wrong_evals": 21
+   },
+   {
+    "project": "dpkg",
+    "opt": "O2-noinline",
+    "func": "printversion",
+    "binaries": 5,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 21
+   },
+   {
+    "project": "gnutls",
+    "opt": "O0",
+    "func": "cmd_parser",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 49,
+    "wrong_evals": 20
+   },
+   {
+    "project": "shadow",
+    "opt": "O0",
+    "func": "catch_signals",
+    "binaries": 4,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 18
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2",
+    "func": "main",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 59,
+    "wrong_evals": 18
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2",
+    "func": "try_help",
+    "binaries": 4,
+    "skel_variants": 2,
+    "cached_nodes": 12,
+    "wrong_evals": 18
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2-noinline",
+    "func": "main",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 59,
+    "wrong_evals": 18
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2-noinline",
+    "func": "try_help",
+    "binaries": 4,
+    "skel_variants": 3,
+    "cached_nodes": 12,
+    "wrong_evals": 18
+   },
+   {
+    "project": "shadow",
+    "opt": "O2-noinline",
+    "func": "catch_signals",
+    "binaries": 4,
+    "skel_variants": 2,
+    "cached_nodes": 1,
+    "wrong_evals": 18
+   },
+   {
+    "project": "diffutils",
+    "opt": "O0",
+    "func": "try_help",
+    "binaries": 4,
+    "skel_variants": 3,
+    "cached_nodes": 12,
+    "wrong_evals": 17
+   },
+   {
+    "project": "diffutils",
+    "opt": "O0",
+    "func": "usage",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 7,
+    "wrong_evals": 17
+   },
+   {
+    "project": "diffutils",
+    "opt": "O0",
+    "func": "main",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 59,
+    "wrong_evals": 17
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "process_signals",
+    "binaries": 4,
+    "skel_variants": 2,
+    "cached_nodes": 8,
+    "wrong_evals": 17
+   },
+   {
+    "project": "coreutils",
+    "opt": "O0",
+    "func": "process_file",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 7,
+    "wrong_evals": 17
+   },
+   {
+    "project": "dpkg",
+    "opt": "O2",
+    "func": "usage",
+    "binaries": 5,
+    "skel_variants": 5,
+    "cached_nodes": 1,
+    "wrong_evals": 17
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2-noinline",
+    "func": "usage",
+    "binaries": 4,
+    "skel_variants": 4,
+    "cached_nodes": 7,
+    "wrong_evals": 17
+   },
+   {
+    "project": "diffutils",
+    "opt": "O2-noinline",
+    "func": "check_stdout",
+    "binaries": 4,
+    "skel_variants": 3,
+    "cached_nodes": 4,
+    "wrong_evals": 17
+   }
+  ],
+  "cat2_proven_example_shadow_main": {
+   "project": "shadow",
+   "function": "main",
+   "cached_project_wide_nodes": 56,
+   "nologin_own_i_nodes": 5,
+   "i_path_of_own_definition": "results/full_run/O0/shadow/compiled/nologin.i",
+   "binaries_defining_main": 40,
+   "distinct_ghidra_skeletons": 38,
+   "reason": "GED scores nologin's decompiled main (a 5-node body) against a 56-node main from a different shadow program; merge is nondeterministic (imap_unordered)."
+  },
+  "cat3_100pct_loading_binaries": [
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh",
+    "n": 742
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "scp",
+    "n": 399
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-add",
+    "n": 693
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-agent",
+    "n": 587
+   },
+   {
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "n": 567
+   },
+   {
+    "opt": "O0",
+    "project": "iproute2",
+    "binary": "ip",
+    "n": 757
+   },
+   {
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "ls",
+    "n": 216
+   },
+   {
+    "opt": "O0",
+    "project": "dpkg",
+    "binary": "dpkg",
+    "n": 238
+   },
+   {
+    "opt": "O0",
+    "project": "e2fsprogs",
+    "binary": "e2fsck",
+    "n": 409
+   },
+   {
+    "opt": "O0",
+    "project": "crazyflie",
+    "binary": "CMSIS_DAP",
+    "n": 1
+   },
+   {
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "n": 1053
+   },
+   {
+    "opt": "O2",
+    "project": "openssh-portable",
+    "binary": "ssh",
+    "n": 673
+   },
+   {
+    "opt": "O2",
+    "project": "openssh-portable",
+    "binary": "ssh-keysign",
+    "n": 628
+   },
+   {
+    "opt": "O2",
+    "project": "crazyflie",
+    "binary": "CMSIS_DAP",
+    "n": 1
+   },
+   {
+    "opt": "O2",
+    "project": "bash",
+    "binary": "bash",
+    "n": 965
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "openssh-portable",
+    "binary": "ssh",
+    "n": 735
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "openssh-portable",
+    "binary": "ssh-keysign",
+    "n": 826
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "openssh-portable",
+    "binary": "ssh-add",
+    "n": 658
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "openssh-portable",
+    "binary": "ssh-agent",
+    "n": 566
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "n": 544
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "iproute2",
+    "binary": "ip",
+    "n": 637
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "[",
+    "n": 19
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "who",
+    "n": 14
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "coreutils",
+    "binary": "rmdir",
+    "n": 7
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "cleanflight",
+    "binary": "cleanflight_DALRCF405",
+    "n": 1865
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "e2fsprogs",
+    "binary": "e2fsck",
+    "n": 379
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "crazyflie",
+    "binary": "CMSIS_DAP",
+    "n": 1
+   },
+   {
+    "opt": "O2-noinline",
+    "project": "bash",
+    "binary": "bash",
+    "n": 1025
+   }
+  ],
+  "cat4_parse_failure_samples": [
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "pqdownheap",
+    "cached_src_nodes": 17,
+    "c_path": "results/full_run/O0/gzip/decompiled/angr_gzip.c",
+    "snippet": "extern unsigned int g_4df200[1277633];\nextern char g_4dfaf4;\nextern char g_4dfb00;\n\nunsigned int [1277633] pqdownheap(unsigned long a0, unsigned int a1)\n{\n    unsigned int v0;  // [bp-0x24]\n    unsigned int i;  // [bp-0x10]\n    unsigned int v2[1277633];  // [bp-0xc]\n\n    v0 = a1;\n    v2 = (unsigned int [1277633])g_4df200[v0];\n    for (i = v0 * 2; i <= *((int *)&g_4dfaf4); i *= 2)\n    {"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "read_tree",
+    "cached_src_nodes": 21,
+    "c_path": "results/full_run/O0/gzip/decompiled/angr_gzip.c",
+    "snippet": "extern unsigned long long g_4e13e0;\nextern int g_4e13e8;\nextern char g_4e1400;\nextern unsigned int g_4e1500;\nextern unsigned int g_4e1580[4];\n\nunsigned int [4] read_tree(void)\n{\n    char v6;  // al\n    int iter;  // [bp-0x28]\n    unsigned int v1;  // [bp-0x24]\n    unsigned int v2;  // [bp-0x24]\n    unsigned int cur[4];  // [bp-0x20], Other Possible Types: int\n    unsigned int v4;  // [bp-0x1c]"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "sdiff",
+    "function": "lf_skip",
+    "cached_src_nodes": 5,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_sdiff.c",
+    "snippet": "void* [4] lf_skip(void* *p, unsigned long long a1)\n{\n    void* ptr[4];  // rax\n    unsigned long long i;  // [bp-0x18]\n\n    for (i = a1; i; ptr[1] = p[1] + 1)\n    {\n        p[1] = rawmemchr(p[1], 10);\n        if (p[1] == p[3])\n        {\n            ptr = sub_4042c0(p);\n            if (!ptr)\n                return ptr;\n        }"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "cmp",
+    "function": "file_position",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_cmp.c",
+    "snippet": "extern unsigned int g_4100b0[4];\nextern unsigned long long g_410200[4];\nextern char g_410215;\nextern unsigned long long g_410220[4];\n\nunsigned long long [4] file_position(unsigned int a0)\n{\n    if (*(&(&g_410215)[a0]) != 1)\n    {\n        *(&(&g_410215)[a0]) = 1;\n        g_410220[a0] = lseek(g_4100b0[a0], g_410200[a0], 1);\n    }\n    return g_410220[a0];\n}"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff3",
+    "function": "scan_diff_line",
+    "cached_src_nodes": 17,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff3.c",
+    "snippet": "typedef struct struct_0 {\n    char padding_0[1];\n    char field_1;\n    char field_2;\n    char field_3;\n    char field_4;\n} struct_0;\n\ntypedef struct FILE {\n} FILE;\n\nextern char g_41410b;\nextern char *g_424148;\nextern FILE *stderr;"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "add_change",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)\n{\n    unsigned long long ptr[5];  // [bp-0x10]\n\n    ptr = sub_41c945(48);\n    ptr[3] = a0;\n    ptr[4] = a1;\n    ptr[1] = a3;\n    ptr[2] = a2;\n    ptr[0] = a4;\n    return ptr;\n}\n\n"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "build_reverse_script",
+    "cached_src_nodes": 13,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "typedef struct struct_0 {\n    char padding_0[200];\n    long long field_c8;\n    char padding_d0[72];\n    unsigned long long field_118;\n    char padding_120[216];\n    long long field_1f8;\n    char padding_200[72];\n    unsigned long long field_248;\n} struct_0;\n\nunsigned long long [5] build_reverse_script(struct_0 *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x50]"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "build_script",
+    "cached_src_nodes": 13,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "unsigned long long [5] build_script(unsigned long long *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x40]\n    unsigned long cur;  // [bp-0x38], Other Possible Types: unsigned long long\n    unsigned long iter;  // [bp-0x30], Other Possible Types: unsigned long long\n    unsigned long v3;  // [bp-0x28]\n    unsigned long v4;  // [bp-0x20]\n    unsigned long v5;  // [bp-0x18]\n    unsigned long v6;  // [bp-0x10]\n\n    v0 = NULL;\n    v3 = ptr[35];\n    v4 = ptr[73];\n    cur = ptr[25];"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "do_printf_spec",
+    "cached_src_nodes": 30,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "typedef struct FILE {\n} FILE;\n\nchar [2] do_printf_spec(FILE *a0, char *a1, long long a2, long long a3, long long *a4)\n{\n    char ptr[2];  // rax\n    char p[2];  // rax\n    char addr[2];  // rax\n    char ptr3[2];  // rax\n    unsigned int v18;  // eax\n    unsigned long v19;  // rax\n    unsigned long long v20;  // rax\n    unsigned long long v21;  // rax\n    char v0;  // [bp-0x1088]"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "scan_char_literal",
+    "cached_src_nodes": 14,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "char [2] scan_char_literal(char *ptr, char *p)\n{\n    char v5[2];  // rbx\n    char v7[2];  // rax\n    char addr[2];  // rax\n    char v0;  // [bp-0x1e]\n    char v1;  // [bp-0x1d]\n    unsigned int v2;  // [bp-0x1c]\n    long long v3;  // [bp-0x18]\n\n    v5 = ptr + 1;\n    v1 = *(ptr);\n    switch (v1)\n    {"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "c_escape",
+    "cached_src_nodes": 18,
+    "c_path": "results/full_run/O0/diffutils/decompiled/angr_diff.c",
+    "snippet": "char [5] c_escape(char *a0)\n{\n    unsigned int flag;  // eax\n    unsigned int choice;  // eax\n    char ptr[5];  // rax\n    char p[5];  // rax\n    char addr[5];  // rax\n    char ptr5[5];  // rax\n    char v0;  // [bp-0x34]\n    char v1;  // [bp-0x33]\n    char v2;  // [bp-0x32]\n    char v3;  // [bp-0x31]\n    char iter[5];  // [bp-0x30]\n    unsigned long long node;  // [bp-0x28]"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "log_facility_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned long long g_471020[4];\nextern unsigned int g_471028[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_471020[2 * i]; i = sub_449b30(i, 1))\n        {\n            if (!strcasecmp(g_471020[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "log_facility_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned long long g_471020[4];\nextern unsigned int g_471028[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_471020[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "log_level_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned long long g_471100[4];\nextern unsigned int g_471108[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_471100[2 * i]; i = sub_449b30(i, 1))\n        {\n            if (!strcasecmp(g_471100[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "log_level_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned long long g_471100[4];\nextern unsigned int g_471108[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_471100[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "hpdelim2",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (!ptr || !*(ptr))\n    {"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "hpdelim",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_4281f9(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "colon",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "iptos2str",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned long long g_4701c0[4];\nextern unsigned int g_4701c8[4];\nextern unsigned long long g_47128c[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_4701c0[2 * v0])\n        {"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "chachapoly_new",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "long long [2] chachapoly_new(long long a0, unsigned int a1)\n{\n    long long v2[2];  // rax\n    long long v3;  // rax\n    long long v4;  // rax\n    long long ptr[2];  // [bp-0x20]\n\n    if (a1 != 64)\n    {\n        v2 = NULL;\n    }\n    else\n    {\n        ptr = calloc(1, 16);"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "ssh_digest_alg_by_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_ssh-sk-helper.c",
+    "snippet": "extern unsigned int g_470560[4];\nextern unsigned long long g_470568[4];\n\nunsigned int [4] ssh_digest_alg_by_name(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (g_470560[8 * v0] == 0xffffffff)\n        {\n            v2 = 0xffffffff;"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "status_to_message",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_sftp-server.c",
+    "snippet": "extern unsigned long long g_434740[4];\n\nunsigned long long [4] status_to_message(unsigned int a0)\n{\n    unsigned int v1;  // eax\n\n    v1 = a0;\n    if (8 < v1)\n        v1 = 8;\n    [D] PutI(904:F64x8)[t44,0] = t47()\n    [D] PutI(968:I8x8)[t44,0] = 0x01()\n    [D] PutI(904:F64x8)[t54,0] = t57()\n    [D] PutI(968:I8x8)[t54,0] = 0x01()\n    [D] PutI(904:F64x8)[t64,0] = t67()"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_facility_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_sftp-server.c",
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_435040[2 * i]; i = sub_42bbc0(i, 1))\n        {\n            if (!strcasecmp(g_435040[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_facility_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_sftp-server.c",
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435040[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "angr",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_level_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/angr_sftp-server.c",
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int i;  // [bp-0xc]\n\n    if (a0)\n    {\n        for (i = 0; g_435120[2 * i]; i = sub_42bbc0(i, 1))\n        {\n            if (!strcasecmp(g_435120[2 * i], a0))\n            {\n                [D] PutI(904:F64x8)[t30,0] = t33()"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "pqdownheap",
+    "cached_src_nodes": 17,
+    "c_path": "results/full_run/O0/gzip/decompiled/phoenix_gzip.c",
+    "snippet": "extern unsigned int g_4df200[1277633];\nextern char g_4dfaf4;\nextern char g_4dfb00;\n\nunsigned int [1277633] pqdownheap(unsigned long a0, unsigned int a1)\n{\n    unsigned int v0;  // [bp-0x24]\n    unsigned int i;  // [bp-0x10]\n    unsigned int v2[1277633];  // [bp-0xc]\n\n    v0 = a1;\n    v2 = (unsigned int [1277633])g_4df200[v0];\n    for (i = v0 * 2; i <= *((int *)&g_4dfaf4); i *= 2)\n    {"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "read_tree",
+    "cached_src_nodes": 21,
+    "c_path": "results/full_run/O0/gzip/decompiled/phoenix_gzip.c",
+    "snippet": "extern unsigned long long g_4e13e0;\nextern int g_4e13e8;\nextern char g_4e1400;\nextern unsigned int g_4e1500;\nextern unsigned int g_4e1580[4];\n\nunsigned int [4] read_tree(void)\n{\n    char v6;  // al\n    int iter;  // [bp-0x28]\n    unsigned int v1;  // [bp-0x24]\n    unsigned int v2;  // [bp-0x24]\n    unsigned int cur[4];  // [bp-0x20], Other Possible Types: int\n    unsigned int v4;  // [bp-0x1c]"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff3",
+    "function": "scan_diff_line",
+    "cached_src_nodes": 17,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff3.c",
+    "snippet": "typedef struct struct_0 {\n    char padding_0[1];\n    char field_1;\n    char field_2;\n    char field_3;\n    char field_4;\n} struct_0;\n\ntypedef struct FILE {\n} FILE;\n\nextern char g_41410b;\nextern char *g_424148;\nextern FILE *stderr;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "add_change",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "unsigned long long [5] add_change(unsigned long a0, unsigned long a1, unsigned long a2, unsigned long a3, unsigned long a4)\n{\n    unsigned long long ptr[5];  // [bp-0x10]\n\n    ptr = sub_41c945(48);\n    ptr[3] = a0;\n    ptr[4] = a1;\n    ptr[1] = a3;\n    ptr[2] = a2;\n    ptr[0] = a4;\n    return ptr;\n}\n\n"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "build_reverse_script",
+    "cached_src_nodes": 13,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "typedef struct struct_0 {\n    char padding_0[200];\n    long long field_c8;\n    char padding_d0[72];\n    unsigned long long field_118;\n    char padding_120[216];\n    long long field_1f8;\n    char padding_200[72];\n    unsigned long long field_248;\n} struct_0;\n\nunsigned long long [5] build_reverse_script(struct_0 *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x50]"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "build_script",
+    "cached_src_nodes": 13,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "unsigned long long [5] build_script(unsigned long long *ptr)\n{\n    unsigned long long v0[5];  // [bp-0x40]\n    unsigned long cur;  // [bp-0x38], Other Possible Types: unsigned long long\n    unsigned long iter;  // [bp-0x30], Other Possible Types: unsigned long long\n    unsigned long v3;  // [bp-0x28]\n    unsigned long v4;  // [bp-0x20]\n    unsigned long v5;  // [bp-0x18]\n    unsigned long v6;  // [bp-0x10]\n\n    v0 = NULL;\n    v3 = ptr[35];\n    v4 = ptr[73];\n    cur = ptr[25];"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "do_printf_spec",
+    "cached_src_nodes": 30,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "typedef struct FILE {\n} FILE;\n\nchar [2] do_printf_spec(FILE *a0, char *a1, long long a2, long long a3, long long *a4)\n{\n    char ptr[2];  // rax\n    char p[2];  // rax\n    char addr[2];  // rax\n    char ptr3[2];  // rax\n    unsigned int v18;  // eax\n    unsigned long v19;  // rax\n    unsigned long long v20;  // rax\n    unsigned long long v21;  // rax\n    char v0;  // [bp-0x1088]"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "scan_char_literal",
+    "cached_src_nodes": 14,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "char [2] scan_char_literal(char *ptr, char *p)\n{\n    char v5[2];  // rbx\n    unsigned int v6;  // eax\n    char v7[2];  // rax\n    char addr[2];  // rax\n    char v0;  // [bp-0x1e]\n    char v1;  // [bp-0x1d]\n    unsigned int v2;  // [bp-0x1c]\n    long long v3;  // [bp-0x18]\n\n    v5 = ptr + 1;\n    v1 = *(ptr);\n    v6 = v1;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "c_escape",
+    "cached_src_nodes": 18,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_diff.c",
+    "snippet": "char [5] c_escape(char *a0)\n{\n    unsigned int flag;  // eax\n    unsigned int choice;  // eax\n    char ptr[5];  // rax\n    char p[5];  // rax\n    char addr[5];  // rax\n    char ptr5[5];  // rax\n    char v0;  // [bp-0x34]\n    char v1;  // [bp-0x33]\n    char v2;  // [bp-0x32]\n    char v3;  // [bp-0x31]\n    char iter[5];  // [bp-0x30]\n    unsigned long long node;  // [bp-0x28]"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "cmp",
+    "function": "file_position",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_cmp.c",
+    "snippet": "extern unsigned int g_4100b0[4];\nextern unsigned long long g_410200[4];\nextern char g_410215;\nextern unsigned long long g_410220[4];\n\nunsigned long long [4] file_position(unsigned int a0)\n{\n    if (*(&(&g_410215)[a0]) != 1)\n    {\n        *(&(&g_410215)[a0]) = 1;\n        g_410220[a0] = lseek(g_4100b0[a0], g_410200[a0], 1);\n    }\n    return g_410220[a0];\n}"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "sdiff",
+    "function": "lf_skip",
+    "cached_src_nodes": 5,
+    "c_path": "results/full_run/O0/diffutils/decompiled/phoenix_sdiff.c",
+    "snippet": "void* [4] lf_skip(void* *p, unsigned long long a1)\n{\n    void* ptr[4];  // rax\n    unsigned long long v0;  // [bp-0x18]\n\n    v0 = a1;\n    while (true)\n    {\n        if (!v0)\n            return ptr;\n        p[1] = rawmemchr(p[1], 10);\n        if (p[1] == p[3])\n        {\n            ptr = sub_4042c0(p);"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "log_facility_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned long long g_47a020[4];\nextern unsigned int g_47a028[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_47a020[2 * v0])\n        {\n            if (!strcasecmp(g_47a020[2 * v0], a0))"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "log_facility_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned long long g_47a020[4];\nextern unsigned int g_47a028[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_47a020[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "log_level_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned long long g_47a100[4];\nextern unsigned int g_47a108[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_47a100[2 * v0])\n        {\n            if (!strcasecmp(g_47a100[2 * v0], a0))"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "log_level_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned long long g_47a100[4];\nextern unsigned int g_47a108[4];\n\nunsigned long long [4] log_level_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_47a100[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "hpdelim2",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "typedef struct struct_0 {\n    char field_0;\n    char field_1;\n} struct_0;\n\nchar [2] hpdelim2(struct_0 **ptr, char *p)\n{\n    unsigned long len;  // rax\n    unsigned int v4;  // eax\n    char ptr[2];  // [bp-0x28]\n    char v1[2];  // [bp-0x20]\n\n    if (ptr)\n    {"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "hpdelim",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "char [2] hpdelim(char *a0[2])\n{\n    char flag;  // [bp-0x19]\n    char v1[2];  // [bp-0x18]\n\n    flag = 0;\n    v1 = sub_42f8ac(a0, &flag);\n    if (flag == 47)\n        v1 = NULL;\n    [D] PutI(904:F64x8)[t30,0] = t33()\n    [D] PutI(968:I8x8)[t30,0] = 0x01()\n    [D] PutI(904:F64x8)[t40,0] = t43()\n    [D] PutI(968:I8x8)[t40,0] = 0x01()\n    [D] PutI(904:F64x8)[t50,0] = t53()"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "colon",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "char [2] colon(char *a0)\n{\n    char cur[2];  // [bp-0x20]\n    unsigned int v1;  // [bp-0xc]\n\n    cur = a0;\n    v1 = 0;\n    if (cur[0] == 58)\n    {\n        cur = NULL;\n    }\n    else\n    {\n        if (cur[0] == 91)"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "iptos2str",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned long long g_479020[4];\nextern unsigned int g_479028[4];\nextern unsigned long long g_47a2ec[4];\n\nunsigned long long [4] iptos2str(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_479020[2 * v0])\n        {"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "chachapoly_new",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "long long [2] chachapoly_new(long long a0, unsigned int a1)\n{\n    long long v2[2];  // rax\n    long long v3;  // rax\n    long long v4;  // rax\n    long long ptr[2];  // [bp-0x20]\n\n    if (a1 != 64)\n    {\n        v2 = NULL;\n    }\n    else\n    {\n        ptr = calloc(1, 16);"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-pkcs11-helper",
+    "function": "ssh_digest_alg_by_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_ssh-pkcs11-helper.c",
+    "snippet": "extern unsigned int g_4793c0[4];\nextern unsigned long long g_4793c8[4];\n\nunsigned int [4] ssh_digest_alg_by_name(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (g_4793c0[8 * v0] == 0xffffffff)\n        {\n            v2 = 0xffffffff;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "status_to_message",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_sftp-server.c",
+    "snippet": "extern unsigned long long g_434740[4];\n\nunsigned long long [4] status_to_message(unsigned int a0)\n{\n    unsigned int v1;  // eax\n\n    v1 = a0;\n    if (8 < v1)\n        v1 = 8;\n    [D] PutI(904:F64x8)[t44,0] = t47()\n    [D] PutI(968:I8x8)[t44,0] = 0x01()\n    [D] PutI(904:F64x8)[t54,0] = t57()\n    [D] PutI(968:I8x8)[t54,0] = 0x01()\n    [D] PutI(904:F64x8)[t64,0] = t67()"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_facility_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_sftp-server.c",
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned int [4] log_facility_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_435040[2 * v0])\n        {\n            if (!strcasecmp(g_435040[2 * v0], a0))"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_facility_name",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_sftp-server.c",
+    "snippet": "extern unsigned long long g_435040[4];\nextern unsigned int g_435048[4];\n\nunsigned long long [4] log_facility_name(unsigned int *a0)\n{\n    unsigned long long v2[4];  // rax\n    unsigned int v0;  // [bp-0xc]\n\n    v0 = 0;\n    while (true)\n    {\n        if (!g_435040[2 * v0])\n        {\n            v2 = NULL;"
+   },
+   {
+    "dec": "phoenix",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "log_level_number",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/phoenix_sftp-server.c",
+    "snippet": "extern unsigned long long g_435120[4];\nextern unsigned int g_435128[4];\n\nunsigned int [4] log_level_number(char *a0)\n{\n    unsigned int v2[4];  // eax\n    unsigned int v0;  // [bp-0xc]\n\n    if (a0)\n    {\n        v0 = 0;\n        while (g_435120[2 * v0])\n        {\n            if (!strcasecmp(g_435120[2 * v0], a0))"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "function": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O0/gnutls/decompiled/ghidra_gnutls-serv.c",
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  uint uVar1;\n  int iVar2;\n  time_t tVar3;\n  long lVar4;\n  void *__dest;\n  undefined1 auVar5 [16];\n  undefined4 local_24;\n  undefined4 uStack_c;\n  \n  tVar3 = time((time_t *)0x0);"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "stat",
+    "function": "neg_to_zero",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_stat.c",
+    "snippet": "\nundefined1  [16] neg_to_zero(undefined8 param_1,long param_2)\n\n{\n  undefined1 auVar1 [16];\n  \n  if (param_2 < 0) {\n    param_1 = 0;\n    param_2 = 0;\n  }\n  auVar1._8_8_ = param_2;\n  auVar1._0_8_ = param_1;\n  return auVar1;\n}"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "dir",
+    "function": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_dir.c",
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "dir",
+    "function": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_dir.c",
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "ls",
+    "function": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_ls.c",
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "ls",
+    "function": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_ls.c",
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "make-prime-list",
+    "function": "binvert",
+    "cached_src_nodes": 4,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_make-prime-list.c",
+    "snippet": "\nundefined1  [16] binvert(ulong param_1,long param_2)\n\n{\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  undefined1 auVar3 [16];\n  undefined1 auVar4 [16];\n  undefined1 auVar5 [16];\n  ulong uVar6;\n  ulong uVar7;\n  ulong uVar8;\n  long lVar9;\n  ulong local_38;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "vdir",
+    "function": "dev_ino_pop",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_vdir.c",
+    "snippet": "\nundefined1  [16] dev_ino_pop(void)\n\n{\n  if ((ulong)((long)DAT_0012b5f8 - DAT_0012b5f0) < 0x10) {\n                    /* WARNING: Subroutine does not return */\n    __assert_fail(\"dev_ino_size <= obstack_object_size (&dev_ino_obstack)\",\"src/ls.c\",0x41d,\n                  \"dev_ino_pop\");\n  }\n  DAT_0012b5f8 = (undefined1 (*) [16])((long)DAT_0012b5f8 + -0x10);\n  return *DAT_0012b5f8;\n}\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "vdir",
+    "function": "get_stat_btime",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ghidra_vdir.c",
+    "snippet": "\nundefined1  [16] get_stat_btime(undefined8 param_1)\n\n{\n  undefined1 auVar1 [16];\n  \n  auVar1 = FUN_0011b491(param_1);\n  return auVar1;\n}\n\n\n"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O0",
+    "project": "tar",
+    "binary": "tar",
+    "function": "decode_timespec",
+    "cached_src_nodes": 42,
+    "c_path": "results/full_run/O0/tar/decompiled/ghidra_tar.c",
+    "snippet": "\nundefined1  [16] decode_timespec(char *param_1,char **param_2,char param_3)\n\n{\n  undefined1 auVar1 [16];\n  int *piVar2;\n  uintmax_t uVar3;\n  bool bVar4;\n  bool local_42;\n  int local_40;\n  int local_3c;\n  uintmax_t local_38;\n  char *local_30;\n  "
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "concat",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2/diffutils/decompiled/ghidra_diff.c",
+    "snippet": "\nundefined1  [16] concat(char *param_1,char *param_2,char *param_3)\n\n{\n  size_t sVar1;\n  size_t sVar2;\n  size_t sVar3;\n  undefined1 auVar4 [16];\n  \n  sVar1 = strlen(param_1);\n  sVar2 = strlen(param_2);\n  sVar3 = strlen(param_3);\n  auVar4._0_8_ = FUN_00116a40(sVar1 + sVar2 + 1 + sVar3);\n  __sprintf_chk(auVar4._0_8_,1,0xffffffffffffffff,\"%s%s%s\",param_1,param_2,param_3);"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "function": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O2/gnutls/decompiled/ghidra_gnutls-serv.c",
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  int iVar1;\n  time_t tVar2;\n  long lVar3;\n  void *__dest;\n  long lVar4;\n  int iVar5;\n  ulong __size;\n  void *pvVar6;\n  undefined1 auVar7 [16];\n  "
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "libexpat",
+    "binary": "xmlwf",
+    "function": "metaLocation",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O2/libexpat/decompiled/ghidra_xmlwf.c",
+    "snippet": "\nundefined1  [16] metaLocation(undefined8 *param_1)\n\n{\n  undefined8 uVar1;\n  undefined1 auVar2 [16];\n  undefined4 uVar3;\n  long lVar4;\n  undefined8 uVar5;\n  undefined8 uVar6;\n  undefined8 uVar7;\n  \n  lVar4 = XML_GetBase();\n  uVar1 = *(undefined8 *)*param_1;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "coreutils",
+    "binary": "true",
+    "function": "main",
+    "cached_src_nodes": 34,
+    "c_path": "results/full_run/O2/coreutils/decompiled/ghidra_true.c",
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2,ulong param_3,ulong param_4)\n\n{\n  char *__s1;\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  int iVar3;\n  \n  if (param_1 != 2) {\n    auVar1._8_8_ = 0;\n    auVar1._0_8_ = param_3;\n    return auVar1 << 0x40;\n  }"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "coreutils",
+    "binary": "false",
+    "function": "main",
+    "cached_src_nodes": 34,
+    "c_path": "results/full_run/O2/coreutils/decompiled/ghidra_false.c",
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2,undefined8 param_3,undefined8 param_4)\n\n{\n  char *__s1;\n  int iVar1;\n  undefined1 auVar2 [16];\n  undefined1 auVar3 [16];\n  \n  if (param_1 != 2) {\n    auVar2._8_8_ = param_3;\n    auVar2._0_8_ = 1;\n    return auVar2;\n  }"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "shadow",
+    "binary": "passwd",
+    "function": "main",
+    "cached_src_nodes": 56,
+    "c_path": "results/full_run/O2/shadow/decompiled/ghidra_passwd.c",
+    "snippet": "\nundefined1  [16] main(int param_1,undefined8 *param_2)\n\n{\n  undefined1 auVar1 [16];\n  FILE *__stream;\n  undefined8 *puVar2;\n  char cVar3;\n  __uid_t _Var4;\n  int iVar5;\n  __uid_t _Var6;\n  undefined8 *puVar7;\n  long lVar8;\n  char *pcVar9;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "libselinux",
+    "binary": "libselinux.so",
+    "function": "regex_arch_string",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2/libselinux/decompiled/ghidra_libselinux.so.c",
+    "snippet": "\nundefined1  [16] regex_arch_string(undefined8 param_1,undefined8 param_2,undefined8 param_3)\n\n{\n  undefined1 auVar1 [16];\n  undefined1 auVar2 [16];\n  \n  if (*PTR_DAT_0012c820 != '\\0') {\n    auVar1._8_8_ = param_3;\n    auVar1._0_8_ = PTR_DAT_0012c820;\n    return auVar1;\n  }\n  __snprintf_chk(&DAT_0012dc20,0x20,1,0x20,\"%zu-%zu-%s\",8,8);\n  PTR_DAT_0012c820 = &DAT_0012dc20;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "tar",
+    "binary": "tar",
+    "function": "tar_checksum",
+    "cached_src_nodes": 15,
+    "c_path": "results/full_run/O2/tar/decompiled/ghidra_tar.c",
+    "snippet": "\nundefined1  [16] tar_checksum(byte *param_1,byte param_2)\n\n{\n  byte bVar1;\n  int iVar2;\n  int iVar3;\n  byte *pbVar4;\n  int iVar5;\n  undefined8 uVar6;\n  undefined1 auVar7 [16];\n  undefined1 auVar8 [16];\n  undefined1 auVar9 [16];\n  "
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "tar",
+    "binary": "tar",
+    "function": "decode_timespec",
+    "cached_src_nodes": 42,
+    "c_path": "results/full_run/O2/tar/decompiled/ghidra_tar.c",
+    "snippet": "\nundefined1  [16] decode_timespec(char *param_1,char **param_2,char param_3)\n\n{\n  char cVar1;\n  int iVar2;\n  int iVar3;\n  int *piVar4;\n  uintmax_t uVar5;\n  long lVar6;\n  char *pcVar7;\n  int iVar8;\n  uint uVar9;\n  int iVar10;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "cronie",
+    "binary": "crond",
+    "function": "load_user",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2/cronie/decompiled/ghidra_crond.c",
+    "snippet": "\nundefined1 (*) [16]\nload_user(int param_1,undefined8 param_2,undefined8 param_3,char *param_4,char *param_5)\n\n{\n  void *pvVar1;\n  undefined8 *puVar2;\n  undefined1 *puVar3;\n  int iVar4;\n  __pid_t _Var5;\n  FILE *__stream;\n  int *piVar6;\n  undefined1 (*__ptr) [16];\n  char *pcVar7;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2",
+    "project": "cronie",
+    "binary": "cronnext",
+    "function": "load_user",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2/cronie/decompiled/ghidra_cronnext.c",
+    "snippet": "\nundefined1 (*) [16]\nload_user(int param_1,undefined8 param_2,undefined8 param_3,char *param_4,char *param_5)\n\n{\n  void *pvVar1;\n  undefined8 *puVar2;\n  undefined1 *puVar3;\n  int iVar4;\n  __pid_t _Var5;\n  FILE *__stream;\n  int *piVar6;\n  undefined1 (*__ptr) [16];\n  char *pcVar7;"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2-noinline",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "concat",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2-noinline/diffutils/decompiled/ghidra_diff.c",
+    "snippet": "\nundefined1  [16] concat(char *param_1,char *param_2,char *param_3)\n\n{\n  size_t sVar1;\n  size_t sVar2;\n  size_t sVar3;\n  undefined1 auVar4 [16];\n  \n  sVar1 = strlen(param_1);\n  sVar2 = strlen(param_2);\n  sVar3 = strlen(param_3);\n  auVar4._0_8_ = FUN_00115f50(sVar1 + sVar2 + 1 + sVar3);\n  __sprintf_chk(auVar4._0_8_,1,0xffffffffffffffff,\"%s%s%s\",param_1,param_2,param_3);"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2-noinline",
+    "project": "gnutls",
+    "binary": "gnutls-serv",
+    "function": "wrap_db_fetch",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O2-noinline/gnutls/decompiled/ghidra_gnutls-serv.c",
+    "snippet": "\nundefined1  [16] wrap_db_fetch(undefined8 param_1,void *param_2,uint param_3)\n\n{\n  int iVar1;\n  time_t tVar2;\n  long lVar3;\n  void *__dest;\n  long lVar4;\n  int iVar5;\n  ulong __size;\n  void *pvVar6;\n  undefined1 auVar7 [16];\n  "
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2-noinline",
+    "project": "iproute2",
+    "binary": "ip",
+    "function": "tnl_print_stats",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O2-noinline/iproute2/decompiled/ghidra_ip.c",
+    "snippet": "\nundefined1  [16] tnl_print_stats(undefined8 *param_1)\n\n{\n  undefined8 uVar1;\n  undefined1 auVar2 [16];\n  undefined8 uVar3;\n  \n  __printf_chk(1,&DAT_00184f09,_SL_);\n  __printf_chk(1,\"RX: Packets    Bytes        Errors CsumErrs OutOfSeq Mcasts%s\",_SL_);\n  __printf_chk(1,\"    %-10lld %-12lld %-6lld %-8lld %-8lld %-8lld%s\",*param_1,param_1[2],param_1[4],\n               param_1[0xd],param_1[0xe],param_1[8],_SL_);\n  __printf_chk(1,\"TX: Packets    Bytes        Errors DeadLoop NoRoute  NoBufs%s\",_SL_);\n  uVar1 = param_1[7];"
+   },
+   {
+    "dec": "ghidra",
+    "opt": "O2-noinline",
+    "project": "iproute2",
+    "binary": "ip",
+    "function": "xfrm_stats_print",
+    "cached_src_nodes": 5,
+    "c_path": "results/full_run/O2-noinline/iproute2/decompiled/ghidra_ip.c",
+    "snippet": "\nundefined1  [16] xfrm_stats_print(undefined4 *param_1,FILE *param_2,char *param_3)\n\n{\n  undefined1 auVar1 [16];\n  undefined *puVar2;\n  \n  fputs(param_3,param_2);\n  __fprintf_chk(param_2,1,\"stats:%s\",_SL_);\n  fputs(param_3,param_2);\n  puVar2 = _SL_;\n  __fprintf_chk(param_2,1,\"  replay-window %u replay %u failed %u%s\",*param_1,param_1[1],param_1[2])\n  ;\n  auVar1._8_8_ = 0x13314d;"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "function": "_el_fn_complete",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/libedit/decompiled/ida_libedit.so.0.0.c",
+    "snippet": "long long el_fn_complete(long long a1)\n{\n  return fn_complete(a1, 0, 0, U\" \\t\\n\\\"\\\\'`@$><=;|&{(\", 0, 0, 0x64u, 0, 0, 0, 0);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "function": "_rl_abort_internal",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/libedit/decompiled/ida_libedit.so.0.0.c",
+    "snippet": "void rl_abort_internal()\n{\n  el_beep(qword_478E0);\n  longjmp(env, 1);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "function": "_rl_qsort_string_compare",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/libedit/decompiled/ida_libedit.so.0.0.c",
+    "snippet": "int rl_qsort_string_compare(const char **a1, const char **a2)\n{\n  return strcoll(*a1, *a2);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "libedit",
+    "binary": "libedit.so.0.0",
+    "function": "_rl_erase_entire_line",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/libedit/decompiled/ida_libedit.so.0.0.c",
+    "snippet": "void rl_erase_entire_line()\n{\n  ;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "iproute2",
+    "binary": "ip",
+    "function": "__print_rta_gateway",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/iproute2/decompiled/ida_ip.c",
+    "snippet": "long long _print_rta_gateway(FILE *a1, unsigned char a2, const char *a3)\n{\n  unsigned int v4; // eax\n\n  if ( (unsigned char)is_json_context(a1) )\n    return sub_19642(2, \"gateway\", 0, a3);\n  fprintf(a1, \"via \");\n  v4 = ifa_family_color(a2);\n  return print_color_string(1, v4, 0, \"%s \", a3);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "coreutils",
+    "binary": "make-prime-list",
+    "function": "print_wide_uint",
+    "cached_src_nodes": 9,
+    "c_path": "results/full_run/O0/coreutils/decompiled/ida_make-prime-list.c",
+    "snippet": "int print_wide_uint(unsigned __int128 a1, int a2, unsigned int a3)\n{\n  unsigned int v6; // [rsp+20h] [rbp-10h]\n\n  v6 = 7;\n  if ( *((long long *)&a1 + 1) | (unsigned long long)a1 ^ a1 & 0xFFFFFFF )\n  {\n    if ( a1 >> 56 != 0 )\n      printf(\"(\");\n    print_wide_uint(a1 >> 28, a1 >> 28 >> 64, (unsigned int)(a2 + 1), a3, a1 >> 28, a1 >> 28 >> 64);\n    if ( a1 >> 56 != 0 )\n      printf(\")\\n%*s\", a2 + 3, (const char *)&unk_200A);\n    printf(\" << %d | \", 28);\n  }"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "libbsd",
+    "binary": "libbsd.so.0.11",
+    "function": "__fdnlist",
+    "cached_src_nodes": 59,
+    "c_path": "results/full_run/O0/libbsd/decompiled/ida_libbsd.so.0.11.c",
+    "snippet": "// bad sp value at call has been detected, the output may be wrong!\nlong long _fdnlist(int a1, const char **a2)\n{\n  int v3; // eax\n  unsigned int v4; // [rsp+18h] [rbp-6138h]\n  unsigned int nbytes; // [rsp+1Ch] [rbp-6134h]\n  int nbytes_4; // [rsp+20h] [rbp-6130h]\n  int i; // [rsp+24h] [rbp-612Ch]\n  int v8; // [rsp+28h] [rbp-6128h]\n  unsigned int size; // [rsp+2Ch] [rbp-6124h]\n  unsigned int size_4; // [rsp+30h] [rbp-6120h]\n  int v11; // [rsp+34h] [rbp-611Ch]\n  const char **j; // [rsp+38h] [rbp-6118h]\n  const char **k; // [rsp+38h] [rbp-6118h]"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_getenv",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "char *getenv(const char *name)\n{\n  return (char *)getenv(name);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_internal_char_cleanup",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_internal_char_cleanup()\n{\n  long long result; // rax\n\n  if ( rl_keep_mark_active )\n  {\n    rl_keep_mark_active = 0;\n  }\n  else if ( (unsigned int)rl_mark_active_p() )\n  {\n    rl_deactivate_mark();\n  }\n  if ( !rl_editing_mode && rl_keymap == &vi_movement_keymap )\n    rl_vi_check();"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_init_line_state",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "char *rl_init_line_state()\n{\n  char *result; // rax\n\n  rl_mark = 0;\n  rl_end = 0;\n  rl_point = 0;\n  qword_17BD38 = rl_line_buffer;\n  result = rl_line_buffer;\n  *rl_line_buffer = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_set_the_line",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "char *rl_set_the_line()\n{\n  qword_17BD38 = rl_line_buffer;\n  return rl_line_buffer;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_keyseq_cxt_alloc",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_keyseq_cxt_alloc()\n{\n  long long result; // rax\n\n  result = xmalloc(48);\n  *(int *)(result + 8) = 0;\n  *(int *)(result + 4) = *(int *)(result + 8);\n  *(int *)result = *(int *)(result + 4);\n  *(int *)(result + 12) = 0;\n  *(long long *)(result + 32) = rl_kscxt;\n  *(int *)(result + 40) = 42;\n  return result;\n}\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_keyseq_cxt_dispose",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_keyseq_cxt_dispose(long long a1)\n{\n  return xfree(a1);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_keyseq_chain_dispose",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_keyseq_chain_dispose()\n{\n  long long result; // rax\n  long long v1; // [rsp+8h] [rbp-8h]\n\n  while ( 1 )\n  {\n    result = rl_kscxt;\n    if ( !rl_kscxt )\n      break;\n    v1 = rl_kscxt;\n    rl_kscxt = *(long long *)(rl_kscxt + 32);\n    rl_keyseq_cxt_dispose(v1);\n  }"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_dispatch_callback",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_dispatch_callback(long long a1)\n{\n  unsigned int v2; // [rsp+18h] [rbp-8h]\n  int v3; // [rsp+1Ch] [rbp-4h]\n\n  if ( (*(int *)a1 & 1) != 0 )\n  {\n    v2 = *(int *)(a1 + 40);\n  }\n  else\n  {\n    v3 = sub_F818C(*(int *)(a1 + 12));\n    if ( v3 < 0 )\n      rl_abort_internal();"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_dispatch",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_dispatch(unsigned int a1, long long a2)\n{\n  rl_dispatching_keymap = a2;\n  return rl_dispatch_subseq(a1, a2, 0);\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_dispatch_subseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_dispatch_subseq(int a1, long long a2, unsigned int a3)\n{\n  unsigned int v3; // ebx\n  int v4; // eax\n  int v6; // eax\n  unsigned int v7; // eax\n  int v8; // eax\n  unsigned int v9; // eax\n  unsigned int v10; // eax\n  int v11; // eax\n  int v12; // eax\n  int v13; // edx\n  long long v14; // rdx\n  const char *v15; // r12"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_init_executing_keyseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_init_executing_keyseq()\n{\n  long long result; // rax\n\n  rl_key_sequence_length = 0;\n  result = rl_executing_keyseq;\n  *(char *)rl_executing_keyseq = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_term_executing_keyseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "char *rl_term_executing_keyseq()\n{\n  char *result; // rax\n\n  result = (char *)(rl_executing_keyseq + rl_key_sequence_length);\n  *result = 0;\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_end_executing_keyseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_end_executing_keyseq()\n{\n  long long result; // rax\n\n  result = (unsigned int)rl_key_sequence_length;\n  if ( rl_key_sequence_length > 0 )\n  {\n    result = rl_executing_keyseq + --rl_key_sequence_length;\n    *(char *)result = 0;\n  }\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_add_executing_keyseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "char *rl_add_executing_keyseq(char a1)\n{\n  int v1; // eax\n  char *result; // rax\n\n  if ( rl_key_sequence_length + 2 >= rl_executing_keyseq_size )\n  {\n    rl_executing_keyseq_size += 16;\n    rl_executing_keyseq = xrealloc(rl_executing_keyseq, rl_executing_keyseq_size);\n  }\n  v1 = rl_key_sequence_length++;\n  result = (char *)(rl_executing_keyseq + v1);\n  *result = a1;\n  return result;"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_del_executing_keyseq",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_del_executing_keyseq()\n{\n  long long result; // rax\n\n  result = (unsigned int)rl_key_sequence_length;\n  if ( rl_key_sequence_length > 0 )\n    return (unsigned int)--rl_key_sequence_length;\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_vi_initialize_line",
+    "cached_src_nodes": 4,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "unsigned long long rl_vi_initialize_line()\n{\n  int i; // ebx\n  unsigned long long result; // rax\n\n  for ( i = 0; i < 26; ++i )\n    dword_17BDE0[i] = -1;\n  result = rl_readline_state & 0xFFFFFFFFFFBFFFFFLL;\n  rl_readline_state &= ~0x400000uLL;\n  return result;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_vi_reset_last",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "void rl_vi_reset_last()\n{\n  rl_vi_last_command = 105;\n  dword_16CC9C = 1;\n  dword_16CCA0 = 1;\n  dword_17BD8C = 0;\n}\n\n"
+   },
+   {
+    "dec": "ida",
+    "opt": "O0",
+    "project": "bash",
+    "binary": "bash",
+    "function": "_rl_vi_set_last",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/bash/decompiled/ida_bash.c",
+    "snippet": "long long rl_vi_set_last(int a1, int a2, unsigned int a3)\n{\n  rl_vi_last_command = a1;\n  dword_16CC9C = a2;\n  dword_16CCA0 = a3;\n  return a3;\n}\n\n"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "rpl_fcntl",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/gzip/decompiled/binja_gzip.c",
+    "snippet": "uint64_t rpl_fcntl(int32_t arg1, int32_t arg2, char arg3 @ rax)\n\n{\n    int64_t rdx;\n    int64_t var_a8 = rdx;\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg3 != 0)\n    {\n        int128_t zmm0;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "open_safer",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/gzip/decompiled/binja_gzip.c",
+    "snippet": "uint64_t open_safer(char* arg1, int32_t arg2, char arg3 @ rax)\n\n{\n    int64_t rdx;\n    int64_t var_a8 = rdx;\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg3 != 0)\n    {\n        int128_t zmm0;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "gzip",
+    "binary": "gzip",
+    "function": "openat_safer",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/gzip/decompiled/binja_gzip.c",
+    "snippet": "uint64_t openat_safer(int32_t arg1, char* arg2, int32_t arg3, char arg4 @ rax)\n\n{\n    int64_t rcx;\n    int64_t var_a0 = rcx;\n    int64_t r8;\n    int64_t var_98 = r8;\n    int64_t r9;\n    int64_t var_90 = r9;\n    if (arg4 != 0)\n    {\n        int128_t zmm0;\n        int128_t var_88_1 = zmm0;\n        int128_t zmm1;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "print_context_script",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/diffutils/decompiled/binja_diff.c",
+    "snippet": "int64_t* print_context_script(int64_t* arg1, char arg2)\n\n{\n    if ((data_2d1ec != 0 || (data_2d1ec == 0 && data_2d280 != 0)))\n    {\n        sub_8c9d(arg1);\n    }\n    if ((data_2d1ec == 0 && data_2d280 == 0))\n    {\n        for (int64_t* var_10_1 = arg1; var_10_1 != 0; var_10_1 = *(int64_t*)var_10_1)\n        {\n            var_10_1[5] = 0;\n        }\n    }"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "find_function",
+    "cached_src_nodes": 7,
+    "c_path": "results/full_run/O0/diffutils/decompiled/binja_diff.c",
+    "snippet": "char* find_function(void* arg1, int64_t arg2)\n\n{\n    int64_t var_28 = arg2;\n    int64_t rax_1 = data_2d1b0;\n    data_2d1b0 = var_28;\n    char* rax_18;\n    while (true)\n    {\n        var_28 = (var_28 - 1);\n        if (var_28 < rax_1)\n        {\n            if (data_2d1b8 == 0x7fffffffffffffff)\n            {"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "compare_names_for_qsort",
+    "cached_src_nodes": 4,
+    "c_path": "results/full_run/O0/diffutils/decompiled/binja_diff.c",
+    "snippet": "uint64_t compare_names_for_qsort(int64_t* arg1, int64_t* arg2)\n\n{\n    char* rax_3 = *(int64_t*)arg1;\n    char* rax_5 = *(int64_t*)arg2;\n    int32_t rax_8;\n    uint64_t rax_9;\n    if (data_2d660 != 0)\n    {\n        rax_8 = sub_c084(rax_3, rax_5);\n        if (rax_8 != 0)\n        {\n            rax_9 = ((uint64_t)rax_8);\n        }"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "diffutils",
+    "binary": "diff",
+    "function": "print_ed_script",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/diffutils/decompiled/binja_diff.c",
+    "snippet": "int64_t* print_ed_script(int64_t* arg1)\n\n{\n    return sub_1245b(arg1, sub_12449, sub_cbb5);\n}\n"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "key_print_wrapper",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "int64_t key_print_wrapper(int32_t* arg1, void* arg2)\n\n{\n    void* rax_1;\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "keygrab_ssh2",
+    "cached_src_nodes": 12,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "int64_t keygrab_ssh2(void* arg1)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char const* const var_68 = \"sntrup761x25519-sha512@openssh.c\u2026\";\n    char const* const var_60 = \"ssh-ed25519-cert-v01@openssh.com\u2026\";\n    char const* const var_58 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_50 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_48 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_40 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_38 = \"none,zlib@openssh.com\";\n    char const* const var_30 = \"none,zlib@openssh.com\";\n    void* const var_28 = &data_7b444;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "keyprint",
+    "cached_src_nodes": 14,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "int64_t keyprint(void* arg1, int32_t* arg2)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char* rax_4;\n    if (*(int64_t*)((char*)arg1 + 0x38) == 0)\n    {\n        rax_4 = *(int64_t*)((char*)arg1 + 0x28);\n    }\n    else\n    {\n        rax_4 = *(int64_t*)((char*)arg1 + 0x38);\n    }"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "ssh_init",
+    "cached_src_nodes": 13,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "uint64_t ssh_init(int32_t*** arg1, int32_t arg2, char** arg3)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    char const* const var_68 = \"sntrup761x25519-sha512@openssh.c\u2026\";\n    char const* const var_60 = \"ssh-ed25519-cert-v01@openssh.com\u2026\";\n    char const* const var_58 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_50 = \"chacha20-poly1305@openssh.com,ae\u2026\";\n    char const* const var_48 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_40 = \"umac-64-etm@openssh.com,umac-128\u2026\";\n    char const* const var_38 = \"none,zlib@openssh.com\";\n    char const* const var_30 = \"none,zlib@openssh.com\";\n    void* const var_28 = &data_7c36c;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "_ssh_verify_host_key",
+    "cached_src_nodes": 6,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "int64_t _ssh_verify_host_key(int32_t* arg1, void* arg2)\n\n{\n    void* var_30 = sub_1269b(arg1);\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "_ssh_host_key_sign",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "uint64_t _ssh_host_key_sign(void* arg1, int32_t* arg2, int64_t arg3, int64_t* arg4, \n    int64_t* arg5, int64_t arg6, uint64_t arg7, char* arg8)\n\n{\n    int64_t var_20 = arg3;\n    uint64_t rax_3;\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keyscan",
+    "function": "kexgex_hash",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keyscan.c",
+    "snippet": "uint64_t kexgex_hash(int32_t arg1, int64_t* arg2, int64_t* arg3, int64_t* arg4, \n    int64_t* arg5, int64_t* arg6, int32_t arg7, int32_t arg8, int32_t arg9, \n    int64_t arg10, int64_t arg11, int64_t arg12, int64_t arg13, int64_t arg14, \n    uint64_t arg15, int64_t arg16, int64_t* arg17)\n\nLoading...\n"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sshd",
+    "function": "grace_alarm_handler",
+    "cached_src_nodes": 3,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sshd.c",
+    "snippet": "int64_t grace_alarm_handler() __noreturn\n\n{\n    int32_t rdi;\n    int32_t var_1c = rdi;\n    if (getpgid(0) == getpid())\n    {\n        sub_b4fca(0xf, 1);\n        kill(0, 0xf);\n    }\n    uint64_t var_38 = ((uint64_t)sub_9a061(data_141ef0));\n    int64_t var_40 = sub_99f12(data_141ef0);\n    sub_95692(\"sshd.c\", \"grace_alarm_handler\", 0x172, 0, 2, 0, 0, \"Timeout before authentication fo\u2026\");\n    /* no return */"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sshd",
+    "function": "main",
+    "cached_src_nodes": 275,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sshd.c",
+    "snippet": "int32_t main(int32_t argc, char** argv, char** envp) __noreturn\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int64_t var_30 = rax;\n    int32_t var_174 = 1;\n    int32_t var_170 = 0xffffffff;\n    int32_t var_16c = 0xffffffff;\n    int32_t var_168 = 0xffffffff;\n    char* var_120 = nullptr;\n    int32_t var_d0 = 0xffffffff;\n    int32_t var_cc = 0xffffffff;\n    int64_t* var_118 = nullptr;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "attrib_to_stat",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sftp-server.c",
+    "snippet": "int64_t attrib_to_stat(int32_t* arg1, void* arg2)\n\n{\n    memset(arg2, 0, 0x90);\n    if ((*(int32_t*)arg1 & 1) != 0)\n    {\n        *(int64_t*)((char*)arg2 + 0x30) = *(int64_t*)((char*)arg1 + 8);\n    }\n    if ((*(int32_t*)arg1 & 2) != 0)\n    {\n        *(int32_t*)((char*)arg2 + 0x1c) = arg1[4];\n        *(int32_t*)((char*)arg2 + 0x20) = arg1[5];\n    }\n    if ((*(int32_t*)arg1 & 4) != 0)"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp-server",
+    "function": "fx2txt",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sftp-server.c",
+    "snippet": "void* const fx2txt(int32_t arg1)\n\n{\n    void* const rax_4;\n    if (arg1 > 8)\n    {\n        rax_4 = \"Unknown status\";\n    }\n    else\n    {\n        switch (arg1)\n        {\n            case 0:\n            {"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "function": "sdirent_comp",
+    "cached_src_nodes": 17,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sftp.c",
+    "snippet": "uint64_t sdirent_comp(int64_t* arg1, int64_t* arg2)\n\n{\n    int64_t* rax_1 = *(int64_t*)arg1;\n    int64_t* rax_3 = *(int64_t*)arg2;\n    int32_t rax_6;\n    if ((data_4b324 & 0x40) == 0)\n    {\n        rax_6 = 1;\n    }\n    else\n    {\n        rax_6 = -1;\n    }"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "function": "parse_args",
+    "cached_src_nodes": 85,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sftp.c",
+    "snippet": "uint64_t parse_args(int64_t* arg1, int32_t* arg2, int32_t* arg3, int32_t* arg4, \n    int32_t* arg5, int32_t* arg6, int32_t* arg7, int32_t* arg8, int32_t* arg9, \n    int32_t* arg10, int32_t* arg11, int64_t* arg12, int64_t* arg13, \n    int64_t* arg14)\n\nLoading...\n"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "sftp",
+    "function": "connect_to_server",
+    "cached_src_nodes": 11,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_sftp.c",
+    "snippet": "int64_t connect_to_server(char* arg1, char** arg2, int32_t* arg3, int32_t* arg4)\n\n{\n    void* fsbase;\n    int64_t rax = *(int64_t*)((char*)fsbase + 0x28);\n    int32_t var_18;\n    if (socketpair(1, 1, 0, &var_18) == 0xffffffff)\n    {\n        char* var_50 = strerror(*(int32_t*)__errno_location());\n        sub_23b81(\"sftp.c\", \"connect_to_server\", 0x938, 0, 1, 0, 0, \"socketpair: %s\");\n        /* no return */\n    }\n    *(int32_t*)arg4 = var_18;\n    *(int32_t*)arg3 = *(int32_t*)arg4;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keysign",
+    "function": "kex_default_pk_alg",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keysign.c",
+    "snippet": "int64_t kex_default_pk_alg()\n\n{\n    int512_t zmm0;\n    int512_t zmm1;\n    int512_t zmm2;\n    int512_t zmm3;\n    int512_t zmm4;\n    int512_t zmm5;\n    int512_t zmm6;\n    int512_t zmm7;\n    int512_t zmm8;\n    int512_t zmm9;\n    int512_t zmm10;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-sk-helper",
+    "function": "sshbuf_alloc",
+    "cached_src_nodes": 1,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-sk-helper.c",
+    "snippet": "int64_t sshbuf_alloc(void* arg1)\n\n{\n    int512_t zmm0;\n    zmm0 = 0;\n    int512_t zmm1;\n    zmm1 = 0;\n    int512_t zmm2;\n    zmm2 = 0;\n    int512_t zmm3;\n    zmm3 = 0;\n    int512_t zmm4;\n    zmm4 = 0;\n    int512_t zmm5;"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keygen",
+    "function": "known_hosts_find_delete",
+    "cached_src_nodes": 29,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keygen.c",
+    "snippet": "int64_t known_hosts_find_delete(int64_t* arg1, int64_t* arg2)\n\n{\n    int64_t var_28 = 0;\n    int64_t var_20 = 0;\n    int32_t rax_2;\n    if (data_b124c != 0)\n    {\n        rax_2 = 1;\n    }\n    else\n    {\n        rax_2 = data_b1010;\n    }"
+   },
+   {
+    "dec": "binja",
+    "opt": "O0",
+    "project": "openssh-portable",
+    "binary": "ssh-keygen",
+    "function": "cert_ext_cmp",
+    "cached_src_nodes": 15,
+    "c_path": "results/full_run/O0/openssh-portable/decompiled/binja_ssh-keygen.c",
+    "snippet": "uint64_t cert_ext_cmp(int64_t* arg1, int64_t* arg2)\n\n{\n    uint64_t rax_8;\n    if (arg1[2] == arg2[2])\n    {\n        int32_t rax_12;\n        char rdx_3;\n        rax_12 = strcmp(*(int64_t*)arg1, *(int64_t*)arg2);\n        if (rax_12 != 0)\n        {\n            rax_8 = ((uint64_t)rax_12);\n        }\n        else"
+   }
+  ],
+  "cat5_probe_results": [
+   {
+    "file": "libwc_avx2_a-wc_avx2.i",
+    "size": 1453656,
+    "funcs": 143,
+    "degen_in_file": 125,
+    "err": null
+   },
+   {
+    "file": "crontab.i",
+    "size": 179913,
+    "funcs": 72,
+    "degen_in_file": 58,
+    "err": null
+   },
+   {
+    "file": "bzip2.i",
+    "size": 211212,
+    "funcs": 68,
+    "degen_in_file": 36,
+    "err": null
+   },
+   {
+    "file": "libcksum_pclmul_a-cksum_pclmul.i",
+    "size": 1456815,
+    "funcs": 140,
+    "degen_in_file": 122,
+    "err": null
+   },
+   {
+    "file": "update-passwd.i",
+    "size": 185570,
+    "funcs": 48,
+    "degen_in_file": 11,
+    "err": null
+   },
+   {
+    "file": "bzlib.i",
+    "size": 127186,
+    "funcs": 48,
+    "degen_in_file": 14,
+    "err": null
+   },
+   {
+    "file": "y.tab.i",
+    "size": 490799,
+    "funcs": 1405,
+    "degen_in_file": 1403,
+    "err": null
+   },
+   {
+    "file": "cron.i",
+    "size": 172424,
+    "funcs": 68,
+    "degen_in_file": 59,
+    "err": null
+   },
+   {
+    "file": "util.i",
+    "size": 235187,
+    "funcs": 121,
+    "degen_in_file": 93,
+    "err": null
+   },
+   {
+    "file": "diff.i",
+    "size": 258270,
+    "funcs": 148,
+    "degen_in_file": 131,
+    "err": null
+   },
+   {
+    "file": "unpack.i",
+    "size": 258411,
+    "funcs": 406,
+    "degen_in_file": 381,
+    "err": null
+   },
+   {
+    "file": "archives.i",
+    "size": 242400,
+    "funcs": 408,
+    "degen_in_file": 378,
+    "err": null
+   },
+   {
+    "file": "subst.i",
+    "size": 559704,
+    "funcs": 1160,
+    "degen_in_file": 1019,
+    "err": null
+   },
+   {
+    "file": "unix.i",
+    "size": 390757,
+    "funcs": 987,
+    "degen_in_file": 936,
+    "err": null
+   },
+   {
+    "file": "pass1.i",
+    "size": 389963,
+    "funcs": 961,
+    "degen_in_file": 886,
+    "err": null
+   },
+   {
+    "file": "pred.i",
+    "size": 443355,
+    "funcs": 232,
+    "degen_in_file": 189,
+    "err": null
+   },
+   {
+    "file": "pcresearch.i",
+    "size": 243917,
+    "funcs": 101,
+    "degen_in_file": 92,
+    "err": null
+   },
+   {
+    "file": "parser.i",
+    "size": 514255,
+    "funcs": 310,
+    "degen_in_file": 240,
+    "err": null
+   },
+   {
+    "file": "grep.i",
+    "size": 364323,
+    "funcs": 252,
+    "degen_in_file": 172,
+    "err": null
+   },
+   {
+    "file": "cli.i",
+    "size": 502939,
+    "funcs": 1278,
+    "degen_in_file": 1231,
+    "err": null
+   },
+   {
+    "file": "certtool.i",
+    "size": 546106,
+    "funcs": 1323,
+    "degen_in_file": 1255,
+    "err": null
+   },
+   {
+    "file": "gzip.i",
+    "size": 239527,
+    "funcs": 139,
+    "degen_in_file": 112,
+    "err": null
+   },
+   {
+    "file": "libgzip_a-printf-frexpl.i",
+    "size": 168312,
+    "funcs": 1,
+    "degen_in_file": 0,
+    "err": null
+   },
+   {
+    "file": "iproute_lwtunnel.i",
+    "size": 362476,
+    "funcs": 458,
+    "degen_in_file": 401,
+    "err": null
+   },
+   {
+    "file": "depmod.i",
+    "size": 298532,
+    "funcs": 248,
+    "degen_in_file": 174,
+    "err": null
+   },
+   {
+    "file": "getfacl.i",
+    "size": 151265,
+    "funcs": 62,
+    "degen_in_file": 49,
+    "err": null
+   },
+   {
+    "file": "ipaddress.i",
+    "size": 357344,
+    "funcs": 431,
+    "degen_in_file": 377,
+    "err": null
+   },
+   {
+    "file": "modprobe.i",
+    "size": 190476,
+    "funcs": 111,
+    "degen_in_file": 93,
+    "err": null
+   },
+   {
+    "file": "setfacl.i",
+    "size": 142413,
+    "funcs": 53,
+    "degen_in_file": 47,
+    "err": null
+   },
+   {
+    "file": "getentropy.i",
+    "size": 234561,
+    "funcs": 48,
+    "degen_in_file": 42,
+    "err": null
+   },
+   {
+    "file": "arc4random.i",
+    "size": 193150,
+    "funcs": 56,
+    "degen_in_file": 46,
+    "err": null
+   },
+   {
+    "file": "xmlwf-xmlfile.i",
+    "size": 106886,
+    "funcs": 72,
+    "degen_in_file": 66,
+    "err": null
+   },
+   {
+    "file": "readline.i",
+    "size": 267565,
+    "funcs": 305,
+    "degen_in_file": 249,
+    "err": null
+   },
+   {
+    "file": "xmlwf-xmlwf.i",
+    "size": 156079,
+    "funcs": 115,
+    "degen_in_file": 94,
+    "err": null
+   },
+   {
+    "file": "terminal.i",
+    "size": 231409,
+    "funcs": 188,
+    "degen_in_file": 158,
+    "err": null
+   },
+   {
+    "file": "selinux_restorecon.i",
+    "size": 305501,
+    "funcs": 241,
+    "degen_in_file": 211,
+    "err": null
+   },
+   {
+    "file": "label_file.i",
+    "size": 260875,
+    "funcs": 232,
+    "degen_in_file": 196,
+    "err": null
+   },
+   {
+    "file": "ssh-keygen.i",
+    "size": 972910,
+    "funcs": 545,
+    "degen_in_file": 483,
+    "err": null
+   },
+   {
+    "file": "sshkey.i",
+    "size": 939066,
+    "funcs": 421,
+    "degen_in_file": 329,
+    "err": null
+   },
+   {
+    "file": "rsyslogd-rsyslogd.i",
+    "size": 376206,
+    "funcs": 598,
+    "degen_in_file": 562,
+    "err": null
+   },
+   {
+    "file": "last.i",
+    "size": 192008,
+    "funcs": 12,
+    "degen_in_file": 5,
+    "err": null
+   },
+   {
+    "file": "usermod.i",
+    "size": 297841,
+    "funcs": 241,
+    "degen_in_file": 222,
+    "err": null
+   },
+   {
+    "file": "useradd.i",
+    "size": 304886,
+    "funcs": 252,
+    "degen_in_file": 226,
+    "err": null
+   },
+   {
+    "file": "rsyslogd-omfwd.i",
+    "size": 400795,
+    "funcs": 536,
+    "degen_in_file": 500,
+    "err": null
+   },
+   {
+    "file": "init.i",
+    "size": 246728,
+    "funcs": 55,
+    "degen_in_file": 11,
+    "err": null
+   },
+   {
+    "file": "tar.i",
+    "size": 355659,
+    "funcs": 491,
+    "degen_in_file": 441,
+    "err": null
+   },
+   {
+    "file": "extract.i",
+    "size": 319154,
+    "funcs": 427,
+    "degen_in_file": 382,
+    "err": null
+   },
+   {
+    "file": "crc32.i",
+    "size": 165809,
+    "funcs": 95,
+    "degen_in_file": 90,
+    "err": null
+   },
+   {
+    "file": "deflate.i",
+    "size": 131355,
+    "funcs": 109,
+    "degen_in_file": 83,
+    "err": null
+   }
+  ]
+ }
+}

--- a/scripts/rebuild_function_data.py
+++ b/scripts/rebuild_function_data.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import json
 import re
-import statistics
 import sys
 from pathlib import Path
 
 from decbench.models.function_data import FunctionData, HardestEntry, SampleEntry
-from decbench.models.scoreboard import DecompilerScore, MetricScore, Scoreboard
+from decbench.models.scoreboard import Scoreboard
 from decbench.scoring.datasets import assign_datasets
+from decbench.scoring.scoreboard import build_scoreboard_from_function_data
 from decbench.utils.results_tree import resolve_binary
 from decbench.utils.source_extract import function_source
 
@@ -96,10 +96,13 @@ def update_byte_match(
                         # No fresh value (artifact gone): drop any stale value.
                         mv.pop("byte_match", None)
                         f.perfects.get(dec, {}).pop("byte_match", None)
+                        f.distances.get(dec, {}).pop("byte_match", None)
                     continue
                 val = float(rec["value"])
                 mv["byte_match"] = val
                 f.perfects.setdefault(dec, {})["byte_match"] = val >= PERFECT["byte_match"]
+                if rec.get("dist") is not None:
+                    f.distances.setdefault(dec, {})["byte_match"] = float(rec["dist"])
                 t = tally.setdefault(dec, {"comp": 0, "tot": 0})
                 t["tot"] += 1
                 if rec.get("compilable"):
@@ -189,80 +192,40 @@ def build_hardest(fd: FunctionData, reader: DiskReader) -> list[HardestEntry]:
 
 
 def recompute_scoreboard(fd: FunctionData, old: Scoreboard) -> Scoreboard:
-    """Recompute per-metric + overall aggregates from the updated dataset."""
-    decs, metrics = fd.decompilers, fd.metrics
-    vals: dict[str, dict[str, list[float]]] = {d: {m: [] for m in metrics} for d in decs}
-    perf: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
-    tot: dict[str, dict[str, int]] = {d: {m: 0 for m in metrics} for d in decs}
-    overall_perf = {d: 0 for d in decs}
-    overall_tot = {d: 0 for d in decs}
+    """Recompute per-metric + overall aggregates from the updated dataset.
 
-    for g in fd.groups:
-        for f in g.functions:
-            for d in decs:
-                fp = f.perfects.get(d)
-                fv = f.values.get(d)
-                if not fp or not fv:
-                    continue
-                for m in metrics:
-                    if m in fv:
-                        tot[d][m] += 1
-                        vals[d][m].append(fv[m])
-                        if fp.get(m):
-                            perf[d][m] += 1
-                # Overall, matching scoring/scoreboard.py + the report JS: count
-                # ONLY functions evaluated on every metric; a function missing a
-                # metric (byte_match abstained for ARM/PE) is EXCLUDED, not failed.
-                if all(m in fp for m in metrics):
-                    overall_tot[d] += 1
-                    if all(fp[m] for m in metrics):
-                        overall_perf[d] += 1
-
-    sb = Scoreboard(
+    Delegates to the shared :func:`build_scoreboard_from_function_data` so the
+    persisted ``scoreboard.toml`` uses the SAME shared per-metric universe
+    denominators as the HTML report (identical across decompilers; a
+    decompile/metric failure is a not-perfect miss, not an exclusion).
+    """
+    return build_scoreboard_from_function_data(
+        fd,
         name=old.name or "DecBench Scoreboard",
         description=old.description,
         version=old.version,
-        projects_evaluated=sorted({g.project for g in fd.groups}),
-        optimization_levels=sorted({g.opt_level for g in fd.groups}),
-        decompilers=decs,
-        metrics=metrics,
-        total_functions=sum(len(g.functions) for g in fd.groups),
-        total_binaries=len(fd.groups),
     )
-    for d in decs:
-        ds = DecompilerScore(name=d)
-        for m in metrics:
-            n = tot[d][m]
-            ds.metric_scores[m] = MetricScore(
-                metric_name=m,
-                decompiler_name=d,
-                perfect_count=perf[d][m],
-                total_count=n,
-                perfect_percentage=(100 * perf[d][m] / n) if n else 0.0,
-                mean=statistics.fmean(vals[d][m]) if vals[d][m] else 0.0,
-                median=statistics.median(vals[d][m]) if vals[d][m] else 0.0,
-            )
-        ds.overall_perfect_count = overall_perf[d]
-        ds.overall_total_count = overall_tot[d]
-        ds.overall_perfect_percentage = (
-            100 * overall_perf[d] / overall_tot[d] if overall_tot[d] else 0.0
-        )
-        sb.decompiler_scores[d] = ds
-    for m in metrics:
-        for rank, (d, _) in enumerate(sb.get_metric_rankings(m), 1):
-            sb.decompiler_scores[d].metric_scores[m].rank = rank
-    for rank, (d, _) in enumerate(sb.get_overall_rankings(), 1):
-        sb.decompiler_scores[d].overall_rank = rank
-    return sb
 
 
 def update_ged(fd: FunctionData, new: dict[str, dict]) -> int:
-    """Merge freshly recomputed GED (from header-stripped source CFGs) in.
+    """Replace the whole GED column with the freshly recomputed values.
 
-    For every (function, decompiler) with a fresh GED value, SET ged + its perfect
-    flag. Existing GED with no fresh value is kept (the reeval is a superset, so
-    this is rare). Returns the number of (function, decompiler) entries set.
+    The reeval (``scripts/reeval_ged.py``) now DROPS unmeasurable functions
+    (empty-prototype/degenerate source) and pairs each binary against its own
+    translation unit, so its output is the authoritative, collision-free GED set.
+    We first CLEAR every existing ged value/perfect (purging stale ``inf`` entries
+    and wrong-source scores from the prior run) and then apply the new ones — a
+    function with no fresh GED ends up with NO ged key, i.e. excluded from GED's
+    denominator. Returns the number of (function, decompiler) entries set.
     """
+    for g in fd.groups:
+        for f in g.functions:
+            for mv in f.values.values():
+                mv.pop("ged", None)
+            for mp in f.perfects.values():
+                mp.pop("ged", None)
+            for md in f.distances.values():
+                md.pop("ged", None)
     n = 0
     for g in fd.groups:
         for f in g.functions:
@@ -274,6 +237,8 @@ def update_ged(fd: FunctionData, new: dict[str, dict]) -> int:
                 val = float(rec["value"])
                 f.values.setdefault(dec, {})["ged"] = val
                 f.perfects.setdefault(dec, {})["ged"] = bool(rec.get("perfect", val == 0.0))
+                # GED distance IS the graph edit distance (the value itself).
+                f.distances.setdefault(dec, {})["ged"] = val
                 n += 1
     return n
 
@@ -295,12 +260,21 @@ def update_type_match(fd: FunctionData, new: dict[str, dict[str, float]]) -> int
                 per = new.get(dec)
                 if not per:
                     continue
-                val = per.get(f"{g.project}::{g.opt_level}::{g.binary}::{f.function}")
-                if val is None:
+                rec = per.get(f"{g.project}::{g.opt_level}::{g.binary}::{f.function}")
+                if rec is None:
                     continue
-                val = float(val)
+                # Back-compat: older type_match_new.json stored a bare float; the
+                # new form is {"value": accuracy, "dist": type-flips (fp+fn)}.
+                if isinstance(rec, dict):
+                    val = float(rec["value"])
+                    dist = rec.get("dist")
+                else:
+                    val = float(rec)
+                    dist = None
                 f.values.setdefault(dec, {})["type_match"] = val
                 f.perfects.setdefault(dec, {})["type_match"] = val >= PERFECT["type_match"]
+                if dist is not None:
+                    f.distances.setdefault(dec, {})["type_match"] = float(dist)
                 n += 1
     return n
 

--- a/scripts/reeval_bytematch.py
+++ b/scripts/reeval_bytematch.py
@@ -52,7 +52,11 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
             out[name] = {"value": 0.0, "compilable": False, "error": str(e)[:120]}
             continue
         md = mv.metadata or {}
-        out[name] = {"value": float(mv.value), "compilable": bool(md.get("compilable", False))}
+        out[name] = {
+            "value": float(mv.value),
+            "compilable": bool(md.get("compilable", False)),
+            "dist": md.get("changed_lines"),  # changed asm lines (distance view)
+        }
     key = f"{opt}::{project}::{stem}::{dec}"
     return key, out
 

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -75,32 +75,59 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
         f"{len(todo)} projects, {workers} workers",
         flush=True,
     )
+    # proj -> {translation-unit stem -> {function name -> CFG}}. Keeping source
+    # CFGs PER-TU (not a project-wide name-keyed union) lets stage B pair each
+    # binary against its OWN translation unit, so per-program functions
+    # (main/usage/static helpers) are scored against the right body instead of an
+    # arbitrary same-named function from another binary (the collision bug).
     acc: dict[str, dict] = {proj: {} for proj in todo}
     ctx = mp.get_context("spawn")
     done = 0
     with ctx.Pool(processes=workers) as pool:
         for ipath, cfgs in pool.imap_unordered(src_cfgs_for_i, all_paths):
-            acc[owner[ipath]].update(cfgs)
+            acc[owner[ipath]][Path(ipath).stem] = cfgs
             done += 1
             if done % 50 == 0 or done == len(all_paths):
                 print(f"[ged/src] {done}/{len(all_paths)} source files", flush=True)
-    for proj, cfgs in acc.items():
-        (src_dir / f"{proj}.pkl").write_bytes(pickle.dumps(cfgs))
-        print(f"[ged/src] {proj}: {len(cfgs)} source functions cached", flush=True)
+    for proj, per_stem in acc.items():
+        (src_dir / f"{proj}.pkl").write_bytes(pickle.dumps(per_stem))
+        nfun = sum(len(c) for c in per_stem.values())
+        print(f"[ged/src] {proj}: {len(per_stem)} TUs, {nfun} source functions cached", flush=True)
     return src_dir
 
 
 # ---- Stage B: GED per (opt, project, binary, dec) -------------------------
+# Per-worker cache: src_pkl path -> (per_stem_dict, best_source_by_name). A pool
+# worker handles many (binary, dec) tasks for the same project, so the cross-TU
+# best-by-name fallback is computed once per project pickle, not per task.
+_SRC_CACHE: dict[str, tuple[dict, dict]] = {}
+
+
+def _load_src(src_pkl: str) -> tuple[dict, dict]:
+    if src_pkl not in _SRC_CACHE:
+        from decbench.utils.cfg import best_source_by_name
+
+        per_stem = pickle.loads(Path(src_pkl).read_bytes())
+        _SRC_CACHE[src_pkl] = (per_stem, best_source_by_name(per_stem))
+    return _SRC_CACHE[src_pkl]
+
+
 def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
     """Worker: recompute GED for every function of one (binary, dec).
 
     ``task`` = (opt, project, stem, dec, decompiled_c_path, src_pkl_path).
+    Resolves each function's source CFG TU-aware (own TU first, cross-TU fallback)
+    and DROPS non-finite (empty-prototype/degenerate source) results so they are
+    excluded from GED's denominator instead of counting as failures.
     """
+    import math
+
     opt, project, stem, dec, c_path, src_pkl = task
     from decbench.metrics.ged import GEDMetric
-    from decbench.utils.cfg import extract_cfgs_from_source
+    from decbench.utils.cfg import extract_cfgs_from_source, resolved_source_for_binary
 
-    src_cfgs = pickle.loads(Path(src_pkl).read_bytes())
+    per_stem, best_by_name = _load_src(src_pkl)
+    src_cfgs = resolved_source_for_binary(stem, per_stem, best_by_name)
     try:
         dec_cfgs = extract_cfgs_from_source(Path(c_path)) or {}
     except Exception:  # noqa: BLE001
@@ -115,6 +142,8 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
         try:
             mv = metric.compute_for_function(None, source_cfg=scfg, decompiled_cfg=dcfg)
         except Exception:  # noqa: BLE001
+            continue
+        if not math.isfinite(mv.value):
             continue
         out[fn] = {"value": float(mv.value), "perfect": bool(mv.value == perfect_val)}
     key = f"{opt}::{project}::{stem}::{dec}"

--- a/scripts/reeval_typematch.py
+++ b/scripts/reeval_typematch.py
@@ -72,7 +72,12 @@ for proj in projects:
                     elif n < o - 1e-9:
                         a["wor"] += 1
                     if emit:
-                        new_scores.setdefault(dname, {})[f"{proj}::{optn}::{binn}::{fn}"] = n
+                        md = mv.metadata or {}
+                        dist = int(md.get("fp", 0)) + int(md.get("fn", 0))
+                        new_scores.setdefault(dname, {})[f"{proj}::{optn}::{binn}::{fn}"] = {
+                            "value": n,
+                            "dist": dist,
+                        }
 
 print(f"\n{'dec':9} {'n':>7} {'OLD mean':>9} {'NEW mean':>9} {'improved':>9} {'worse':>7}")
 for d in sorted(agg):

--- a/scripts/rerun_binja.sh
+++ b/scripts/rerun_binja.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Re-decompile ONLY Binary Ninja across an existing results tree with the
+# Loading-race fix (decbench/decompilers/raw/binja_raw.py), then re-score binja's
+# GED + type_match and re-render — WITHOUT disturbing the other decompilers' data.
+#
+# Why a wrapper: run_benchmark.py always rewrites function_results.json at the end
+# (from its in-process evals), which would clobber the carefully re-eval'd GED/type
+# data. So we snapshot function_results.json/scoreboard.toml, let run_benchmark
+# re-decompile binja (DECOMPILE_ONLY skips its Joern eval and updates the
+# checkpoints + decompiled/binja_*.c), restore our snapshot, then re-run the
+# targeted reeval + rebuild.
+#
+# This is a MULTI-HOUR job (binja headless analyzes ~800 binaries with
+# update_analysis_and_wait). Runs detached-safe; each stage is resumable.
+#
+# Usage:  bash scripts/rerun_binja.sh results/full_run
+set -uo pipefail
+ROOT=${1:-results/full_run}
+cd "$(dirname "$0")/.."
+export PYTHONWARNINGS=ignore
+export GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1
+VENV=/home/mahaloz/.virtualenvs/decbench/bin/python
+BIN=/home/mahaloz/.virtualenvs/decbench/bin/decbench
+
+echo "[binja] snapshotting good metric data..."
+cp -f "$ROOT/function_results.json" "$ROOT/function_results.beforebinja.json"
+cp -f "$ROOT/scoreboard.toml"        "$ROOT/scoreboard.beforebinja.toml"
+
+echo "[binja] (1/5) re-decompiling binja only (DECOMPILE_ONLY; updates checkpoints + decompiled/)..."
+# Modest workers: binja headless is heavy; keep it small to avoid contention.
+DECBENCH_DECOMPILERS="angr,phoenix,ghidra,ida,binja,kuna" \
+  DECBENCH_REDO_DECOMPILERS="binja" \
+  DECBENCH_DECOMPILE_ONLY="1" \
+  DECBENCH_WORKERS="8" \
+  $VENV scripts/run_benchmark.py "$ROOT"
+
+echo "[binja] restoring the good metric data (run_benchmark clobbers it)..."
+mv -f "$ROOT/function_results.beforebinja.json" "$ROOT/function_results.json"
+mv -f "$ROOT/scoreboard.beforebinja.toml"        "$ROOT/scoreboard.toml"
+
+echo "[binja] (2/5) re-scoring GED for the fresh binja .c (drop binja ckpts so only binja re-runs)..."
+rm -f "$ROOT"/reeval_ged/*__binja.json
+$VENV scripts/reeval_ged.py "$ROOT" 12
+
+echo "[binja] (3/5) re-scoring type_match from the updated checkpoints..."
+$VENV scripts/reeval_typematch.py "$ROOT" --emit
+
+echo "[binja] (4/5) merging GED + type_match..."
+$VENV scripts/rebuild_function_data.py "$ROOT" --ged
+$VENV scripts/rebuild_function_data.py "$ROOT" --type-match
+# byte_match: reuse the restored values (unchanged); recompute the scoreboard only.
+$VENV - "$ROOT" <<'PY'
+import sys, json
+from pathlib import Path
+from decbench.models.function_data import FunctionData
+from decbench.models.scoreboard import Scoreboard
+from decbench.scoring.scoreboard import build_scoreboard_from_function_data
+root = Path(sys.argv[1])
+fd = FunctionData.from_json(root / "function_results.json")
+old = Scoreboard.from_toml(root / "scoreboard.toml")
+build_scoreboard_from_function_data(fd, name=old.name, description=old.description,
+                                    version=old.version).to_toml(root / "scoreboard.toml")
+print("[binja] scoreboard recomputed")
+PY
+
+echo "[binja] (5/5) rendering report..."
+$BIN report "$ROOT/scoreboard.toml" -o "$ROOT/report.html"
+echo "[binja] DONE — binja GED should jump from ~4.7% toward the ~20-40% band."

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -298,10 +298,22 @@ int main() {
         )
         # Register-resident args at -O2: names differ, no stack offsets.
         gt_vars = [
-            {"name": "count", "type": ["int"], "rbp_offset": [], "size": 4,
-             "is_arg": True, "arg_index": 0},
-            {"name": "buf", "type": ["char*"], "rbp_offset": [], "size": 8,
-             "is_arg": True, "arg_index": 1},
+            {
+                "name": "count",
+                "type": ["int"],
+                "rbp_offset": [],
+                "size": 4,
+                "is_arg": True,
+                "arg_index": 0,
+            },
+            {
+                "name": "buf",
+                "type": ["char*"],
+                "rbp_offset": [],
+                "size": 8,
+                "is_arg": True,
+                "arg_index": 1,
+            },
         ]
 
         metric = TypeMatchMetric()
@@ -323,8 +335,14 @@ int main() {
             ],
         )
         gt_vars = [
-            {"name": "n", "type": ["long long"], "rbp_offset": [], "size": 8,
-             "is_arg": True, "arg_index": 0},
+            {
+                "name": "n",
+                "type": ["long long"],
+                "rbp_offset": [],
+                "size": 8,
+                "is_arg": True,
+                "arg_index": 0,
+            },
         ]
 
         metric = TypeMatchMetric()
@@ -417,9 +435,9 @@ int main() {
 
         gt_forms = normalize_type("short int")
         for decompiler_spelling in ("short", "__int16", "_WORD", "ushort"):
-            assert gt_forms & normalize_type(decompiler_spelling), (
-                f"'short int' does not match {decompiler_spelling!r}"
-            )
+            assert gt_forms & normalize_type(
+                decompiler_spelling
+            ), f"'short int' does not match {decompiler_spelling!r}"
 
     def test_binary_calibration_ignores_single_slot_coincidences(self) -> None:
         """All-single-var functions must not elect a spurious nonzero shift."""
@@ -600,20 +618,23 @@ class TestByteMatchMetric:
     def test_jaccard_similarity(self) -> None:
         from decbench.metrics.byte_match import _compute_jaccard_similarity
 
-        # Identical
+        # Returns (similarity, changed_lines). Identical -> perfect, 0 changes.
         lines = ["mov rax, rbx", "add rax, 1", "ret"]
-        sim = _compute_jaccard_similarity(lines, lines)
+        sim, changed = _compute_jaccard_similarity(lines, lines)
         assert sim == 1.0
+        assert changed == 0
 
-        # Completely different
+        # Completely different -> 0 similarity, every line changed on both sides.
         lines_a = ["mov rax, rbx", "ret"]
         lines_b = ["push rbp", "pop rbp"]
-        sim = _compute_jaccard_similarity(lines_a, lines_b)
+        sim, changed = _compute_jaccard_similarity(lines_a, lines_b)
         assert sim == 0.0
+        assert changed == len(lines_a) + len(lines_b)
 
         # Empty
-        sim = _compute_jaccard_similarity([], [])
+        sim, changed = _compute_jaccard_similarity([], [])
         assert sim == 1.0
+        assert changed == 0
 
 
 class TestMetricConfig:


### PR DESCRIPTION
…ators, type_match, binja

The O0 ("easiest") scores looked broken (no decompiler >~15% on any metric). A forensic audit found the causes were mostly bugs/mis-framing, not decompiler quality. Fixes:

GED (dominant): source CFGs were cached project-wide keyed by function NAME, last-writer-wins across translation units, so every binary's main/usage/static helper was scored against an arbitrary same-named function and prototype stubs clobbered real bodies (~53% of evals were inf, counted as failures). Now cache source CFGs per-TU and match TU-aware (own TU first, then non-degenerate/largest across TUs); exclude only empty-prototype (all-Nop) single-block sources so genuine straight-line functions are scored; drop non-finite GED at the recording layer so it leaves the denominator instead of counting as a miss. O0 GED perfect jumps e.g. ida ~13%->39%, most others ~6-10%->22-24%; coverage 24k->53k evals. vj_ged + the Joern bundle were fine (refuted).

Denominators: every (decompiler, metric) now shares ONE per-metric universe denominator (a decompile/metric failure is a not-perfect miss in-denominator; only unmeasurable-for-everyone is excluded uniformly). New single source of truth build_scoreboard_from_function_data used by both the executor and rebuild_function_data; html.py recompute() matches. Denominators are now identical across all decompilers per metric.

type_match: uncommitted width types (undefinedN/__intN/_QWORD/intN) match a same-width ground-truth scalar, and local_/var_<hex> name-encoded stack offsets are recovered; struct*->void* and scalar<->pointer stay misses. IDA mean 0.170->0.221.

byte_match: scoring unchanged; only capture a changed_lines edit-distance for the new report view.

binja: 73% of bodies were the literal 'Loading...' placeholder (analysis race). _load now update_analysis_and_wait() and _render_c guards the placeholder. Validated (touch: 189 real bodies, 0 Loading). Full re-decompile via scripts/rerun_binja.sh.

Report: new 'distance' view (per-metric raw edit distance) + FunctionRecord .distances. docs/JOERN_FAILURES.md catalogs the remaining source-parse failures for a follow-up pass.


Claude-Session: https://claude.ai/code/session_017XLm5UXRhY94GQYmuQKVkS