### PR TITLE
feat(site): let text span the full screen width on every page

### DIFF
--- a/decbench/rendering/assets/app.css
+++ b/decbench/rendering/assets/app.css
@@ -105,7 +105,6 @@ a { color: var(--text); text-decoration: none; }
 .main {
     flex: 1;
     min-width: 0;
-    max-width: 1100px;
     padding: 1.8rem 2rem 3rem;
 }
 .view { display: none; }
@@ -117,7 +116,7 @@ a { color: var(--text); text-decoration: none; }
 }
 h2.view-title { font-size: 1.3rem; font-weight: 700; margin-bottom: 0.2rem; }
 h2.view-title:before { content: "## "; color: var(--text-muted); }
-.view-desc { color: var(--text-muted); font-size: 0.88em; margin-bottom: 1.1rem; max-width: 70ch; }
+.view-desc { color: var(--text-muted); font-size: 0.88em; margin-bottom: 1.1rem; }
 h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
 h3.sub:before { content: "> "; color: var(--text-muted); }
 
@@ -172,7 +171,7 @@ button:hover, select:hover { color: #000; background: var(--text); }
 .goal-head { font-weight: 700; font-size: 1.02em; margin-bottom: 0.2rem; }
 .goal-head .num { color: var(--green); margin-right: 0.4rem; }
 .goal-metric { color: var(--amber); font-size: 0.82em; margin-bottom: 0.5rem; }
-.goal-body { color: var(--text); font-size: 0.88em; max-width: 75ch; }
+.goal-body { color: var(--text); font-size: 0.88em; }
 .goal-body .perfect { color: var(--text-muted); }
 .formula { color: var(--text-muted); font-size: 0.82em; margin-top: 0.5rem; }
 .recovered {


### PR DESCRIPTION
Removes the three width caps in `app.css` — `.main` (1100px), `.view-desc` (70ch), `.goal-body` (75ch) — so page text keeps expanding with the viewport on every view instead of cutting off around 80 characters (e.g. the leaderboard's "ranked by Union — the share of functions a decompiler recovers…" line).

Tested: `pytest tests/test_site.py tests/test_content.py` (39 passed). Site tree will be re-rendered and committed at the end of tonight's push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbvB8urA4uqipuwH2Mcv4Q