### PR TITLE
feat(datasets): redo the dataset presets (unoptimized default, optimized/inlined/large/sample-set)

### DIFF
--- a/decbench/cli.py
+++ b/decbench/cli.py
@@ -339,8 +339,9 @@ def report(scoreboard_path, output, function_data) -> None:
     else:
         console.print("[yellow]No function data found; generating static report.[/yellow]")
 
-    # Ensure the dataset presets (full/hard/hard-inlined/tiny) are tagged so the
-    # report's dataset selector works even when re-rendering older data.
+    # Ensure the dataset presets (unoptimized/optimized/inlined/large/sample-set)
+    # are tagged so the report's dataset selector works even when re-rendering
+    # older data.
     if fd is not None and not fd.dataset_presets:
         try:
             from decbench.scoring.datasets import assign_datasets
@@ -717,7 +718,8 @@ def improvements(
 def download(config, dest, repo_path, include, revision) -> None:
     """Download a published DecBench dataset config (alias for `decbench-data`).
 
-    CONFIG is one of the published configs: full / hard / hard-inlined / tiny.
+    CONFIG is one of the published configs, e.g. sample-set / large /
+    unoptimized / optimized / inlined / full.
     This is a thin alias that delegates to the standalone `decbench_data`
     package (shipped from the HuggingFace dataset repo), so no heavy DecBench
     imports are pulled in.

--- a/decbench/models/function_data.py
+++ b/decbench/models/function_data.py
@@ -53,8 +53,8 @@ class FunctionRecord(BaseModel):
     datasets: list[str] = Field(
         default_factory=list,
         description="Names of the dataset presets this function belongs to "
-        "(e.g. 'full', 'hard', 'hard-inlined', 'tiny'); drives the report's "
-        "single dataset selector instead of many ad-hoc toggles",
+        "(e.g. 'unoptimized', 'optimized', 'inlined', 'large', 'sample-set'); "
+        "drives the report's single dataset selector instead of many ad-hoc toggles",
     )
 
 
@@ -114,9 +114,10 @@ class DatasetPreset(BaseModel):
     """A named, selectable view of the dataset shown in the report.
 
     Replaces the report's many label/binary toggles with a small fixed set of
-    curated views (full / hard / hard-inlined / tiny). Membership per function
-    is precomputed server-side (see :mod:`decbench.scoring.datasets`) and stored
-    on :attr:`FunctionRecord.datasets`.
+    curated views (unoptimized / optimized / inlined / large / sample-set).
+    Membership per function is precomputed server-side (see
+    :mod:`decbench.scoring.datasets`) and stored on
+    :attr:`FunctionRecord.datasets`.
 
     Only :attr:`name` is meaningful for new data: the presentation is owned by
     ``decbench/rendering/content/datasets.toml`` and joined on at render time.
@@ -195,7 +196,8 @@ class FunctionData(BaseModel):
     )
     dataset_presets: list[DatasetPreset] = Field(
         default_factory=list,
-        description="The selectable dataset views (full/hard/hard-inlined/tiny)",
+        description="The selectable dataset views "
+        "(unoptimized/optimized/inlined/large/sample-set)",
     )
     hardest: list[HardestEntry] = Field(
         default_factory=list,

--- a/decbench/publish/layout.py
+++ b/decbench/publish/layout.py
@@ -45,7 +45,9 @@ logger = logging.getLogger(__name__)
 # Normative constants from the publishing contract.
 DATASET_NAME = "decbench-dataset"
 DATASET_REPO_ID = "noelo-lab/decbench-dataset"
-DEFAULT_CONFIGS = ["tiny", "hard", "hard-inlined", "unoptimized", "full"]
+# `full` is a publisher-only config (the master everything slice); it is no
+# longer a scoring preset, so select_groups/copy_artifacts special-case it.
+DEFAULT_CONFIGS = ["sample-set", "large", "unoptimized", "optimized", "inlined", "full"]
 _FULL = "full"
 
 Logger = Callable[[str], None]
@@ -176,14 +178,17 @@ def select_groups(
 ) -> list[BinaryGroup]:
     """Groups to process: those with >=1 function tagged by a requested config.
 
-    ``full`` tags every record, so requesting it selects every group. The first
-    ``max_binaries`` (in dataset order) are kept for fast, targeted self-tests.
+    ``full`` is the publisher's everything-config (not a scoring preset), so
+    requesting it selects every group. The first ``max_binaries`` (in dataset
+    order) are kept for fast, targeted self-tests.
     """
     wanted = set(configs)
-    selected: list[BinaryGroup] = []
-    for group in fd.groups:
-        if any(wanted.intersection(f.datasets) for f in group.functions):
-            selected.append(group)
+    if _FULL in wanted:
+        selected = list(fd.groups)
+    else:
+        selected = [
+            g for g in fd.groups if any(wanted.intersection(f.datasets) for f in g.functions)
+        ]
     if max_binaries is not None:
         selected = selected[:max_binaries]
     return selected
@@ -303,7 +308,12 @@ def copy_artifacts(
 
         all_fns = [f.function for f in group.functions]
         config_fns = {
-            cfg: [f.function for f in group.functions if cfg in f.datasets] for cfg in configs
+            cfg: (
+                list(all_fns)
+                if cfg == _FULL
+                else [f.function for f in group.functions if cfg in f.datasets]
+            )
+            for cfg in configs
         }
         result.groups.append(
             GroupRecord(

--- a/decbench/rendering/content/datasets.toml
+++ b/decbench/rendering/content/datasets.toml
@@ -13,27 +13,27 @@
 # Button order is the order of the tables below.
 
 [[preset]]
-name = "full"
-label = "full"
-description = "everything — O0 + O2 + O2-noinline (per-opt double-count ok)"
+name = "unoptimized"
+label = "unoptimized"
+description = "unoptimized builds (O0) — surfaces simple structural differences"
 default = true
 
 [[preset]]
-name = "hard"
-label = "hard"
-description = "optimized, no inlining (O2-noinline), large functions only"
+name = "optimized"
+label = "optimized"
+description = "optimized without inlining (O2-noinline)"
 
 [[preset]]
-name = "hard-inlined"
-label = "hard-inlined"
-description = "optimized WITH inlining (O2), large functions only"
+name = "inlined"
+label = "inlined"
+description = "optimized WITH inlining (plain O2)"
 
 [[preset]]
-name = "unoptimized"
-label = "unoptimized"
-description = "unoptimized only (O0) — surfaces simple structural differences"
+name = "large"
+label = "large"
+description = "large functions only (upper size tail), optimized without inlining"
 
 [[preset]]
-name = "tiny"
-label = "tiny"
-description = "~100 functions evenly sampled across inlined/optimized/unoptimized/large and projects"
+name = "sample-set"
+label = "sample-set"
+description = "~250 functions evenly sampled across unoptimized/optimized/inlined/large/ARM-unoptimized and projects"

--- a/decbench/rendering/html.py
+++ b/decbench/rendering/html.py
@@ -339,7 +339,7 @@ def _side_stats(scoreboard: Scoreboard, content: Content) -> str:
 
 
 def _dataset_selector(function_data: FunctionData, content: Content) -> str:
-    """The sidebar dataset selector (full / hard / hard-inlined / ... / tiny).
+    """The sidebar dataset selector (unoptimized / optimized / ... / sample-set).
 
     Preset *names* come from the run; their labels, descriptions and which one is
     preselected come from ``content/datasets.toml`` (see

--- a/decbench/scoring/datasets.py
+++ b/decbench/scoring/datasets.py
@@ -1,22 +1,26 @@
 """Curated dataset *presets* for the report's single dataset selector.
 
-Rather than exposing dozens of label/binary toggles, the report offers four
+Rather than exposing dozens of label/binary toggles, the report offers five
 fixed, meaningful views. This module tags every :class:`FunctionRecord` with the
 presets it belongs to (``FunctionRecord.datasets``) and records the preset
 metadata on the :class:`FunctionData`:
 
-* **full** — everything (O0 + O2 + O2-noinline). The same source function at
-  multiple opt levels counts multiple times; that double-counting is intended.
-* **hard** — optimized, **no inlining** (O2-noinline), **large** functions only.
-* **hard-inlined** — like *hard* but **with** inlining (plain O2), large only.
 * **unoptimized** — O0 functions only, to surface simple structural differences
-  without optimization noise.
-* **tiny** — ~100 functions total, evenly sampled from four categories
-  (inlined=O2, optimized=O2-noinline, unoptimized=O0, large), spread evenly
-  across projects, and — while there are enough distinct binaries — taking **at
-  most one function per binary**, so it is a fast, representative slice. The
-  sample is a **seeded random** selection — stable across runs for a given seed,
-  but changeable via ``DECBENCH_TINY_SEED`` (or ``assign_datasets(seed=...)``).
+  without optimization noise. The selector's default view.
+* **optimized** — optimized **without** inlining (O2-noinline). Inlining is an
+  outlier optimization that destroys function boundaries, so the plain
+  "optimized" view keeps it off.
+* **inlined** — optimized **with** inlining (plain O2).
+* **large** — optimized (no inlining, O2-noinline), **large** functions only.
+  This is the upper tail of the size bell curve — the genuinely hard cases.
+  (Previously named ``hard``; membership is unchanged.)
+* **sample-set** — ~250 functions total, evenly sampled from five categories
+  (unoptimized=O0, optimized=O2-noinline, inlined=O2, large, and
+  ARM-unoptimized=O0 on a non-x86 target), spread evenly across projects,
+  and — while there are enough distinct binaries — taking **at most one
+  function per binary**, so it is a fast, representative slice. The sample is a
+  **seeded random** selection — stable across runs for a given seed, but
+  changeable via ``DECBENCH_SAMPLE_SEED`` (or ``assign_datasets(seed=...)``).
 
 "Large" is the upper tail of the function-size bell curve (``mean + k·std`` over
 decompiled line counts), matching :mod:`decbench.scoring.subset`. The majority
@@ -44,41 +48,59 @@ from decbench.models.function_data import DatasetPreset
 if TYPE_CHECKING:
     from decbench.models.function_data import BinaryGroup, FunctionData, FunctionRecord
 
-__all__ = ["assign_datasets", "large_threshold", "PRESETS", "DEFAULT_TINY_SEED"]
+__all__ = ["assign_datasets", "large_threshold", "PRESETS", "DEFAULT_SAMPLE_SEED"]
 
-# Fixed default seed for the `tiny` sample so the selection is reproducible
-# across runs/machines. Override per call (``assign_datasets(seed=...)``) or via
-# the ``DECBENCH_TINY_SEED`` environment variable to roll a different sample.
-DEFAULT_TINY_SEED = 1337
+# Fixed default seed for the `sample-set` sample so the selection is
+# reproducible across runs/machines. Override per call
+# (``assign_datasets(seed=...)``) or via the ``DECBENCH_SAMPLE_SEED``
+# environment variable to roll a different sample.
+DEFAULT_SAMPLE_SEED = 1337
 
 
 def _resolve_seed(seed: int | None) -> int:
-    """Resolve the tiny-sample seed: explicit arg > env var > default."""
+    """Resolve the sample-set seed: explicit arg > env var > default.
+
+    ``DECBENCH_TINY_SEED`` (the preset's pre-rename spelling) is still honoured
+    so existing run scripts keep reproducing the same slice.
+    """
     if seed is not None:
         return seed
-    env = os.environ.get("DECBENCH_TINY_SEED")
-    if env:
-        try:
-            return int(env)
-        except ValueError:
-            pass
-    return DEFAULT_TINY_SEED
+    for var in ("DECBENCH_SAMPLE_SEED", "DECBENCH_TINY_SEED"):
+        env = os.environ.get(var)
+        if env:
+            try:
+                return int(env)
+            except ValueError:
+                pass
+    return DEFAULT_SAMPLE_SEED
 
 
 #: The presets this module knows how to assign, in selector order. Names only:
 #: each one's label and description are the renderer's business (see the module
 #: docstring), and duplicating them here is how they drift.
 PRESETS: list[DatasetPreset] = [
-    DatasetPreset(name="full"),
-    DatasetPreset(name="hard"),
-    DatasetPreset(name="hard-inlined"),
     DatasetPreset(name="unoptimized"),
-    DatasetPreset(name="tiny"),
+    DatasetPreset(name="optimized"),
+    DatasetPreset(name="inlined"),
+    DatasetPreset(name="large"),
+    DatasetPreset(name="sample-set"),
 ]
 
 _O2 = "O2"
 _O2_NOINLINE = "O2-noinline"
 _O0 = "O0"
+
+#: Binary labels that mark a group as built for a non-x86 (ARM) target. The CPS
+#: firmware projects all carry ``cps`` plus arch labels like ``armv7`` or
+#: ``cortex-m4``; the sailr packages and the malware targets are x86 (ELF or
+#: PE), so none of these labels appear there.
+_ARM_LABELS = frozenset({"cps", "arm", "armv7", "aarch64", "arm64", "bare-metal", "embedded-linux"})
+
+
+def _is_arm(group: BinaryGroup) -> bool:
+    """Whether a binary group was cross-compiled for a non-x86 (ARM) target."""
+    labels = group.labels or []
+    return any(label in _ARM_LABELS or label.startswith("cortex-") for label in labels)
 
 
 def large_threshold(function_data: FunctionData, k: float = 1.0) -> float | None:
@@ -121,8 +143,8 @@ def _sample_even(
     The member order within each project and the project visitation order are
     shuffled with ``rng`` (random but fully reproducible for a given seed).
     ``chosen_fns`` (``id(record)``) and ``used_bins`` (:func:`_binkey`) are
-    shared across the four category buckets and **mutated** here, so the rules
-    hold across the whole ``tiny`` sample, not just within one bucket.
+    shared across the five category buckets and **mutated** here, so the rules
+    hold across the whole ``sample-set`` sample, not just within one bucket.
     """
     by_project: OrderedDict[str, list[tuple[BinaryGroup, FunctionRecord]]] = OrderedDict()
     ordered = sorted(
@@ -171,16 +193,16 @@ def _sample_even(
 
 def assign_datasets(
     function_data: FunctionData,
-    tiny_total: int = 100,
+    sample_total: int = 250,
     k: float = 1.0,
     seed: int | None = None,
 ) -> FunctionData:
     """Tag every record with its dataset presets and set ``dataset_presets``.
 
-    The ``tiny`` sample is a **seeded random** selection: deterministic for a
-    given seed (so the chosen targets are stable across runs), but changeable.
-    Seed resolution: ``seed`` arg > ``DECBENCH_TINY_SEED`` env var >
-    :data:`DEFAULT_TINY_SEED`.
+    The ``sample-set`` sample is a **seeded random** selection: deterministic
+    for a given seed (so the chosen targets are stable across runs), but
+    changeable. Seed resolution: ``seed`` arg > ``DECBENCH_SAMPLE_SEED`` env
+    var > :data:`DEFAULT_SAMPLE_SEED`.
 
     Idempotent: re-running with the same seed re-derives identical membership.
     """
@@ -196,32 +218,34 @@ def assign_datasets(
         (g, f) for g in function_data.groups for f in g.functions
     ]
 
-    # full / hard / hard-inlined / unoptimized are rule-based.
+    # unoptimized / optimized / inlined / large are rule-based.
     for g, f in records:
-        ds = ["full"]
+        ds = []
         if g.opt_level == _O0:
             ds.append("unoptimized")
-        if is_large(f):
-            if g.opt_level == _O2_NOINLINE:
-                ds.append("hard")
-            elif g.opt_level == _O2:
-                ds.append("hard-inlined")
+        elif g.opt_level == _O2_NOINLINE:
+            ds.append("optimized")
+            if is_large(f):
+                ds.append("large")
+        elif g.opt_level == _O2:
+            ds.append("inlined")
         f.datasets = ds
 
-    # tiny: even sample across four categories and across projects.
+    # sample-set: even sample across five categories and across projects.
     buckets: dict[str, list[tuple[BinaryGroup, FunctionRecord]]] = {
-        "inlined": [(g, f) for g, f in records if g.opt_level == _O2],
-        "optimized": [(g, f) for g, f in records if g.opt_level == _O2_NOINLINE],
         "unoptimized": [(g, f) for g, f in records if g.opt_level == _O0],
-        "large": [(g, f) for g, f in records if is_large(f)],
+        "optimized": [(g, f) for g, f in records if g.opt_level == _O2_NOINLINE],
+        "inlined": [(g, f) for g, f in records if g.opt_level == _O2],
+        "large": [(g, f) for g, f in records if g.opt_level == _O2_NOINLINE and is_large(f)],
+        "unoptimized-arm": [(g, f) for g, f in records if g.opt_level == _O0 and _is_arm(g)],
     }
-    per_bucket = max(1, tiny_total // len(buckets))
+    per_bucket = max(1, sample_total // len(buckets))
     chosen: set[int] = set()
     used_bins: set[tuple[str, str, str]] = set()
     for _name, items in buckets.items():
         for _g, f in _sample_even(items, per_bucket, chosen, used_bins, rng):
-            if "tiny" not in f.datasets:
-                f.datasets.append("tiny")
+            if "sample-set" not in f.datasets:
+                f.datasets.append("sample-set")
 
     function_data.dataset_presets = [p.model_copy() for p in PRESETS]
     return function_data

--- a/decbench/scoring/report_extras.py
+++ b/decbench/scoring/report_extras.py
@@ -466,22 +466,23 @@ def _topup_samples(
     excluded: set[str],
     headroom: int = 4,
 ) -> list[tuple[BinaryGroup, FunctionRecord]]:
-    """Replace excluded ``tiny`` records with non-excluded ones of the same shape.
+    """Replace excluded ``sample-set`` records with non-excluded ones of the same shape.
 
-    The ``tiny`` slice is a deliberately even sample (see
-    :mod:`decbench.scoring.datasets`): balanced across the inlined / optimized /
-    unoptimized / large categories, spread across projects, at most one function
-    per binary. Dropping the malware members without replacing them would both
-    shorten the Compare view and skew that balance, so each dropped record is
-    replaced by one drawn from the same ``(opt_level, is_large)`` bucket, reusing
-    the same even-spread sampler and honouring the binaries already taken.
+    The ``sample-set`` slice is a deliberately even sample (see
+    :mod:`decbench.scoring.datasets`): balanced across the unoptimized /
+    optimized / inlined / large / ARM categories, spread across projects, at
+    most one function per binary. Dropping the malware members without
+    replacing them would both shorten the Compare view and skew that balance,
+    so each dropped record is replaced by one drawn from the same
+    ``(opt_level, is_large)`` bucket, reusing the same even-spread sampler and
+    honouring the binaries already taken.
 
-    ``tiny`` *membership itself is left untouched* — it feeds the report's
+    ``sample-set`` *membership itself is left untouched* — it feeds the report's
     client-side aggregates, and re-sampling it would move published numbers.
     ``headroom`` over-draws so replacements that turn out to have no decompiled
     code can be skipped without shortening the result.
     """
-    # Same-package internals: the tiny slice's own sampler, reused so the
+    # Same-package internals: the sample-set slice's own sampler, reused so the
     # replacements obey the identical spread rules.
     from decbench.scoring.datasets import _resolve_seed, _sample_even
 
@@ -515,14 +516,15 @@ def _topup_samples(
 def build_samples(
     function_data: FunctionData,
     decompile_results: Any,
-    max_samples: int = 140,
+    max_samples: int = 250,
     excluded_projects: Iterable[str] | None = None,
 ) -> list[Any]:
     """Curated side-by-side samples (source + each decompiler's output).
 
-    Prefers the ``tiny`` representative slice (so it spans projects/opt levels at
-    one function per binary); falls back to any function with decompiled code.
-    Requires datasets to be assigned first (see :func:`attach_extras`).
+    Prefers the ``sample-set`` representative slice (so it spans projects/opt
+    levels at one function per binary); falls back to any function with
+    decompiled code. Requires datasets to be assigned first (see
+    :func:`attach_extras`).
 
     Functions from ``excluded_projects`` (by default the malware targets — see
     :func:`publish_malware_allowed`) are dropped and *replaced* by equivalent
@@ -536,8 +538,8 @@ def build_samples(
     def opt_key_for(group_opt: str) -> Any:
         return group_opt  # _lookup_* tolerate string opt keys via _opt_value
 
-    tiny = [(g, f) for g in groups for f in g.functions if "tiny" in (f.datasets or [])]
-    candidates = tiny or [(g, f) for g in groups for f in g.functions]
+    sample_set = [(g, f) for g in groups for f in g.functions if "sample-set" in (f.datasets or [])]
+    candidates = sample_set or [(g, f) for g in groups for f in g.functions]
     # Publish no more than the unfiltered slice would have — and, thanks to the
     # top-up below, no fewer.
     limit = min(max_samples, len(candidates))
@@ -550,7 +552,7 @@ def build_samples(
         removed = [(g, f) for g, f in candidates if g.project in excluded]
         if removed:
             _log_exclusions("samples", Counter(g.project for g, _f in removed))
-            if tiny:
+            if sample_set:
                 kept += _topup_samples(function_data, removed, kept, excluded)
         candidates = kept
 
@@ -712,9 +714,10 @@ def attach_extras(
         except Exception:
             function_data.history = []
 
-    # Tag each function with its dataset presets (full/hard/hard-inlined/tiny)
-    # so the report shows a single dataset selector instead of many toggles.
-    # Must run BEFORE build_samples (which prefers the `tiny` slice).
+    # Tag each function with its dataset presets (unoptimized/optimized/inlined/
+    # large/sample-set) so the report shows a single dataset selector instead of
+    # many toggles. Must run BEFORE build_samples (which prefers the
+    # `sample-set` slice).
     try:
         from decbench.scoring.datasets import assign_datasets
 
@@ -723,8 +726,8 @@ def attach_extras(
         pass
 
     # Side-by-side Compare samples (original source vs each decompiler's output).
-    # Runs after assign_datasets so the `tiny` slice (and its malware-replacement
-    # top-up) is available.
+    # Runs after assign_datasets so the `sample-set` slice (and its
+    # malware-replacement top-up) is available.
     try:
         function_data.samples = build_samples(
             function_data, decompile_results, excluded_projects=excluded

--- a/docs/SITE_DATA_SCHEMA.md
+++ b/docs/SITE_DATA_SCHEMA.md
@@ -8,7 +8,7 @@ Nothing per-function is shipped except the two bounded, code-carrying lists
 
 Every aggregate the report renders is a pure function of two selectors:
 
-* the **dataset preset** (`full` / `hard` / `hard-inlined` / `unoptimized` / `tiny`)
+* the **dataset preset** (`unoptimized` / `optimized` / `inlined` / `large` / `sample-set`)
 * the **normalize-failures** toggle (on / off)
 
 That is `5 x 2 = 10` combinations. The old report shipped all 91,483 `FunctionRecord`s

--- a/scripts/publish_dataset.py
+++ b/scripts/publish_dataset.py
@@ -15,7 +15,7 @@ Examples::
 
     python scripts/publish_dataset.py results/full_run
     python scripts/publish_dataset.py results/full_run --cfgs --cfg-workers 8
-    python scripts/publish_dataset.py results/full_run --only-config tiny --max-binaries 8
+    python scripts/publish_dataset.py results/full_run --only-config sample-set --max-binaries 8
 """
 
 from __future__ import annotations
@@ -63,7 +63,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--cfgs", action="store_true", help="also build source-CFG JSONs (slow)")
     parser.add_argument("--cfg-workers", type=int, default=1, help="parallel CFG workers")
-    parser.add_argument("--configs", default=None, help="comma list: tiny,hard,hard-inlined,full")
+    parser.add_argument("--configs", default=None, help="comma list: sample-set,large,unoptimized,optimized,inlined,full")
     parser.add_argument("--only-config", default=None, help="build a single config")
     parser.add_argument("--skip-binaries", action="store_true", help="do not copy binaries")
     parser.add_argument("--skip-results", action="store_true", help="do not copy decompiled output")

--- a/scripts/rebuild_function_data.py
+++ b/scripts/rebuild_function_data.py
@@ -38,7 +38,7 @@ from decbench.utils.source_extract import function_source
 
 MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
 PERFECT = {"ged": 0.0, "type_match": 1.0, "byte_match": 1.0}
-MAX_SAMPLES = 140
+MAX_SAMPLES = 250
 HARDEST_PER = 12
 
 
@@ -126,9 +126,11 @@ def build_samples(fd: FunctionData, reader: DiskReader) -> list[SampleEntry]:
     rebuild would put the malware straight back.
     """
     out: list[SampleEntry] = []
-    # Prefer the 'tiny' representative slice; fall back to any with code.
-    tiny = [(g, f) for g in fd.groups for f in g.functions if "tiny" in (f.datasets or [])]
-    candidates = tiny or [(g, f) for g in fd.groups for f in g.functions]
+    # Prefer the 'sample-set' representative slice; fall back to any with code.
+    sample_set = [
+        (g, f) for g in fd.groups for f in g.functions if "sample-set" in (f.datasets or [])
+    ]
+    candidates = sample_set or [(g, f) for g in fd.groups for f in g.functions]
     limit = min(MAX_SAMPLES, len(candidates))
 
     excluded = set() if publish_malware_allowed() else malware_projects(fd)
@@ -137,7 +139,7 @@ def build_samples(fd: FunctionData, reader: DiskReader) -> list[SampleEntry]:
         removed = [(g, f) for g, f in candidates if g.project in excluded]
         if removed:
             _log_exclusions("samples", Counter(g.project for g, _f in removed))
-            if tiny:
+            if sample_set:
                 kept += _topup_samples(fd, removed, kept, excluded)
         candidates = kept
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -700,7 +700,7 @@ def main() -> int:
         decompilers=DECOMPILERS,
     )
     fd = build_function_data(all_evaluate, projects, all_decompile)
-    # Populate the report's code-carrying extras: dataset tags (full/hard/tiny),
+    # Populate the report's code-carrying extras: dataset tags (unoptimized/optimized/...),
     # side-by-side Compare samples (with source), Hardest functions, and
     # per-decompiler compile rates. Without this the report has no Compare view,
     # no Hardest list, and no dataset selector.

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -172,19 +172,19 @@ def test_exactly_one_default_dataset(content: Content) -> None:
     assert content.default_dataset is defaults[0]
 
 
-def test_default_dataset_is_full_and_not_positional(content: Content) -> None:
+def test_default_dataset_is_unoptimized_and_not_positional(content: Content) -> None:
     """The default is explicit, so reordering datasets.toml cannot change it."""
     assert content.default_dataset is not None
-    assert content.default_dataset.name == "full"
+    assert content.default_dataset.name == "unoptimized"
 
 
 def test_dataset_presets_cover_the_selector(content: Content) -> None:
     assert [p.name for p in content.dataset_presets] == [
-        "full",
-        "hard",
-        "hard-inlined",
         "unoptimized",
-        "tiny",
+        "optimized",
+        "inlined",
+        "large",
+        "sample-set",
     ]
     for preset in content.dataset_presets:
         assert preset.label and preset.description

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,4 @@
-"""Tests for the curated dataset presets (full/hard/hard-inlined/unoptimized/tiny)."""
+"""Tests for the curated dataset presets (unoptimized/optimized/inlined/large/sample-set)."""
 
 from __future__ import annotations
 
@@ -14,9 +14,14 @@ def _make_data() -> FunctionData:
                 FunctionRecord(function=f"{proj}_{opt}_f{i}", size=sz)
                 for i, sz in enumerate([5, 8, 12, 40, 150, 220])
             ]
+            labels = ["cps", "cortex-m4"] if proj == "gamma" else []
             groups.append(
                 BinaryGroup(
-                    project=proj, opt_level=opt, binary=f"{proj}bin", functions=funcs
+                    project=proj,
+                    opt_level=opt,
+                    binary=f"{proj}bin",
+                    labels=labels,
+                    functions=funcs,
                 )
             )
     return FunctionData(decompilers=["angr"], metrics=["ged"], groups=groups)
@@ -26,20 +31,21 @@ def test_presets_are_attached() -> None:
     fd = _make_data()
     assign_datasets(fd)
     assert [p.name for p in fd.dataset_presets] == [
-        "full",
-        "hard",
-        "hard-inlined",
         "unoptimized",
-        "tiny",
+        "optimized",
+        "inlined",
+        "large",
+        "sample-set",
     ]
 
 
-def test_full_contains_everything() -> None:
+def test_every_function_lands_in_an_opt_preset() -> None:
     fd = _make_data()
     assign_datasets(fd)
+    by_opt = {"O0": "unoptimized", "O2": "inlined", "O2-noinline": "optimized"}
     for g in fd.groups:
         for f in g.functions:
-            assert "full" in f.datasets
+            assert by_opt[g.opt_level] in f.datasets
 
 
 def test_unoptimized_is_exactly_O0() -> None:
@@ -50,34 +56,54 @@ def test_unoptimized_is_exactly_O0() -> None:
             assert ("unoptimized" in f.datasets) == (g.opt_level == "O0")
 
 
-def test_hard_rules() -> None:
+def test_optimized_and_inlined_split_by_opt_level() -> None:
+    fd = _make_data()
+    assign_datasets(fd)
+    for g in fd.groups:
+        for f in g.functions:
+            assert ("optimized" in f.datasets) == (g.opt_level == "O2-noinline")
+            assert ("inlined" in f.datasets) == (g.opt_level == "O2")
+
+
+def test_large_rules() -> None:
+    """`large` (nee `hard`) keeps its membership: O2-noinline AND large."""
     fd = _make_data()
     assign_datasets(fd)
     thr = large_threshold(fd)
     for g in fd.groups:
         for f in g.functions:
-            if "hard" in f.datasets:
+            if "large" in f.datasets:
                 assert g.opt_level == "O2-noinline" and f.size >= thr
-            if "hard-inlined" in f.datasets:
-                assert g.opt_level == "O2" and f.size >= thr
     # there IS at least one large function per opt level here (size 220)
-    assert any("hard" in f.datasets for g in fd.groups for f in g.functions)
-    assert any("hard-inlined" in f.datasets for g in fd.groups for f in g.functions)
+    assert any("large" in f.datasets for g in fd.groups for f in g.functions)
 
 
-def test_tiny_is_bounded_and_spread() -> None:
+def test_sample_set_is_bounded_and_spread() -> None:
     fd = _make_data()
-    assign_datasets(fd, tiny_total=20)
-    tiny = [
+    assign_datasets(fd, sample_total=20)
+    picked = [
         (g.opt_level, g.project)
         for g in fd.groups
         for f in g.functions
-        if "tiny" in f.datasets
+        if "sample-set" in f.datasets
     ]
-    assert 0 < len(tiny) <= 24  # ~tiny_total, bounded
+    assert 0 < len(picked) <= 25  # ~sample_total, bounded (5 buckets x quota)
     # spread across all opt levels and all projects
-    assert {opt for opt, _ in tiny} == {"O0", "O2", "O2-noinline"}
-    assert {proj for _, proj in tiny} == {"alpha", "beta", "gamma"}
+    assert {opt for opt, _ in picked} == {"O0", "O2", "O2-noinline"}
+    assert {proj for _, proj in picked} == {"alpha", "beta", "gamma"}
+
+
+def test_sample_set_includes_arm_unoptimized() -> None:
+    """The fifth bucket draws O0 functions from ARM (cps-labeled) binaries."""
+    fd = _make_data()
+    assign_datasets(fd, sample_total=20)
+    arm_o0 = [
+        f
+        for g in fd.groups
+        for f in g.functions
+        if g.project == "gamma" and g.opt_level == "O0" and "sample-set" in f.datasets
+    ]
+    assert arm_o0, "expected at least one ARM O0 function in the sample-set"
 
 
 def test_idempotent() -> None:
@@ -89,32 +115,32 @@ def test_idempotent() -> None:
     assert first == second
 
 
-def _tiny_keys(fd: FunctionData) -> set[str]:
+def _sample_keys(fd: FunctionData) -> set[str]:
     return {
         f"{g.project}/{g.opt_level}/{f.function}"
         for g in fd.groups
         for f in g.functions
-        if "tiny" in f.datasets
+        if "sample-set" in f.datasets
     }
 
 
-def test_tiny_is_seeded_and_reproducible() -> None:
-    # Same seed -> identical tiny selection, every time.
+def test_sample_set_is_seeded_and_reproducible() -> None:
+    # Same seed -> identical sample-set selection, every time.
     fd1 = _make_data()
-    assign_datasets(fd1, tiny_total=20, seed=42)
+    assign_datasets(fd1, sample_total=20, seed=42)
     fd2 = _make_data()
-    assign_datasets(fd2, tiny_total=20, seed=42)
-    assert _tiny_keys(fd1) == _tiny_keys(fd2)
-    assert len(_tiny_keys(fd1)) > 0
+    assign_datasets(fd2, sample_total=20, seed=42)
+    assert _sample_keys(fd1) == _sample_keys(fd2)
+    assert len(_sample_keys(fd1)) > 0
 
 
-def test_tiny_changes_with_seed() -> None:
+def test_sample_set_changes_with_seed() -> None:
     # A different seed should (with this much data) pick a different sample.
     fd_a = _make_data()
-    assign_datasets(fd_a, tiny_total=20, seed=1)
+    assign_datasets(fd_a, sample_total=20, seed=1)
     fd_b = _make_data()
-    assign_datasets(fd_b, tiny_total=20, seed=2)
-    assert _tiny_keys(fd_a) != _tiny_keys(fd_b)
+    assign_datasets(fd_b, sample_total=20, seed=2)
+    assert _sample_keys(fd_a) != _sample_keys(fd_b)
 
 
 def _make_many_binaries(n_bins: int = 40) -> FunctionData:
@@ -136,36 +162,45 @@ def _make_many_binaries(n_bins: int = 40) -> FunctionData:
     return FunctionData(decompilers=["angr"], metrics=["ged"], groups=groups)
 
 
-def _tiny_binkeys(fd: FunctionData) -> list[tuple[str, str, str]]:
+def _sample_binkeys(fd: FunctionData) -> list[tuple[str, str, str]]:
     return [
         (g.project, g.opt_level, g.binary)
         for g in fd.groups
         for f in g.functions
-        if "tiny" in f.datasets
+        if "sample-set" in f.datasets
     ]
 
 
-def test_tiny_one_function_per_binary_when_enough() -> None:
+def test_sample_set_one_function_per_binary_when_enough() -> None:
     # With many distinct binaries, no binary contributes more than one function.
     fd = _make_many_binaries(n_bins=40)
-    assign_datasets(fd, tiny_total=100)
-    keys = _tiny_binkeys(fd)
+    assign_datasets(fd, sample_total=100)
+    keys = _sample_binkeys(fd)
     assert len(keys) == len(set(keys)), "each binary should appear at most once"
-    assert len(keys) >= 40  # plenty selected
+    assert len(keys) >= 20  # plenty selected (only the O0 bucket has candidates)
 
 
-def test_tiny_relaxes_when_few_binaries() -> None:
+def test_sample_set_relaxes_when_few_binaries() -> None:
     # Only 9 binary-groups but we want ~20 -> must reuse some binaries.
     fd = _make_data()
-    assign_datasets(fd, tiny_total=20)
-    keys = _tiny_binkeys(fd)
+    assign_datasets(fd, sample_total=50)
+    keys = _sample_binkeys(fd)
     assert len(keys) > len(set(keys)), "should reuse binaries when too few exist"
 
 
 def test_env_var_seed(monkeypatch) -> None:
-    monkeypatch.setenv("DECBENCH_TINY_SEED", "777")
+    monkeypatch.setenv("DECBENCH_SAMPLE_SEED", "777")
     fd_env = _make_data()
-    assign_datasets(fd_env, tiny_total=20)  # seed from env
+    assign_datasets(fd_env, sample_total=20)  # seed from env
     fd_explicit = _make_data()
-    assign_datasets(fd_explicit, tiny_total=20, seed=777)  # same, explicit
-    assert _tiny_keys(fd_env) == _tiny_keys(fd_explicit)
+    assign_datasets(fd_explicit, sample_total=20, seed=777)  # same, explicit
+    assert _sample_keys(fd_env) == _sample_keys(fd_explicit)
+
+
+def test_legacy_tiny_seed_env_var_still_honoured(monkeypatch) -> None:
+    monkeypatch.setenv("DECBENCH_TINY_SEED", "888")
+    fd_env = _make_data()
+    assign_datasets(fd_env, sample_total=20)
+    fd_explicit = _make_data()
+    assign_datasets(fd_explicit, sample_total=20, seed=888)
+    assert _sample_keys(fd_env) == _sample_keys(fd_explicit)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -62,19 +62,19 @@ def function_data() -> FunctionData:
                         values={"angr": {"ged": 0.0, "type_match": 1.0}},
                         perfects={"angr": {"ged": True, "type_match": True}},
                         decompiled={"angr": True},
-                        datasets=["full"],
+                        datasets=["unoptimized"],
                     ),
                     FunctionRecord(
                         function="f2",
                         values={"angr": {"ged": 2.0, "type_match": 0.5}},
                         perfects={"angr": {"ged": False, "type_match": False}},
                         decompiled={"angr": True},
-                        datasets=["full", "tiny"],
+                        datasets=["unoptimized", "sample-set"],
                     ),
                 ],
             )
         ],
-        dataset_presets=[DatasetPreset(name="full"), DatasetPreset(name="tiny")],
+        dataset_presets=[DatasetPreset(name="unoptimized"), DatasetPreset(name="sample-set")],
         samples=[
             SampleEntry(
                 project="proj",
@@ -148,7 +148,12 @@ def test_aggregates_carry_the_registry_and_the_default_view(
     assert agg["metric_registry"]["ged"]["short_name"] == "Structure"
     assert agg["default_view"] == "leaderboard"
     # Every (preset x normalize) combination is precomputed, not recomputed client-side.
-    assert set(agg["combos"]) == {"full|0", "full|1", "tiny|0", "tiny|1"}
+    assert set(agg["combos"]) == {
+        "unoptimized|0",
+        "unoptimized|1",
+        "sample-set|0",
+        "sample-set|1",
+    }
 
 
 def test_preset_text_comes_from_the_content_registry(
@@ -159,10 +164,10 @@ def test_preset_text_comes_from_the_content_registry(
     build_site(scoreboard, function_data, out)
     agg = json.loads((out / "data" / "aggregates.json").read_text())
 
-    full = next(p for p in agg["presets"] if p["name"] == "full")
-    assert full["label"] == "full"
-    assert "O2-noinline" in full["description"]
-    assert full["default"] is True
+    unopt = next(p for p in agg["presets"] if p["name"] == "unoptimized")
+    assert unopt["label"] == "unoptimized"
+    assert "O0" in unopt["description"]
+    assert unopt["default"] is True
 
 
 def test_nojekyll_is_present(


### PR DESCRIPTION
Redoes the report's dataset selector per tonight's config plan:

| before | after |
|---|---|
| `full` (default) | removed (publisher keeps a `full` everything-config) |
| `hard` | `large` (membership unchanged: O2-noinline + upper size tail) |
| `hard-inlined` | removed |
| `unoptimized` | `unoptimized` — **new default** |
| — | `optimized` (O2-noinline) |
| — | `inlined` (plain O2) |
| `tiny` (~100) | `sample-set` (~250, five buckets: unoptimized / optimized / inlined / large / **ARM-unoptimized**) |

ARM identification uses the cps/arm/cortex-* binary labels (all 9 CPS firmware targets; sailr + malware are x86 ELF/PE). Seed env var is now `DECBENCH_SAMPLE_SEED` (legacy `DECBENCH_TINY_SEED` still honoured). Membership is re-tagged at render time, so the site picks this up on re-render alone.

Tested: 158 unit tests pass (`test_datasets`, `test_content`, `test_site`, `test_aggregate`, `test_report_extras`, + rest of the non-decompiler suite); touched files black-formatted; only pre-existing ruff findings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbvB8urA4uqipuwH2Mcv4Q