### PR TITLE
feat(site): hide phoenix from the site (results kept on disk)

### DIFF
--- a/decbench/rendering/content.py
+++ b/decbench/rendering/content.py
@@ -144,6 +144,7 @@ class SiteContent:
     sidebar: Sidebar
     banners: dict[str, str]
     side_stats: dict[str, str]
+    hidden_decompilers: tuple[str, ...] = ()
 
     @property
     def no_function_data_banner(self) -> str:
@@ -431,12 +432,14 @@ def _load_view(view_id: str, metrics: tuple[MetricSpec, ...]) -> ViewContent:
 def _load_site() -> SiteContent:
     """Parse ``site.toml``."""
     raw = _load_toml("site.toml")
+    hidden = tuple((raw.get("decompilers") or {}).get("hidden") or ())
     return SiteContent(
         brand=Brand(**raw["brand"]),
         footer=Footer(**raw["footer"]),
         sidebar=Sidebar(**raw["sidebar"]),
         banners=dict(raw["banners"]),
         side_stats=dict(raw["side_stats"]),
+        hidden_decompilers=hidden,
     )
 
 

--- a/decbench/rendering/content/site.toml
+++ b/decbench/rendering/content/site.toml
@@ -31,3 +31,12 @@ metrics = " metrics"
 dataset_label = "dataset"
 normalize_label = "normalize failures"
 normalize_title = "Only count functions that EVERY decompiler decompiled successfully (apples-to-apples)."
+
+# Decompilers hidden from the SITE only. Their results stay in
+# function_results.json (nothing is deleted or re-run) — they are filtered out at
+# render time, so every table, chart, payload, and sample the site ships omits
+# them. A name here matches a decompiler id exactly OR by its base name before
+# `@`, so "phoenix" also hides any "phoenix@<version>". Edit + re-render to
+# change; no benchmark re-run needed.
+[decompilers]
+hidden = ["phoenix"]

--- a/decbench/rendering/html.py
+++ b/decbench/rendering/html.py
@@ -214,6 +214,9 @@ def render_html_report(
         function_data: Optional per-function dataset. Without it the report falls
             back to static tables built from the scoreboard alone.
     """
+    from decbench.rendering.visibility import apply_hidden_decompilers
+
+    scoreboard, function_data = apply_hidden_decompilers(scoreboard, function_data)
     if function_data is None:
         assets = static_assets()
     else:

--- a/decbench/rendering/site.py
+++ b/decbench/rendering/site.py
@@ -59,6 +59,12 @@ def build_site(scoreboard: Scoreboard, function_data: FunctionData, out_dir: Pat
             Required: a site with no data has nothing to show.
         out_dir: The tree root, e.g. ``site/``.
     """
+    from decbench.rendering.visibility import apply_hidden_decompilers
+
+    # Hide site-hidden decompilers (content/site.toml) from EVERY page and
+    # payload; their results stay on disk, untouched.
+    scoreboard, function_data = apply_hidden_decompilers(scoreboard, function_data)
+
     out_dir.mkdir(parents=True, exist_ok=True)
 
     for generated in (out_dir / _DATA_DIR, out_dir / _FONTS_DIR):

--- a/decbench/rendering/visibility.py
+++ b/decbench/rendering/visibility.py
@@ -1,0 +1,107 @@
+"""Render-time hiding of specific decompilers from the site.
+
+Some decompilers are benchmarked and kept in ``function_results.json`` but should
+not appear on the published site (e.g. an experimental backend whose numbers are
+not ready to show). Rather than delete their results or re-run the benchmark
+without them, this module produces *filtered copies* of the
+:class:`~decbench.models.function_data.FunctionData` and
+:class:`~decbench.models.scoreboard.Scoreboard` with the hidden decompilers
+stripped from every list, map, and code-carrying payload. The two rendering entry
+points (:func:`decbench.rendering.html.render_html_report` and
+:func:`decbench.rendering.site.build_site`) pass their inputs through
+:func:`apply_hidden_decompilers` first, so the whole rendering stack below them
+only ever sees the visible decompilers.
+
+The hidden set lives in ``content/site.toml`` (``[decompilers] hidden``). A name
+matches a decompiler id exactly OR by its base name before ``@``, so hiding
+``"phoenix"`` also hides any ``"phoenix@<version>"``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from decbench.models.function_data import FunctionData
+from decbench.models.scoreboard import Scoreboard
+from decbench.rendering.content import Content, load_content
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = ["apply_hidden_decompilers", "is_hidden"]
+
+
+def _base_name(dec: str) -> str:
+    """A decompiler id's base name (``ghidra@12.1`` -> ``ghidra``)."""
+    return dec.split("@", 1)[0]
+
+
+def is_hidden(dec: str, hidden: Iterable[str]) -> bool:
+    """Whether decompiler id ``dec`` is hidden by exact id or base name."""
+    hidden_set = set(hidden)
+    return dec in hidden_set or _base_name(dec) in hidden_set
+
+
+def _visible(decompilers: Iterable[str], hidden: Iterable[str]) -> list[str]:
+    """The visible decompilers, order preserved."""
+    hidden_set = set(hidden)
+    return [d for d in decompilers if not is_hidden(d, hidden_set)]
+
+
+def _filter_function_data(function_data: FunctionData, hidden: set[str]) -> FunctionData:
+    """A deep copy of ``function_data`` with hidden decompilers stripped everywhere."""
+    fd = function_data.model_copy(deep=True)
+    keep = set(_visible(fd.decompilers, hidden))
+
+    fd.decompilers = [d for d in fd.decompilers if d in keep]
+    fd.decompiler_versions = {d: v for d, v in fd.decompiler_versions.items() if d in keep}
+    fd.compile_rates = {d: r for d, r in fd.compile_rates.items() if d in keep}
+
+    for group in fd.groups:
+        for record in group.functions:
+            record.values = {d: v for d, v in record.values.items() if d in keep}
+            record.perfects = {d: v for d, v in record.perfects.items() if d in keep}
+            record.distances = {d: v for d, v in record.distances.items() if d in keep}
+            record.decompiled = {d: v for d, v in record.decompiled.items() if d in keep}
+
+    for sample in fd.samples:
+        sample.decompiled = {d: c for d, c in sample.decompiled.items() if d in keep}
+        sample.values = {d: v for d, v in sample.values.items() if d in keep}
+        sample.perfects = {d: v for d, v in sample.perfects.items() if d in keep}
+    # A sample whose only shown output was a hidden decompiler has nothing left.
+    fd.samples = [s for s in fd.samples if s.decompiled]
+
+    fd.hardest = [h for h in fd.hardest if not is_hidden(h.decompiler, hidden)]
+    fd.history = [h for h in fd.history if not is_hidden(h.decompiler, hidden)]
+    return fd
+
+
+def _filter_scoreboard(scoreboard: Scoreboard, hidden: set[str]) -> Scoreboard:
+    """A deep copy of ``scoreboard`` with hidden decompilers stripped."""
+    sb = scoreboard.model_copy(deep=True)
+    keep = set(_visible(sb.decompilers, hidden))
+    sb.decompilers = [d for d in sb.decompilers if d in keep]
+    sb.decompiler_scores = {d: s for d, s in sb.decompiler_scores.items() if d in keep}
+    return sb
+
+
+def apply_hidden_decompilers(
+    scoreboard: Scoreboard,
+    function_data: FunctionData | None,
+    content: Content | None = None,
+) -> tuple[Scoreboard, FunctionData | None]:
+    """Return copies with the site's hidden decompilers removed everywhere.
+
+    A no-op (returns the inputs unchanged) when nothing is hidden, so the common
+    case pays no copy cost. Otherwise both objects are deep-copied and filtered,
+    leaving the on-disk results untouched.
+    """
+    content = content or load_content()
+    hidden = set(content.site.hidden_decompilers)
+    if not hidden:
+        return scoreboard, function_data
+    filtered_sb = _filter_scoreboard(scoreboard, hidden)
+    filtered_fd = (
+        _filter_function_data(function_data, hidden) if function_data is not None else None
+    )
+    return filtered_sb, filtered_fd

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -1,0 +1,141 @@
+"""Tests for render-time decompiler hiding (:mod:`decbench.rendering.visibility`).
+
+Phoenix is hidden from the site in ``content/site.toml`` but kept on disk. These
+guard that the filter strips a hidden decompiler from every list / map / payload
+while leaving the visible ones — and the inputs — untouched.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+from decbench.models.function_data import (
+    BinaryGroup,
+    DatasetPreset,
+    FunctionData,
+    FunctionRecord,
+    HistoryPoint,
+    SampleEntry,
+)
+from decbench.models.scoreboard import DecompilerScore, Scoreboard
+from decbench.rendering.content import load_content
+from decbench.rendering.site import build_site
+from decbench.rendering.visibility import apply_hidden_decompilers, is_hidden
+
+
+def _fd() -> FunctionData:
+    return FunctionData(
+        decompilers=["angr", "phoenix", "ghidra"],
+        decompiler_versions={"angr": "9.2", "phoenix": "9.2", "ghidra": "12.1"},
+        metrics=["ged"],
+        perfect_values={"ged": 0.0},
+        compile_rates={"angr": 0.4, "phoenix": 0.3, "ghidra": 0.5},
+        groups=[
+            BinaryGroup(
+                project="proj",
+                opt_level="O0",
+                binary="bin1",
+                functions=[
+                    FunctionRecord(
+                        function="f1",
+                        values={d: {"ged": 0.0} for d in ("angr", "phoenix", "ghidra")},
+                        perfects={d: {"ged": True} for d in ("angr", "phoenix", "ghidra")},
+                        distances={d: {"ged": 0.0} for d in ("angr", "phoenix", "ghidra")},
+                        decompiled={"angr": True, "phoenix": True, "ghidra": True},
+                        datasets=["unoptimized"],
+                    )
+                ],
+            )
+        ],
+        dataset_presets=[DatasetPreset(name="unoptimized")],
+        samples=[
+            SampleEntry(
+                project="proj",
+                opt_level="O0",
+                binary="bin1",
+                function="f1",
+                difficulty="easy",
+                decompiled={"angr": "A", "phoenix": "P", "ghidra": "G"},
+                values={d: {"ged": 0.0} for d in ("angr", "phoenix", "ghidra")},
+                perfects={d: {"ged": True} for d in ("angr", "phoenix", "ghidra")},
+            )
+        ],
+        history=[
+            HistoryPoint(decompiler="phoenix", version="9.2", scores={"ged": 50.0}),
+            HistoryPoint(decompiler="ghidra@12.1", version="12.1", scores={"ged": 60.0}),
+        ],
+    )
+
+
+def _sb() -> Scoreboard:
+    return Scoreboard(
+        name="t",
+        metrics=["ged"],
+        decompilers=["angr", "phoenix", "ghidra"],
+        decompiler_scores={d: DecompilerScore(name=d) for d in ("angr", "phoenix", "ghidra")},
+    )
+
+
+def _content_hiding(*hidden: str):
+    """A Content whose site hides ``hidden`` (site is a frozen dataclass)."""
+    content = load_content()
+    site = dataclasses.replace(content.site, hidden_decompilers=tuple(hidden))
+    return dataclasses.replace(content, site=site)
+
+
+def test_is_hidden_matches_id_and_base_name() -> None:
+    assert is_hidden("phoenix", {"phoenix"})
+    assert is_hidden("phoenix@9.2", {"phoenix"})  # base-name match
+    assert not is_hidden("ghidra@12.1", {"phoenix"})
+    assert not is_hidden("angr", {"phoenix"})
+
+
+def test_hidden_decompiler_stripped_everywhere() -> None:
+    fd, sb = _fd(), _sb()
+    out_sb, out_fd = apply_hidden_decompilers(sb, fd, _content_hiding("phoenix"))
+
+    assert "phoenix" not in out_sb.decompilers
+    assert "phoenix" not in out_sb.decompiler_scores
+    assert out_fd is not None
+    assert out_fd.decompilers == ["angr", "ghidra"]
+    assert "phoenix" not in out_fd.decompiler_versions
+    assert "phoenix" not in out_fd.compile_rates
+    rec = out_fd.groups[0].functions[0]
+    for m in (rec.values, rec.perfects, rec.distances, rec.decompiled):
+        assert "phoenix" not in m and "angr" in m
+    s = out_fd.samples[0]
+    assert set(s.decompiled) == {"angr", "ghidra"}
+    assert [h.decompiler for h in out_fd.history] == ["ghidra@12.1"]  # base-name hide
+
+
+def test_filter_is_a_copy_inputs_untouched() -> None:
+    fd, sb = _fd(), _sb()
+    apply_hidden_decompilers(sb, fd, _content_hiding("phoenix"))
+    assert "phoenix" in fd.decompilers  # original untouched
+    assert "phoenix" in sb.decompilers
+
+
+def test_no_hidden_is_a_noop() -> None:
+    fd, sb = _fd(), _sb()
+    out_sb, out_fd = apply_hidden_decompilers(sb, fd, _content_hiding())
+    assert out_sb is sb and out_fd is fd  # same objects, no copy
+
+
+def test_phoenix_is_hidden_in_the_shipped_config() -> None:
+    """The site config actually hides phoenix (the whole point of this feature)."""
+    assert "phoenix" in load_content().site.hidden_decompilers
+
+
+def test_build_site_omits_hidden_decompiler(tmp_path: Path) -> None:
+    """End-to-end: phoenix must not appear in any shipped payload."""
+    out = tmp_path / "site"
+    build_site(_sb(), _fd(), out)
+    agg = json.loads((out / "data" / "aggregates.json").read_text())
+    assert "phoenix" not in agg["decompilers"]
+    assert set(agg["decompilers"]) == {"angr", "ghidra"}
+    blob = "".join(
+        (out / "data" / f"{name}.json").read_text() for name in ("aggregates", "samples", "history")
+    )
+    assert "phoenix" not in blob


### PR DESCRIPTION
Hides the `phoenix` decompiler from the published site without deleting its results or re-running anything. A new render-time filter (`decbench/rendering/visibility.py`) produces filtered copies of the `FunctionData` + `Scoreboard` with site-hidden decompilers stripped from every list, map, chart, table, and code payload; both entry points (`render_html_report`, `build_site`) pass through it first.

The hidden set is config — `content/site.toml` `[decompilers] hidden = ["phoenix"]` — matched by exact id or base name (`phoenix` also hides `phoenix@<version>`). Edit + re-render to change.

Verified: 6 new unit tests; `site build results/full_run` ships angr/binja/ghidra/ida/kuna with **zero** `phoenix` occurrences across `index.html` and every `data/*.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbvB8urA4uqipuwH2Mcv4Q