### PR TITLE
feat(decompilers): add dewolf backend (out-of-process Binary Ninja frontend)

### DIFF
--- a/decbench/decompilers/raw/__init__.py
+++ b/decbench/decompilers/raw/__init__.py
@@ -22,9 +22,10 @@ from __future__ import annotations
 from decbench.decompilers.raw import (
     angr_raw,  # noqa: F401
     binja_raw,  # noqa: F401
+    dewolf_raw,  # noqa: F401
     ghidra_raw,  # noqa: F401
     ida_raw,  # noqa: F401
     kuna_raw,  # noqa: F401
 )
 
-__all__ = ["angr_raw", "ghidra_raw", "ida_raw", "binja_raw", "kuna_raw"]
+__all__ = ["angr_raw", "ghidra_raw", "ida_raw", "binja_raw", "kuna_raw", "dewolf_raw"]

--- a/decbench/decompilers/raw/dewolf_driver.py
+++ b/decbench/decompilers/raw/dewolf_driver.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Out-of-process dewolf driver — runs in the dewolf virtualenv, not decbench's.
+
+dewolf (github.com/fkie-cad/dewolf) is a Binary Ninja plugin pinned to
+``z3-solver==4.8.10`` and Python 3.10, so it cannot be imported into the
+decbench venv (Python 3.14). :class:`decbench.decompilers.raw.dewolf_raw.
+RawDewolfDecompiler` therefore shells out to THIS script inside the dewolf venv
+(``DECBENCH_DEWOLF_PYTHON`` / ``DECBENCH_DEWOLF_REPO``); it does the Binary Ninja
+analysis and dewolf decompilation and streams one JSON object per function back
+on stdout.
+
+It drives Binary Ninja ONCE per binary (a single ``BinaryView`` shared across
+every function — dewolf's own ``Decompiler.from_raw`` wraps it), which is far
+cheaper than the per-function subprocess the ``decompile.py`` CLI would cost.
+
+Protocol (all on stdout, one JSON object per line):
+  {"type": "meta", "load_base": <int>, "count": <int>}          # first line
+  {"type": "func", "name": str, "addr": <elf-file-space int>,
+   "code": str, "seconds": float}                                # per success
+  {"type": "fail", "name": str, "addr": <int>, "error": str}     # per failure
+  {"type": "done"}                                               # last line
+
+Args: ``dewolf_driver.py <binary> <elf_min_vaddr> [addrs_json]``. ``addrs_json``
+is a JSON list of ELF-file-space addresses to restrict to (the project's source
+functions); omit / "NONE" to decompile every function binja finds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+import time
+from typing import Any
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    binary = sys.argv[1]
+    elf_base = int(sys.argv[2])
+    target_addrs: set[int] | None = None
+    if len(sys.argv) > 3 and sys.argv[3] not in ("", "NONE"):
+        try:
+            target_addrs = {int(a) for a in json.loads(sys.argv[3])} or None
+        except Exception:  # noqa: BLE001
+            target_addrs = None
+
+    import binaryninja as bn
+    from decompile import Decompiler
+    from decompiler.util.options import Options
+
+    bv = bn.load(binary)
+    bv.update_analysis_and_wait()
+    load_base = int(bv.start)
+
+    # ELF-file-space address for a binja function start (mirrors binja_raw).
+    def elf_addr(start: int) -> int:
+        return (int(start) - load_base) + elf_base
+
+    # Thumb functions (ARM) can carry the low bit set; compare with it cleared.
+    def matches(addr: int) -> bool:
+        if target_addrs is None:
+            return True
+        return addr in target_addrs or (addr & ~1) in target_addrs or (addr | 1) in target_addrs
+
+    selected = []
+    for func in bv.functions:
+        try:
+            if getattr(func, "is_thunk", False):
+                continue
+            addr = elf_addr(func.start)
+            if matches(addr):
+                selected.append((func, addr))
+        except Exception:  # noqa: BLE001
+            continue
+
+    _emit({"type": "meta", "load_base": load_base, "count": len(selected)})
+
+    options: Options = Decompiler.create_options()
+    # Keep a single stubborn function from wedging the whole binary: bound the
+    # logic-engine timeouts (dewolf's dominant slow path — sympy/z3 on complex
+    # conditions). These are milliseconds.
+    for key in ("logic.engine.dead_path_timeout", "logic.engine.dead_loop_timeout"):
+        with contextlib.suppress(Exception):
+            options.set(key, 2000)
+
+    decompiler = Decompiler.from_raw(bv)
+    for func, addr in selected:
+        name = str(func.name or f"sub_{func.start:x}")
+        started = time.time()
+        try:
+            # dewolf accepts a function identifier: the binja Function works
+            # directly (its frontend resolves name/address/object).
+            _task, code = decompiler.decompile(func, options)
+            if code and code.strip():
+                _emit(
+                    {
+                        "type": "func",
+                        "name": name,
+                        "addr": addr,
+                        "code": code,
+                        "seconds": time.time() - started,
+                    }
+                )
+            else:
+                _emit({"type": "fail", "name": name, "addr": addr, "error": "empty output"})
+        except Exception as exc:  # noqa: BLE001
+            _emit({"type": "fail", "name": name, "addr": addr, "error": str(exc)[:200]})
+
+    _emit({"type": "done"})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/decbench/decompilers/raw/dewolf_raw.py
+++ b/decbench/decompilers/raw/dewolf_raw.py
@@ -1,0 +1,249 @@
+"""Raw dewolf decompiler backend (github.com/fkie-cad/dewolf).
+
+dewolf is a Binary-Ninja-based research decompiler pinned to ``z3-solver==4.8.10``
+and Python 3.10, so it cannot share decbench's (3.14) interpreter. This backend
+runs the decompilation OUT OF PROCESS, in the dewolf virtualenv, via
+:mod:`decbench.decompilers.raw.dewolf_driver`: that driver does the Binary Ninja
+analysis once per binary and streams one JSON object per function back on stdout,
+which this backend turns into :class:`FunctionDecompilation` objects with
+ELF-file-space addresses (so they line up with DWARF for scoring).
+
+Configuration (``~/.config/decbench/decompilers.toml`` ``[dewolf.versions."X"]``
+or the environment):
+
+* ``python`` / ``DECBENCH_DEWOLF_PYTHON`` — the dewolf venv's interpreter.
+* ``repo`` / ``DECBENCH_DEWOLF_REPO`` — the dewolf checkout (added to
+  ``PYTHONPATH`` so ``import decompile`` resolves).
+* ``astyle_path`` / ``DECBENCH_DEWOLF_ASTYLE`` — optional dir prepended to
+  ``PATH`` so dewolf finds ``astyle`` for output indentation.
+
+Like the other raw backends it drives a fully-stripped binary and filters to the
+project's source functions BY ADDRESS (``function_names`` is a set of ints), with
+per-function partial-progress checkpointing so a timeout still yields the
+functions completed so far.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from decbench.decompilers.base import Decompiler, DecompilerConfig
+from decbench.decompilers.raw import common
+from decbench.decompilers.registry import register_decompiler
+from decbench.models.decompilation import (
+    DecompilationResult,
+    DecompilerMetadata,
+    FunctionDecompilation,
+)
+
+_l = logging.getLogger(__name__)
+
+_DRIVER = Path(__file__).with_name("dewolf_driver.py")
+
+
+@register_decompiler("dewolf")
+class RawDewolfDecompiler(Decompiler):
+    """dewolf driven out-of-process in its own venv (Binary Ninja frontend)."""
+
+    name = "dewolf"
+    display_name = "dewolf"
+
+    def __init__(self, config: DecompilerConfig | None = None):
+        super().__init__(config)
+
+    #
+    # Config resolution
+    #
+
+    def _settings(self) -> dict:
+        """Per-version settings, falling back to the ``default`` entry.
+
+        The bare ``dewolf`` spec has no requested version, so read the
+        ``[dewolf.versions.default]`` table for it; an explicit ``dewolf@X`` reads
+        its own table.
+        """
+        from decbench.decompilers.spec import version_settings
+
+        settings = version_settings("dewolf", self.requested_version)
+        if not settings and self.requested_version is None:
+            settings = version_settings("dewolf", "default")
+        return settings
+
+    def _python(self) -> str | None:
+        """The dewolf venv interpreter (config > env)."""
+        return self._settings().get("python") or os.environ.get("DECBENCH_DEWOLF_PYTHON")
+
+    def _repo(self) -> str | None:
+        """The dewolf checkout added to PYTHONPATH (config > env)."""
+        return self._settings().get("repo") or os.environ.get("DECBENCH_DEWOLF_REPO")
+
+    def _astyle_dir(self) -> str | None:
+        return self._settings().get("astyle_path") or os.environ.get("DECBENCH_DEWOLF_ASTYLE")
+
+    def _child_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        repo = self._repo()
+        if repo:
+            existing = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = repo + (os.pathsep + existing if existing else "")
+        astyle = self._astyle_dir()
+        if astyle:
+            env["PATH"] = astyle + os.pathsep + env.get("PATH", "")
+        return env
+
+    #
+    # Decompiler interface
+    #
+
+    def is_available(self) -> bool:
+        python = self._python()
+        if not python or not Path(python).exists():
+            return False
+        return _DRIVER.exists()
+
+    def get_version(self) -> str | None:
+        repo = self._repo()
+        if not repo:
+            return None
+        try:
+            out = subprocess.run(
+                ["git", "-C", repo, "describe", "--tags", "--always"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if out.returncode == 0 and out.stdout.strip():
+                return out.stdout.strip()
+        except Exception:  # noqa: BLE001
+            pass
+        return "unknown"
+
+    def decompile_binary(
+        self,
+        binary_path: Path,
+        functions: list[tuple[str, int]] | None = None,
+        output_dir: Path | None = None,
+        function_names: set[int] | set[str] | None = None,
+        progress_path: Path | None = None,
+    ) -> DecompilationResult:
+        """Decompile ``binary_path`` via the out-of-process dewolf driver."""
+        if not self.is_available():
+            raise RuntimeError(f"Decompiler '{self.name}' is not available")
+
+        start_time = time.time()
+        elf_base = common.elf_min_vaddr(binary_path)
+
+        decompiled_functions: dict[str, FunctionDecompilation] = {}
+        failed_functions: list[str] = []
+
+        # The driver filters by address itself; pass the int targets through.
+        target_addrs = {a for a in (function_names or set()) if isinstance(a, int)} or None
+        addrs_arg = json.dumps(sorted(target_addrs)) if target_addrs else "NONE"
+
+        def _meta(partial: bool, error: str | None = None) -> DecompilerMetadata:
+            extra: dict[str, Any] = {"backend": "dewolf", "via": "raw"}
+            if partial:
+                extra["partial"] = True
+            if error:
+                extra["error"] = error
+                extra["failure"] = error
+            return DecompilerMetadata(
+                decompiler_name=self.id,
+                decompiler_version=self.get_version(),
+                total_time_seconds=time.time() - start_time,
+                failed_functions=list(failed_functions),
+                extra=extra,
+            )
+
+        def _dump() -> None:
+            if progress_path is None:
+                return
+            partial = DecompilationResult(
+                binary_path=binary_path,
+                binary_name=binary_path.stem,
+                decompiler=_meta(partial=True),
+                functions=dict(decompiled_functions),
+                output_dir=output_dir,
+            )
+            common.dump_progress(progress_path, partial)
+
+        cmd = [str(self._python()), str(_DRIVER), str(binary_path), str(elf_base), addrs_arg]
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=self._child_env(),
+                text=True,
+                bufsize=1,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _l.error("dewolf-raw failed to launch on %s: %s", binary_path, exc)
+            return self._error_result(binary_path, start_time, str(exc))
+
+        assert proc.stdout is not None
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                kind = obj.get("type")
+                if kind == "func":
+                    name = str(obj.get("name") or "")
+                    code = obj.get("code") or ""
+                    if not name or not code:
+                        continue
+                    decompiled_functions[name] = FunctionDecompilation(
+                        name=name,
+                        address=int(obj.get("addr", 0)),
+                        decompiled_code=code,
+                        line_count=code.count("\n") + 1,
+                        line_mappings=[],
+                        variables=[],
+                        metadata=common.extract_metrics(code),
+                    )
+                    _dump()
+                elif kind == "fail":
+                    failed_functions.append(str(obj.get("name") or obj.get("addr")))
+        finally:
+            proc.wait()
+
+        result = DecompilationResult(
+            binary_path=binary_path,
+            binary_name=binary_path.stem,
+            decompiler=_meta(partial=False),
+            functions=decompiled_functions,
+            output_dir=output_dir,
+        )
+
+        if output_dir:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            result.to_c_file(output_dir / f"{self.name}_{binary_path.stem}.c")
+            result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
+
+        return result
+
+    def _error_result(
+        self, binary_path: Path, start_time: float, error: str
+    ) -> DecompilationResult:
+        return DecompilationResult(
+            binary_path=binary_path,
+            binary_name=binary_path.stem,
+            decompiler=DecompilerMetadata(
+                decompiler_name=self.id,
+                decompiler_version=self.get_version(),
+                total_time_seconds=time.time() - start_time,
+                failed_functions=["all"],
+                extra={"error": error, "backend": "dewolf", "via": "raw"},
+            ),
+        )

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -103,12 +103,19 @@ DECOMPILE_TIMEOUT = int(os.environ.get("DECBENCH_DECOMPILE_TIMEOUT") or "300")
 #     bash) — 900s. Its per-FUNCTION hang guard is now --max-fn-seconds (passed by
 #     the backend), so a pathological function can't hang the batch; the
 #     process-group SIGKILL stays as a belt-and-suspenders leak guard.
+#   - dewolf: Binary Ninja frontend + a z3/sympy logic-simplification pipeline
+#     that can blow up on complex control flow (the paper's main timeout source);
+#     runs out-of-process in its own venv. Give it a Ghidra-class budget.
+#   - r2dec: radare2 `aaa` analysis then per-function pseudo-C; `aaa` on a big
+#     binary can run minutes, so budget like ghidra/binja.
 DECOMPILER_TIMEOUT = {
     "kuna": int(os.environ.get("DECBENCH_KUNA_TIMEOUT") or "900"),
     "angr": int(os.environ.get("DECBENCH_ANGR_TIMEOUT") or "3600"),
     "phoenix": int(os.environ.get("DECBENCH_PHOENIX_TIMEOUT") or "3600"),
     "ghidra": int(os.environ.get("DECBENCH_GHIDRA_TIMEOUT") or "1800"),
     "binja": int(os.environ.get("DECBENCH_BINJA_TIMEOUT") or "1800"),
+    "dewolf": int(os.environ.get("DECBENCH_DEWOLF_TIMEOUT") or "1800"),
+    "r2dec": int(os.environ.get("DECBENCH_R2DEC_TIMEOUT") or "1800"),
 }
 _HERE = Path(__file__).resolve().parent
 _DECOMPILE_ONE = _HERE / "decompile_one.py"

--- a/tests/test_dewolf_backend.py
+++ b/tests/test_dewolf_backend.py
@@ -1,0 +1,113 @@
+"""Unit tests for the dewolf backend's config + JSON-stream parsing.
+
+The real decompilation runs Binary Ninja + dewolf in a separate venv, so these
+tests exercise the parts that do NOT need that toolchain: config resolution,
+availability gating, and turning the driver's JSON-line protocol into
+``FunctionDecompilation`` objects (via a fake driver subprocess).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import decbench.decompilers  # noqa: F401  (registers the raw backends)
+from decbench.decompilers.raw.dewolf_raw import RawDewolfDecompiler
+from decbench.decompilers.registry import DecompilerRegistry
+
+
+def test_dewolf_is_registered() -> None:
+    dec = DecompilerRegistry.get("dewolf")
+    assert isinstance(dec, RawDewolfDecompiler)
+    assert dec.id == "dewolf"
+
+
+def test_unavailable_without_python(monkeypatch) -> None:
+    monkeypatch.delenv("DECBENCH_DEWOLF_PYTHON", raising=False)
+    monkeypatch.delenv("DECBENCH_DEWOLF_REPO", raising=False)
+    dec = RawDewolfDecompiler()
+    # No configured interpreter (and the test env has no versions config for it):
+    monkeypatch.setattr(dec, "_python", lambda: None)
+    assert dec.is_available() is False
+
+
+def test_child_env_prepends_repo_and_astyle(monkeypatch, tmp_path: Path) -> None:
+    dec = RawDewolfDecompiler()
+    monkeypatch.setattr(dec, "_repo", lambda: "/opt/dewolf")
+    monkeypatch.setattr(dec, "_astyle_dir", lambda: "/opt/astyle/bin")
+    monkeypatch.setenv("PYTHONPATH", "/existing")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    env = dec._child_env()
+    assert env["PYTHONPATH"].split(":")[0] == "/opt/dewolf"
+    assert "/existing" in env["PYTHONPATH"]
+    assert env["PATH"].split(":")[0] == "/opt/astyle/bin"
+
+
+# A stand-in driver: emits the JSON protocol and exits, so decompile_binary can
+# be exercised without Binary Ninja or the dewolf venv.
+_FAKE_DRIVER = """\
+import json, sys
+def e(o): sys.stdout.write(json.dumps(o) + "\\n")
+e({"type": "meta", "load_base": 4194304, "count": 2})
+e({"type": "func", "name": "alpha", "addr": 4096, "code": "int alpha(){return 1;}"})
+e({"type": "fail", "name": "beta", "addr": 8192, "error": "boom"})
+e({"type": "func", "name": "gamma", "addr": 12288, "code": "int gamma(){return 3;}"})
+e({"type": "done"})
+"""
+
+
+def test_decompile_binary_parses_driver_stream(monkeypatch, tmp_path: Path) -> None:
+    driver = tmp_path / "fake_driver.py"
+    driver.write_text(_FAKE_DRIVER)
+    binary = tmp_path / "bin.elf"
+    binary.write_bytes(b"\x7fELF" + b"\x00" * 60)
+
+    dec = RawDewolfDecompiler()
+    monkeypatch.setattr(dec, "is_available", lambda: True)
+    monkeypatch.setattr(dec, "get_version", lambda: "vTEST")
+    monkeypatch.setattr(dec, "_python", lambda: sys.executable)
+    monkeypatch.setattr(dec, "_child_env", dict)
+    monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw._DRIVER", driver)
+    # elf_min_vaddr on our stub bytes → 0; the driver's addrs are already
+    # ELF-file-space, so they pass straight through.
+    monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw.common.elf_min_vaddr", lambda p: 0)
+
+    out = tmp_path / "out"
+    result = dec.decompile_binary(binary, output_dir=out, function_names={4096, 12288})
+
+    assert set(result.functions) == {"alpha", "gamma"}
+    assert result.functions["alpha"].address == 4096
+    assert result.functions["gamma"].line_count == 1
+    assert "beta" in result.decompiler.failed_functions
+    assert (out / "dewolf_bin.c").exists()
+
+
+def test_int_address_filter_arg_is_json(monkeypatch, tmp_path: Path) -> None:
+    """Only int targets reach the driver, serialized as a JSON list."""
+    captured = {}
+
+    class _FakeProc:
+        stdout = iter([json.dumps({"type": "done"})])
+
+        def wait(self):
+            return 0
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _FakeProc()
+
+    binary = tmp_path / "bin.elf"
+    binary.write_bytes(b"\x7fELF" + b"\x00" * 60)
+    dec = RawDewolfDecompiler()
+    monkeypatch.setattr(dec, "is_available", lambda: True)
+    monkeypatch.setattr(dec, "get_version", lambda: "vTEST")
+    monkeypatch.setattr(dec, "_python", lambda: "python")
+    monkeypatch.setattr(dec, "_child_env", dict)
+    monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw.common.elf_min_vaddr", lambda p: 0)
+    monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw.subprocess.Popen", fake_popen)
+
+    dec.decompile_binary(binary, function_names={4096, 8192, "not-an-int"})
+
+    addrs_arg = captured["cmd"][-1]
+    assert json.loads(addrs_arg) == [4096, 8192]


### PR DESCRIPTION
Adds the **dewolf** decompiler (github.com/fkie-cad/dewolf) as a benchmark backend.

dewolf is BN-based and pinned to `z3-solver==4.8.10` / Python 3.10, so it can't share decbench's 3.14 interpreter. The backend runs it **out of process** in its own venv:

- **`dewolf_driver.py`** (runs in the dewolf venv): one Binary Ninja analysis per binary, dewolf per function, streaming one JSON object per function on stdout. Addresses normalized to ELF-file-space (BN base `0x400000` → DWARF), Thumb-bit tolerant, filtered to the requested source addresses.
- **`dewolf_raw.py`** (registered `dewolf`): shells out to the driver, parses the stream into `FunctionDecompilation`s, checkpoints partial progress, writes `.c`/`.toml`. Config via `[dewolf.versions.default]` (interpreter/repo/astyle) or `DECBENCH_DEWOLF_*`.
- `run_benchmark` gains `dewolf` + `r2dec` per-binary timeout budgets.

Works on stripped binaries by design (BN analysis discovers functions; matched by address — no symtab needed).

Verified: `list-decompilers` shows dewolf=Y v2026.7.11; `decompile_binary` over a stripped libacl (8 functions by address) returns 8/8 with correct ELF-space addresses; 5 unit tests pass. The full data collection runs after the historical Ghidra + r2dec data tasks (serialized to respect core budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbvB8urA4uqipuwH2Mcv4Q