### PR TITLE
fix(run): give dewolf the same 3600s per-binary budget as angr

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -105,7 +105,9 @@ DECOMPILE_TIMEOUT = int(os.environ.get("DECBENCH_DECOMPILE_TIMEOUT") or "300")
 #     process-group SIGKILL stays as a belt-and-suspenders leak guard.
 #   - dewolf: Binary Ninja frontend + a z3/sympy logic-simplification pipeline
 #     that can blow up on complex control flow (the paper's main timeout source);
-#     runs out-of-process in its own venv. Give it a Ghidra-class budget.
+#     runs out-of-process in its own venv. It is as slow as angr on the hard
+#     binaries, so it gets the SAME 3600s budget — truncating it at a smaller
+#     budget than angr would unfairly count its hardest functions as failures.
 #   - r2dec: radare2 `aaa` analysis then per-function pseudo-C; `aaa` on a big
 #     binary can run minutes, so budget like ghidra/binja.
 DECOMPILER_TIMEOUT = {
@@ -114,7 +116,7 @@ DECOMPILER_TIMEOUT = {
     "phoenix": int(os.environ.get("DECBENCH_PHOENIX_TIMEOUT") or "3600"),
     "ghidra": int(os.environ.get("DECBENCH_GHIDRA_TIMEOUT") or "1800"),
     "binja": int(os.environ.get("DECBENCH_BINJA_TIMEOUT") or "1800"),
-    "dewolf": int(os.environ.get("DECBENCH_DEWOLF_TIMEOUT") or "1800"),
+    "dewolf": int(os.environ.get("DECBENCH_DEWOLF_TIMEOUT") or "3600"),
     "r2dec": int(os.environ.get("DECBENCH_R2DEC_TIMEOUT") or "1800"),
 }
 _HERE = Path(__file__).resolve().parent


### PR DESCRIPTION
dewolf's z3 logic-simplification is as slow as angr on the hardest binaries; capping it at 1800s (vs angr/phoenix's 3600s) truncated its hard functions and unfairly counted them as failures. Bumps the dewolf per-binary default to 3600s. Applied to the in-flight dewolf data run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbvB8urA4uqipuwH2Mcv4Q