### PR TITLE
decompilers: add kimi-code LLM backend (Kimi Code CLI, default kimi-code/k3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Significant changes to DecBench that introduce or update results.
 
+### 2026-07-23
+
+- Added a third LLM/coding-agent decompiler backend: **kimi-code** (Kimi Code
+  CLI, default model `kimi-code/k3`), benchmarked on the sample-set slice like
+  codex/claude-code.
+
 ### 2026-07-22
 
 - **DecBench goes live** with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,8 +240,9 @@ three families:
   container (or natively for r2dec) and split whole-program C into per-function
   results. Build images with `decbench decompiler-build <name>`; Dockerfiles in
   `docker/`.
-- **LLM / coding-agent** (`llm_dec.py`: `codex`, `claude-code`): drive a coding
-  agent CLI (OpenAI `codex` / Anthropic `claude`) as a decompiler, one agentic
+- **LLM / coding-agent** (`llm_dec.py`: `codex`, `claude-code`, `kimi-code`):
+  drive a coding agent CLI (OpenAI `codex` / Anthropic `claude` / Moonshot
+  `kimi`) as a decompiler, one agentic
   call per function. **Cost is controlled by only ever running on the
   `sample-set` slice**: freeze it with `scripts/export_sample_set.py`
   (→ `sample_set_manifest.json`), then `DECBENCH_SAMPLESET_MANIFEST=<manifest>
@@ -249,7 +250,8 @@ three families:
   results/full_run`; `DECBENCH_LLM_FN_WORKERS` decompiles a binary's sampled
   functions concurrently. On the SITE they are **sample-set-only** decompilers
   (`[decompilers] sample_set_only` in site.toml + `visibleDecs()` in app.js).
-  Default models: codex `gpt-5.6-sol`, claude-code `claude-opus-4-8`. NOTE: a
+  Default models: codex `gpt-5.6-sol`, claude-code `claude-opus-4-8`, kimi-code
+  `kimi-code/k3`. NOTE: a
   nested `claude` (launched from inside a Claude Code session) needs an isolated
   `CLAUDE_CONFIG_DIR` + a per-call OAuth credential RE-SYNC (a one-time copy goes
   stale) — the backend does both automatically. Full guide: `docs/LLM_DECOMPILERS.md`.

--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ decompiler's identity is `name` or `name@version` (e.g. `ghidra@12.0` vs
 
 The canonical `angr`/`ghidra`/`ida`/`binja` backends drive each tool's own API
 directly (no `declib`). Additional backends run in Docker: **RetDec**, **Reko**,
-and **r2dec** (build images with `decbench decompiler-build <name>`). Two **LLM
-coding agents** — **codex** and **claude-code** — are also registered as
-decompilers, one agentic CLI call per function; they run on the `sample-set`
-slice only (see [docs/LLM_DECOMPILERS.md](docs/LLM_DECOMPILERS.md)).
+and **r2dec** (build images with `decbench decompiler-build <name>`). Three **LLM
+coding agents** — **codex**, **claude-code**, and **kimi-code** — are also
+registered as decompilers, one agentic CLI call per function; they run on the
+`sample-set` slice only (see [docs/LLM_DECOMPILERS.md](docs/LLM_DECOMPILERS.md)).
 
 ## Results
 

--- a/decbench/decompilers/llm_dec.py
+++ b/decbench/decompilers/llm_dec.py
@@ -1,7 +1,8 @@
-"""LLM / coding-agent decompiler backends (Codex, Claude Code).
+"""LLM / coding-agent decompiler backends (Codex, Claude Code, Kimi Code).
 
-This family drives a **general coding agent** (OpenAI's ``codex`` CLI or
-Anthropic's ``claude`` CLI) as a decompiler: for each target function it hands
+This family drives a **general coding agent** (OpenAI's ``codex`` CLI,
+Anthropic's ``claude`` CLI, or Moonshot's ``kimi`` CLI) as a decompiler: for
+each target function it hands
 the agent the stripped binary and asks it to *manually* reconstruct the original
 C source — the agent is explicitly **forbidden from using any decompiler** and
 may only reach for simple disassemblers (``objdump``/``readelf``/``nm``/…). The
@@ -673,6 +674,10 @@ class _AgentDecompiler(Decompiler):
         token_dirs = (
             (home / ".codex", "/root/.codex"),
             (home / ".claude", "/root/.claude"),
+            (
+                Path(os.environ.get("KIMI_CODE_HOME") or home / ".kimi-code"),
+                "/root/.kimi-code",
+            ),
         )
         for host_dir, cont_dir in token_dirs:
             if host_dir.is_dir():
@@ -680,7 +685,15 @@ class _AgentDecompiler(Decompiler):
         for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
             if os.environ.get(key):
                 docker += ["-e", key]
-        docker += ["-e", "CODEX_HOME=/root/.codex", "-e", "HOME=/root", image]
+        docker += [
+            "-e",
+            "CODEX_HOME=/root/.codex",
+            "-e",
+            "KIMI_CODE_HOME=/root/.kimi-code",
+            "-e",
+            "HOME=/root",
+            image,
+        ]
         # Inside the container the workdir is /work, so rebuild the argv against it.
         argv = self._agent_argv(Path("/work"), prompt, model)
         return docker + argv, {"env": env}
@@ -893,5 +906,126 @@ class ClaudeCodeDecompiler(_AgentDecompiler):
             sessions = sorted(proj.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
             if sessions:
                 shutil.copy2(sessions[-1], dest)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@register_decompiler("kimi-code")
+class KimiCodeDecompiler(_AgentDecompiler):
+    """Moonshot Kimi Code CLI driven as a manual decompiler (default model k3)."""
+
+    name = "kimi-code"
+    display_name = "Kimi Code"
+    cli = "kimi"
+    # ``kimi-code/k3`` is the Kimi K3 model alias a Kimi Code OAuth (membership)
+    # login exposes; such logins also carry ``kimi-code/kimi-for-coding``
+    # (-highspeed). Pin via spec/config, e.g. ``-d kimi-code@kimi-code/k3``.
+    default_model = "kimi-code/k3"
+    # Kimi Code reads NO credential from the shell environment (an exported
+    # ``KIMI_API_KEY`` is ignored): auth is the OAuth store under
+    # ``$KIMI_CODE_HOME/credentials/`` or an ``api_key`` in ``config.toml``. The
+    # single env channel it honors is the ``KIMI_MODEL_*`` family (synthesized
+    # provider) — all three are handled in is_available().
+    cred_files = ()
+    cred_env = ()
+
+    @staticmethod
+    def _real_home() -> Path:
+        """The user's live Kimi Code home (``KIMI_CODE_HOME`` or ``~/.kimi-code``)."""
+        env = os.environ.get("KIMI_CODE_HOME")
+        return Path(env) if env else Path.home() / ".kimi-code"
+
+    def is_available(self) -> bool:
+        if shutil.which(self.cli) is None:
+            return False
+        home = self._real_home()
+        creds = home / "credentials"
+        if creds.is_dir() and any(creds.glob("*.json")):
+            return True
+        # The env-synthesized provider — the only credential channel read from env.
+        if os.environ.get("KIMI_MODEL_NAME") and os.environ.get("KIMI_MODEL_API_KEY"):
+            return True
+        # An API-key provider written into config.toml ([providers.*] api_key /
+        # [providers.*.env] KIMI_API_KEY). Presence check only; never logged.
+        cfg = home / "config.toml"
+        return cfg.is_file() and "api_key" in cfg.read_text(errors="replace")
+
+    def _agent_argv(self, workdir: Path, prompt: str, model: str) -> list[str]:
+        argv = [
+            self.cli,
+            "-p",
+            prompt,
+            "--output-format",
+            "text",
+            # Point skill discovery at an EMPTY directory: --skills-dir replaces
+            # the auto-discovered user and project skill dirs for this launch,
+            # so a `decompiler` skill (which drives real decompilers) cannot
+            # load. ``-p`` already runs under the auto permission policy (no
+            # approval prompts) — the kimi equivalent of claude's
+            # --dangerously-skip-permissions.
+            "--skills-dir",
+            str(self._empty_skills_dir()),
+        ]
+        if model:
+            argv += ["-m", model]
+        return argv
+
+    def _agent_env(self) -> dict[str, str]:
+        env = dict(os.environ)
+        # Run under an ISOLATED KIMI_CODE_HOME so benchmark calls never touch
+        # the user's live sessions/state; credentials + config.toml are synced
+        # from ~/.kimi-code, and its skills/ dir stays empty as
+        # defense-in-depth behind --skills-dir.
+        env["KIMI_CODE_HOME"] = str(self._isolated_kimi_home())
+        return env
+
+    def _isolated_kimi_home(self) -> Path:
+        """A decbench-owned KIMI_CODE_HOME: no skills, synced auth + config."""
+        import contextlib
+
+        override = self._opt("kimi_code_home", "DECBENCH_KIMI_CODE_HOME", "")
+        home = (
+            Path(override) if override else Path.home() / ".cache" / "decbench" / "kimi-code-home"
+        )
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "skills").mkdir(exist_ok=True)  # empty -> no Kimi-specific user skills
+        (home / "no-skills").mkdir(exist_ok=True)  # the --skills-dir target
+        src = self._real_home()
+        # Sync config.toml (providers/models) and the OAuth credential store
+        # from ~/.kimi-code only when the host copy is newer, so kimi's own
+        # in-place token refresh (into the isolated copies) is not clobbered.
+        s, d = src / "config.toml", home / "config.toml"
+        if s.is_file() and (not d.exists() or s.stat().st_mtime > d.stat().st_mtime):
+            with contextlib.suppress(Exception):
+                shutil.copy2(s, d)
+        src_creds = src / "credentials"
+        if src_creds.is_dir():
+            dst_creds = home / "credentials"
+            dst_creds.mkdir(exist_ok=True)
+            for c in src_creds.glob("*.json"):
+                d = dst_creds / c.name
+                if not d.exists() or c.stat().st_mtime > d.stat().st_mtime:
+                    with contextlib.suppress(Exception):
+                        shutil.copy2(c, d)
+        return home
+
+    def _empty_skills_dir(self) -> Path:
+        return self._isolated_kimi_home() / "no-skills"
+
+    def _copy_session_jsonl(self, workdir: Path, transcript: str, dest: Path) -> None:
+        """Copy kimi's ``wire.jsonl`` (the complete agent record, every tool call).
+
+        Sessions live under ``<KIMI_CODE_HOME>/sessions/<workDirKey>/<sessionId>/
+        agents/main/wire.jsonl``; each backend call runs in a fresh temp workdir,
+        so the most recently written wire log is this call's.
+        """
+        try:
+            root = self._isolated_kimi_home() / "sessions"
+            wires = sorted(
+                root.glob("*/*/agents/main/wire.jsonl"),
+                key=lambda p: p.stat().st_mtime,
+            )
+            if wires:
+                shutil.copy2(wires[-1], dest)
         except Exception:  # noqa: BLE001
             pass

--- a/decbench/rendering/content/decompilers.toml
+++ b/decbench/rendering/content/decompilers.toml
@@ -91,6 +91,12 @@ license = "closed-source"
 logo = true
 
 [[decompiler]]
+id = "kimi-code"
+display_name = "Kimi Code"
+url = "https://www.kimi.com/code"
+license = "closed-source"
+
+[[decompiler]]
 id = "retdec"
 display_name = "RetDec"
 url = "https://github.com/avast/retdec"

--- a/decbench/rendering/content/site.toml
+++ b/decbench/rendering/content/site.toml
@@ -42,14 +42,14 @@ normalize_title = "Only count functions that EVERY decompiler decompiled success
 hidden = ["phoenix"]
 
 # Decompilers shown ONLY on the `sample-set` view. The LLM/coding-agent backends
-# (codex, claude-code) are run on the sample-set slice only, so on every other
-# preset (unoptimized/optimized/inlined/large) they would have near-zero coverage
-# and look artificially bad under the shared-denominator leaderboard. Listing them
-# here keeps their rows off those views and shows them only where the comparison is
-# fair (all decompilers cover the same 250 functions). Their data still ships in the
-# payload; it is just not rendered outside the sample-set preset. Base-name match,
-# same as `hidden`.
-sample_set_only = ["codex", "claude-code"]
+# (codex, claude-code, kimi-code) are run on the sample-set slice only, so on
+# every other preset (unoptimized/optimized/inlined/large) they would have
+# near-zero coverage and look artificially bad under the shared-denominator
+# leaderboard. Listing them here keeps their rows off those views and shows them
+# only where the comparison is fair (all decompilers cover the same 250
+# functions). Their data still ships in the payload; it is just not rendered
+# outside the sample-set preset. Base-name match, same as `hidden`.
+sample_set_only = ["codex", "claude-code", "kimi-code"]
 
 # GitHub Pages custom domain. `decbench site build` writes it into the tree's
 # CNAME file; the authoritative routing for workflow deploys is the repo's Pages

--- a/docker/llm-agents.Dockerfile
+++ b/docker/llm-agents.Dockerfile
@@ -1,6 +1,6 @@
-# LLM coding-agent decompilers (Codex + Claude Code) in a container.
+# LLM coding-agent decompilers (Codex + Claude Code + Kimi Code) in a container.
 #
-# This image bundles both CLIs plus the *only* binary-inspection tools the
+# This image bundles the three CLIs plus the *only* binary-inspection tools the
 # agents are allowed to use (objdump/readelf/nm/strings/xxd/file). It carries NO
 # credentials: the decbench backend (decompilers/llm_dec.py, container mode) runs
 # it with the HOST's token dirs bind-mounted read-only and the API-key env vars
@@ -18,8 +18,10 @@
 # The backend adds, per agent call:
 #   docker run --rm -v <workdir>:/work -w /work \
 #     -v ~/.codex:/root/.codex:ro -v ~/.claude:/root/.claude:ro \
-#     -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CODEX_HOME=/root/.codex -e HOME=/root \
-#     decbench/llm-agents:latest <codex exec ... | claude -p ...>
+#     -v ~/.kimi-code:/root/.kimi-code:ro \
+#     -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CODEX_HOME=/root/.codex \
+#     -e KIMI_CODE_HOME=/root/.kimi-code -e HOME=/root \
+#     decbench/llm-agents:latest <codex exec ... | claude -p ... | kimi -p ...>
 #
 # To run it by hand for a smoke test:
 #   docker run --rm -v ~/.codex:/root/.codex:ro -e CODEX_HOME=/root/.codex \
@@ -37,13 +39,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-# The two coding-agent CLIs.
-RUN npm install -g @openai/codex @anthropic-ai/claude-code \
+# The three coding-agent CLIs.
+RUN npm install -g @openai/codex @anthropic-ai/claude-code @moonshot-ai/kimi-code \
     && npm cache clean --force
 
-# HOME defaults to /root; the backend mounts ~/.codex and ~/.claude there and
-# points CODEX_HOME at the mounted dir. Credentials never live in the image.
+# HOME defaults to /root; the backend mounts ~/.codex, ~/.claude and ~/.kimi-code
+# there and points CODEX_HOME/KIMI_CODE_HOME at the mounted dirs. Credentials
+# never live in the image.
 ENV HOME=/root \
-    CODEX_HOME=/root/.codex
+    CODEX_HOME=/root/.codex \
+    KIMI_CODE_HOME=/root/.kimi-code
 
 WORKDIR /work

--- a/docs/LLM_DECOMPILERS.md
+++ b/docs/LLM_DECOMPILERS.md
@@ -1,4 +1,4 @@
-# LLM / coding-agent decompilers (Codex, Claude Code)
+# LLM / coding-agent decompilers (Codex, Claude Code, Kimi Code)
 
 DecBench can benchmark a **general coding agent driven as a decompiler**. For
 each target function the agent is handed the (stripped) binary and asked to
@@ -8,19 +8,20 @@ decompiler** and may only use simple disassemblers (`objdump`, `readelf`, `nm`,
 the exact list). Its C output is scored by GED / type_match / byte_match exactly
 like Ghidra or IDA.
 
-Two backends ship today (`decbench/decompilers/llm_dec.py`):
+Three backends ship today (`decbench/decompilers/llm_dec.py`):
 
 | id            | tool            | default model        | credentials |
 |---------------|-----------------|----------------------|-------------|
 | `codex`       | OpenAI Codex CLI| `gpt-5.6-sol`        | `~/.codex/auth.json` **or** `OPENAI_API_KEY` |
 | `claude-code` | Claude Code CLI | `claude-opus-4-8`    | `~/.claude/.credentials.json` **or** `ANTHROPIC_API_KEY` |
+| `kimi-code`   | Kimi Code CLI   | `kimi-code/k3`       | `~/.kimi-code/credentials/` (OAuth) or `api_key` in `~/.kimi-code/config.toml` |
 
 Pin a model as a version spec so it becomes its own scoreboard column:
-`-d codex@gpt-5.6-sol`, `-d claude-code@claude-opus-4-8`.
+`-d codex@gpt-5.6-sol`, `-d claude-code@claude-opus-4-8`, `-d kimi-code@kimi-code/k3`.
 
 ## The shared prompt
 
-Both backends share one instruction, `LLM_DECOMPILE_PROMPT` in
+All three backends share one instruction, `LLM_DECOMPILE_PROMPT` in
 `decbench/decompilers/llm_dec.py`: reconstruct original-source-faithful C for
 one function under the **hard tool policy** above, and write only that
 function's C to `decompiled.c`. Per-function specifics (binary path, entry
@@ -71,13 +72,17 @@ model = "gpt-5.6-sol"  # the gpt-5.6 variant a ChatGPT-account login allows
 
 [claude-code.versions.default]
 model = "claude-opus-4-8"
+
+[kimi-code.versions.default]
+model = "kimi-code/k3"   # the Kimi K3 alias a Kimi Code OAuth login exposes
+# kimi_code_home = "~/.cache/decbench/kimi-code-home"  # isolated KIMI_CODE_HOME
 ```
 
 Env equivalents: `DECBENCH_LLM_MODEL`, `DECBENCH_LLM_TIMEOUT`,
 `DECBENCH_LLM_MAX_FUNCS`, `DECBENCH_LLM_FN_WORKERS`,
 `DECBENCH_LLM_DOCKER_IMAGE`. Per-decompiler wall-clock in the driver:
-`DECBENCH_CODEX_TIMEOUT` / `DECBENCH_CLAUDE_CODE_TIMEOUT` (default 3600s per
-binary).
+`DECBENCH_CODEX_TIMEOUT` / `DECBENCH_CLAUDE_CODE_TIMEOUT` /
+`DECBENCH_KIMI_CODE_TIMEOUT` (default 3600s per binary).
 
 **Traces.** Every agent call is traced by default (disable with
 `DECBENCH_LLM_SAVE_TRACES=0` / `save_traces = false`): the prompt, transcript,
@@ -105,6 +110,15 @@ By default the backends run the CLI **on the host**, but under a
   copy goes stale. When those OAuth credentials exist, `ANTHROPIC_API_KEY` is
   dropped (a set key shadows the much faster OAuth login); force the API-key
   path with `DECBENCH_CLAUDE_USE_API_KEY=1`.
+- **kimi-code** points `KIMI_CODE_HOME` at `~/.cache/decbench/kimi-code-home`
+  (override: `DECBENCH_KIMI_CODE_HOME` / `kimi_code_home`) and passes an empty
+  `--skills-dir` (which replaces all discovered skill dirs for the launch), so
+  no user/project skill — e.g. a `decompiler` skill driving real decompilers —
+  can load; `config.toml` + `credentials/` are synced from `~/.kimi-code` only
+  when the host copy is newer, so kimi's in-place OAuth refresh isn't
+  clobbered. Kimi Code reads **no** API key from the shell env (`export
+  KIMI_API_KEY=...` is ignored) — auth is the OAuth store under
+  `$KIMI_CODE_HOME/credentials/` or an `api_key` written in `config.toml`.
 
 ## Running in the project container (token inheritance)
 
@@ -128,8 +142,10 @@ outside" (the `docker/llm-agents.Dockerfile` header shows the same invocation):
 ```
 docker run --rm -v <workdir>:/work -w /work \
   -v ~/.codex:/root/.codex:ro -v ~/.claude:/root/.claude:ro \
-  -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CODEX_HOME=/root/.codex -e HOME=/root \
-  decbench/llm-agents:latest <codex exec ... | claude -p ...>
+  -v ~/.kimi-code:/root/.kimi-code:ro \
+  -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e CODEX_HOME=/root/.codex \
+  -e KIMI_CODE_HOME=/root/.kimi-code -e HOME=/root \
+  decbench/llm-agents:latest <codex exec ... | claude -p ... | kimi -p ...>
 ```
 
 ## How it fits the pipeline
@@ -145,7 +161,8 @@ parses the C signature into ABI-positioned arguments plus locals and scores
 them through the structured matcher (name-based text parsing only as a last
 resort). Before publishing, refresh the metric overlays as with any newly added
 decompiler — but note `scripts/reeval_ged.py` and `scripts/reeval_bytematch.py`
-hard-code a `DECOMPILERS` tuple that does **not** include `codex`/`claude-code`:
+hard-code a `DECOMPILERS` tuple that does **not** include the LLM backends
+(`codex`/`claude-code`/`kimi-code`):
 extend those tuples (and run `scripts/reeval_typematch.py`, which covers every
 decompiler in the checkpoints) so the overlays cover the LLM columns, then
 `scripts/rebuild_function_data.py`.

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -125,6 +125,7 @@ DECOMPILER_TIMEOUT = {
     # bounds a stuck call while still crediting finished functions.
     "codex": int(os.environ.get("DECBENCH_CODEX_TIMEOUT") or "3600"),
     "claude-code": int(os.environ.get("DECBENCH_CLAUDE_CODE_TIMEOUT") or "3600"),
+    "kimi-code": int(os.environ.get("DECBENCH_KIMI_CODE_TIMEOUT") or "3600"),
 }
 _HERE = Path(__file__).resolve().parent
 _DECOMPILE_ONE = _HERE / "decompile_one.py"
@@ -136,8 +137,8 @@ def _load_sampleset_manifest() -> dict[tuple[str, str, str], set[str]] | None:
     Restricts the whole run to the frozen ``sample-set`` slice (see
     ``scripts/export_sample_set.py``): a decompiler is only ever asked to
     decompile the listed function *names*, per ``(project, opt, binary_stem)``.
-    This is the cost gate for the LLM backends — with it set, codex/claude-code
-    run on ~250 functions instead of the whole corpus.
+    This is the cost gate for the LLM backends — with it set,
+    codex/claude-code/kimi-code run on ~250 functions instead of the whole corpus.
     """
     path = os.environ.get("DECBENCH_SAMPLESET_MANIFEST")
     if not path:
@@ -597,7 +598,8 @@ def main() -> int:
             "     DECBENCH_DECOMPILE_TIMEOUT, DECBENCH_{KUNA,ANGR,PHOENIX,GHIDRA,BINJA}_TIMEOUT,\n"
             "     DECBENCH_KUNA_MAX_FN_SECONDS, DECBENCH_DECOMPILE_ONLY, GHIDRA_INSTALL_DIR,\n"
             "     DECBENCH_SAMPLESET_MANIFEST (gate the run to the frozen sample-set slice;\n"
-            "       required for the LLM backends codex/claude-code — see docs/LLM_DECOMPILERS.md)."
+            "       required for the LLM backends codex/claude-code/kimi-code — see\n"
+            "       docs/LLM_DECOMPILERS.md)."
         )
         return 0
     out_dir = Path(args[0]) if args else Path("results/sailr_full")

--- a/tests/test_llm_decompilers.py
+++ b/tests/test_llm_decompilers.py
@@ -20,7 +20,7 @@ from decbench.models.decompilation import DecompilationResult
 
 
 def test_backends_register():
-    for name in ("codex", "claude-code"):
+    for name in ("codex", "claude-code", "kimi-code"):
         dec = DecompilerRegistry.get(name)
         assert dec.id == name
         assert dec.name == name
@@ -30,6 +30,10 @@ def test_versioned_spec_sets_model():
     dec = DecompilerRegistry.get("codex@gpt-5.6-sol")
     assert dec.id == "codex@gpt-5.6-sol"
     assert dec._model() == "gpt-5.6-sol"
+    # The kimi model alias itself contains a slash and a dash.
+    dec = DecompilerRegistry.get("kimi-code@kimi-code/k3")
+    assert dec.id == "kimi-code@kimi-code/k3"
+    assert dec._model() == "kimi-code/k3"
 
 
 def test_shared_prompt_states_the_policy():
@@ -122,7 +126,7 @@ def test_export_sample_set_shape():
     os.environ.get("DECBENCH_LLM_LIVE") != "1",
     reason="live agent call is opt-in (DECBENCH_LLM_LIVE=1) — paid + slow",
 )
-@pytest.mark.parametrize("name", ["codex", "claude-code"])
+@pytest.mark.parametrize("name", ["codex", "claude-code", "kimi-code"])
 def test_live_single_function(name, tmp_path):
     import shutil
     import subprocess


### PR DESCRIPTION
## Summary

**PR mainly made with Kimi Code using K3 model**

Adds a third LLM/coding-agent decompiler backend, **`kimi-code`**, which drives Moonshot's [Kimi Code CLI](https://www.kimi.com/code) (`kimi`) as a manual decompiler — default model **`kimi-code/k3`** (the Kimi K3 alias a Kimi Code OAuth login exposes). It joins `codex` and `claude-code` under the shared `_AgentDecompiler` driver in `decbench/decompilers/llm_dec.py`, so it inherits the common prompt (`LLM_DECOMPILE_PROMPT`), the per-function agent loop, the `max_funcs` cost cap, trace saving, and scoring through GED / type_match / byte_match exactly like every other backend. Like the other LLM backends it is meant to run on the `sample-set` slice only, gated by `DECBENCH_SAMPLESET_MANIFEST`.

```bash
DECBENCH_DECOMPILERS=kimi-code \
  DECBENCH_SAMPLESET_MANIFEST=results/full_run/sample_set_manifest.json \
  python scripts/run_benchmark.py results/full_run
```

A pinned model becomes its own scoreboard column as usual: `-d kimi-code@kimi-code/k3`.

## Backend design (mirrors codex / claude-code)

- **Invocation**: `kimi -p <prompt> --output-format text --skills-dir <empty-dir> [-m <model>]`, `cwd` set to a fresh per-function temp workdir holding an anonymized `target.bin`. `-p` is the headless mode and runs under the `auto` permission policy (no approval prompts) — the Kimi equivalent of claude's `--dangerously-skip-permissions`.
- **Decompiler-ban enforcement**: `--skills-dir` is pointed at an empty directory, which *replaces* all auto-discovered user/project skill dirs for the launch, so no `decompiler` skill (one that drives real decompilers) can load. The isolated home's own `skills/` dir is kept empty as defense-in-depth.
- **Auth**: Kimi Code deliberately reads **no** API key from the shell environment (`export KIMI_API_KEY=...` is ignored; keys live in `config.toml` under `[providers.*]`). `is_available()` therefore checks, in order: the OAuth store `$KIMI_CODE_HOME/credentials/*.json`, the `KIMI_MODEL_NAME`/`KIMI_MODEL_API_KEY` env family (the one env channel the CLI does honor), or an `api_key` present in `config.toml`.
- **Isolated home**: runs with `KIMI_CODE_HOME=~/.cache/decbench/kimi-code-home` (override via `kimi_code_home` config / `DECBENCH_KIMI_CODE_HOME`). `config.toml` (providers/models) and `credentials/` (OAuth) are synced from the real `~/.kimi-code` only when the host copy is newer, so the CLI's own in-place token refresh into the isolated copies is never clobbered — same pattern as codex's isolated `CODEX_HOME`.
- **Traces**: alongside the usual markdown trace, the backend copies the session's `agents/main/wire.jsonl` (Kimi Code's complete agent record — every tool call), the audit evidence for the no-decompilers policy.
- **Container mode**: the shared `_invocation` wrapper now also bind-mounts `~/.kimi-code` read-only (honoring a custom `KIMI_CODE_HOME` on the host) and exports `KIMI_CODE_HOME=/root/.kimi-code`; `docker/llm-agents.Dockerfile` now installs `@moonshot-ai/kimi-code` next to the codex/claude CLIs.

## Other changes

- `scripts/run_benchmark.py`: per-binary wall-clock knob `DECBENCH_KIMI_CODE_TIMEOUT` (default 3600s), matching the other LLM backends.
- Site content: `kimi-code` added to `sample_set_only` in `content/site.toml` (it will only ever cover the sample-set slice) and to the decompiler registry in `content/decompilers.toml` — without `logo = true`, since no `.dlogo-kimi-code` asset is shipped.
- Docs: `docs/LLM_DECOMPILERS.md` (backend table, config knobs, host-mode isolation bullet, container run example, reeval note), `README.md`, `CLAUDE.md`, `CHANGELOG.md`.
- Tests: registration now covers all three backends, plus a `kimi-code@kimi-code/k3` versioned-spec parsing test (the alias contains a slash), and the opt-in live test is parametrized over `kimi-code` too.

## Verification

- `pytest tests/test_llm_decompilers.py`: 9 passed, 5 skipped (skips need a results tree / are the opt-in paid live test).
- Full suite: 181 passed — identical pass/fail set to the pre-change baseline on this machine (the pre-existing failures/collection errors are missing local deps such as `mistune`, verified via `git stash`).
- `ruff check` and `black --check` clean on all touched Python files (remaining `run_benchmark.py` ruff warnings are pre-existing on `main`).
- Live smoke on macOS with a real Kimi Code login: `decbench list-decompilers` reports `kimi-code  Y  kimi-code/k3 (0.29.0)`.
- **Not done**: no real (paid) agent decompile was run — `DECBENCH_LLM_LIVE=1` remains the opt-in for that.

## Maintainer notes

- Publishing numbers requires a maintainer sample-set run with working Kimi credentials, then the usual overlay refresh: extend the hard-coded `DECOMPILERS` tuples in `scripts/reeval_ged.py` / `reeval_bytematch.py` to cover the LLM columns (they currently list only the traditional decompilers), run `reeval_typematch.py` + `rebuild_function_data.py`, and rebuild the site.
- Rebuild the `decbench/llm-agents` image for container mode (`decbench decompiler-build`-adjacent: `docker build -f docker/llm-agents.Dockerfile -t decbench/llm-agents:latest docker/`).
