### PR TITLE
Markdownify the site HTML

### DIFF
--- a/decbench/rendering/assets/app.css
+++ b/decbench/rendering/assets/app.css
@@ -192,6 +192,34 @@ h2.view-title:before { content: "## "; color: var(--text-muted); }
 h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
 h3.sub:before { content: "> "; color: var(--text-muted); }
 
+/* ---- Prose lists ----
+   Markdown bodies (the changelog's dated entries, any bulleted prose) render to
+   plain <ul>/<ol>. The browser default — ~40px indent and disc bullets — floats
+   the markers left of the terminal content column and clashes with the `## `/`> `
+   heading prefixes. Scope compact, muted, dash-marked lists to the content area so
+   a bullet reads like a terminal `- ` line and items sit under their date heading.
+   .view ul/ol/li here only ever match markdown output — no scaffold uses lists. */
+.view ul, .view ol {
+    margin: 0.45rem 0 1.1rem;
+    padding-left: 1.4em;
+    font-size: 0.9em;
+    line-height: 1.55;
+}
+.view li { margin: 0.3rem 0; }
+.view li::marker { color: var(--text-muted); }
+.view ul { list-style: none; }
+.view ul > li { position: relative; }
+.view ul > li::before {
+    content: "-";
+    position: absolute;
+    left: -1.4em;
+    color: var(--text-muted);
+}
+.view ol { list-style: decimal; }
+/* Nested lists share the gutter, don't compound the shrink, and lose the trailing
+   block margin so a sub-list hugs its parent item. */
+.view li > ul, .view li > ol { margin: 0.3rem 0 0; font-size: 1em; }
+
 /* ---- Tables ---- */
 table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
 th, td {

--- a/decbench/rendering/content/about.md
+++ b/decbench/rendering/content/about.md
@@ -7,6 +7,13 @@ sits near the end of the nav (just before changelog). The starting-page prose is
 split between the two — the
 short intro above the table lives in leaderboard.md, the long explainer is here.
 
+WRITE PLAIN MARKDOWN (the shared conventions live in leaderboard.md): prose is
+**bold**/*italic*/[links](url)/`code` with literal unicode punctuation (— · ≥),
+not <strong>/<em>/<a>/&mdash;. Raw HTML is only for the required scaffolds/hooks
+below (elements with ids, the <div class="recovered"> callout) and the
+hand-authored metric-viz "islands" — which markdown does NOT reach inside, so
+their contents stay hand-written HTML (leave them exactly as they are).
+
 This page absorbed the old `metrics` and `dataset` views, so it is the one
 place that explains WHY the benchmark exists, WHAT the three metrics measure
 (the `## [n]` goal cards below — the renderer turns each into a
@@ -19,7 +26,7 @@ GOAL CARDS. The `## [n] ...` sections are STRUCTURED:
   ## [n] <card title>              -> <div class="goal-head"><span class="num">[n]</span>...
   metric: <metric display name>    -> <div class="goal-metric">metric: ...
                                       Must match a `display_name` in metrics.toml.
-  <body prose + markup>            -> <div class="goal-body">...
+  <body prose, plain markdown>     -> <div class="goal-body">...
   **perfect =** <definition>       -> <span class="perfect">perfect = ...</span>
                                       Must repeat that metric's `perfect_definition`
                                       from metrics.toml verbatim; the test suite
@@ -68,14 +75,14 @@ inaccurate, we use multiple metrics described below.
 ### the three metrics
 
 Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
-decompilation that is <em>nearly</em> right is still a thing you have to read
+how often a decompiler gets each *perfect* — because a
+decompilation that is *nearly* right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.
 
 ## [1] Control-flow structure correctness
 metric: Structural Correctness (GED)
 
-Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.
+Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.
 
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
@@ -310,9 +317,9 @@ Did the decompiler recover the right variable and argument types? We match the d
 ## [3] Recompilation correctness
 metric: Recompilation Bytematch
 
-Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.
+Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.
 
-The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.
+The leaderboard's **Compiles** column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.
 
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
@@ -408,9 +415,9 @@ The leaderboard's <strong>Compiles</strong> column reports the first half of thi
 ### pipeline health (our own tooling)
 
 GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the **source**, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
-them). When Joern fails on a single decompiler's <strong>output</strong>,
+them). When Joern fails on a single decompiler's **output**,
 that's reported here (per decompiler), not folded into the headline score.
 
 <div id="joern-source" class="goal"></div>

--- a/decbench/rendering/content/distance.md
+++ b/decbench/rendering/content/distance.md
@@ -3,16 +3,16 @@
 # distance
 
 When a decompiler can't yet achieve a perfect score on a function, it can be
-helpful to understand the <em>distance</em> it is from perfection. For each
+helpful to understand the *distance* it is from perfection. For each
 metric, we measure distance as the number of edits required to convert that
-form of data into its source-code equivalent. For <strong>GED</strong>, that
+form of data into its source-code equivalent. For **GED**, that
 is the number of edits to control-flow structures. For
-<strong>types</strong>, that is the number of type-flips needed to reach
-ground truth. For <strong>recompilation</strong>, that is the number of
+**types**, that is the number of type-flips needed to reach
+ground truth. For **recompilation**, that is the number of
 assembly lines that must change to convert the recompiled assembly into the
 ground-truth assembly.
 
-Each cell shows the <em>mean</em>, the <em>median</em>, and how many functions
+Each cell shows the *mean*, the *median*, and how many functions
 are already at distance 0 (perfect), averaged over the functions each
 decompiler was scored on.
 
@@ -30,7 +30,7 @@ full-coverage rows above.</p>
 ### compiles
 
 The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually *recompiled* after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves

--- a/decbench/rendering/content/leaderboard.md
+++ b/decbench/rendering/content/leaderboard.md
@@ -7,13 +7,22 @@ decbench/rendering/content.py):
   # [empty] <title>    the empty-state section, shown when the view has no data.
                        Omit the title to reuse the main one.
   # [outro]            body content that the renderer places AFTER its generated
-                       markup (see metrics.md).
+                       markup (see about.md).
 
-Markdown paragraphs become <p class="view-desc">, `###` becomes <h3 class="sub">.
-Inline HTML (<em>, <strong>, &mdash;) is passed through UNESCAPED — it is already
-final markup. HTML comments like this one are stripped before rendering. Static
-scaffold elements (empty divs/tables the JS fills in) live here too, so prose and
-scaffold keep their order; data-dependent tables are appended by the renderer.
+WRITE PLAIN MARKDOWN. Prose is markdown, not HTML: **bold**, *italic*,
+[text](url), `code`, and literal unicode punctuation (— · ≥) — never
+<strong>/<em>/<a> tags or &mdash;/&middot;/&ge; entities. Paragraphs become
+<p class="view-desc">, `###` becomes <h3 class="sub">, `- ` bullets become styled
+lists.
+
+Reach for raw HTML ONLY where markdown can't carry the meaning: scaffold elements
+the JS fills or toggles (anything with an id — <table id=...>, <div id=...>,
+<p id=...>), styling hooks (<div class="recovered">), and the hand-authored
+metric-viz "islands" in about.md. Inline HTML still passes through UNESCAPED when
+you do use it (it is treated as final markup), so keep raw tags to those cases.
+HTML comments like this one are stripped before rendering. Static scaffold
+elements live here too, so prose and scaffold keep their order; data-dependent
+tables are appended by the renderer.
 
 THIS is the page the site opens on (`default = true` in views.toml), so the prose
 below is the first text a visitor reads. The empty #leaderboard-dataset-desc div
@@ -32,8 +41,8 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
-<em>at least one</em> of those metrics. Click a column to sort.
+initially ranked by Union — their ability to score perfectly on
+*at least one* of those metrics. Click a column to sort.
 
 AI can also compete on these metrics, as seen on the
 [sample-set leaderboard](https://decbench.com/leaderboard/?dataset=sample-set)

--- a/decbench/rendering/content/view.md
+++ b/decbench/rendering/content/view.md
@@ -11,11 +11,11 @@ the contract with app.js's initView/renderView.
 
 # view
 
-Original source next to a decompiler's output. <strong>Difficulty</strong> is
+Original source next to a decompiler's output. **Difficulty** is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+**easy** — most decompilers recover the control flow
+perfectly; **hard** — the functions farthest from perfect
+for everyone (the old hall of shame); **medium** — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.
 
 <div class="controls">

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/site/app.css
+++ b/site/app.css
@@ -192,6 +192,34 @@ h2.view-title:before { content: "## "; color: var(--text-muted); }
 h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
 h3.sub:before { content: "> "; color: var(--text-muted); }
 
+/* ---- Prose lists ----
+   Markdown bodies (the changelog's dated entries, any bulleted prose) render to
+   plain <ul>/<ol>. The browser default — ~40px indent and disc bullets — floats
+   the markers left of the terminal content column and clashes with the `## `/`> `
+   heading prefixes. Scope compact, muted, dash-marked lists to the content area so
+   a bullet reads like a terminal `- ` line and items sit under their date heading.
+   .view ul/ol/li here only ever match markdown output — no scaffold uses lists. */
+.view ul, .view ol {
+    margin: 0.45rem 0 1.1rem;
+    padding-left: 1.4em;
+    font-size: 0.9em;
+    line-height: 1.55;
+}
+.view li { margin: 0.3rem 0; }
+.view li::marker { color: var(--text-muted); }
+.view ul { list-style: none; }
+.view ul > li { position: relative; }
+.view ul > li::before {
+    content: "-";
+    position: absolute;
+    left: -1.4em;
+    color: var(--text-muted);
+}
+.view ol { list-style: decimal; }
+/* Nested lists share the gutter, don't compound the shrink, and lose the trailing
+   block margin so a sub-list hugs its parent item. */
+.view li > ul, .view li > ol { margin: 0.3rem 0 0; font-size: 1em; }
+
 /* ---- Tables ---- */
 table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
 th, td {

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view active" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/site/distance/index.html
+++ b/site/distance/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/site/index.html
+++ b/site/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/site/leaderboard/index.html
+++ b/site/leaderboard/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/site/view/index.html
+++ b/site/view/index.html
@@ -59,7 +59,7 @@ point where they can recover the exact source code from various binaries. This
 benchmark ranks decompilers by their ability to recover exact source code,
 measured across three metrics. All metrics are shown as the percentage of
 functions on which a decompiler achieves a perfect score. Decompilers are
-initially ranked by Union &mdash; their ability to score perfectly on
+initially ranked by Union — their ability to score perfectly on
 <em>at least one</em> of those metrics. Click a column to sort.</p>
 <p class="view-desc">AI can also compete on these metrics, as seen on the
 <a href="https://decbench.com/leaderboard/?dataset=sample-set">sample-set leaderboard</a>
@@ -96,7 +96,7 @@ full-coverage rows above.</p>
 
 <h3 class="sub">compiles</h3>
 <p class="view-desc">The share of each decompiler's byte_match-measured functions whose output
-actually <em>recompiled</em> after the uniform compilability-fixup pass &mdash; a
+actually <em>recompiled</em> after the uniform compilability-fixup pass — a
 fairness control, not a metric (type recovery is scored separately). The
 denominator is per-decompiler: functions where byte_match was measurable, so
 ARM / PE targets with no host recompiler never count against it. This rate moves
@@ -111,9 +111,9 @@ overlap with the sample-set slice.</p>
         <h2 class="view-title">view</h2>
         <p class="view-desc">Original source next to a decompiler's output. <strong>Difficulty</strong> is
 derived from structural (GED) agreement across decompilers:
-<strong>easy</strong> &mdash; most decompilers recover the control flow
-perfectly; <strong>hard</strong> &mdash; the functions farthest from perfect
-for everyone (the old hall of shame); <strong>medium</strong> &mdash; in
+<strong>easy</strong> — most decompilers recover the control flow
+perfectly; <strong>hard</strong> — the functions farthest from perfect
+for everyone (the old hall of shame); <strong>medium</strong> — in
 between. Pick a difficulty, a decompiler, and a metric to highlight.</p>
 <div class="controls">
     <label for="view-difficulty">difficulty:</label>
@@ -160,13 +160,13 @@ source code of a function. Since measuring this with pure strings is
 inaccurate, we use multiple metrics described below.</p>
 <h3 class="sub">the three metrics</h3>
 <p class="view-desc">Decompilation has three separable goals, so we measure three things and report
-how often a decompiler gets each <em>perfect</em> &mdash; because a
+how often a decompiler gets each <em>perfect</em> — because a
 decompilation that is <em>nearly</em> right is still a thing you have to read
 twice. Expand the panel inside each card to see how the metric actually works.</p>
         <div class="goal">
             <div class="goal-head"><span class="num">[1]</span>Control-flow structure correctness</div>
             <div class="goal-metric">metric: Structural Correctness (GED)</div>
-            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) &mdash; the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
+            <div class="goal-body"><p>Does the decompiled code branch and loop the same way the source does? We compare the control-flow graphs of the source and the decompilation with a Graph Edit Distance (GED) — the number of node/edge insertions, deletions, and substitutions needed to turn one CFG into the other.</p>
 <details class="metric-viz" open>
 <summary>how GED works: source &rarr; CFG &rarr; graph diff</summary>
 <div class="viz-wrap">
@@ -395,8 +395,8 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
         <div class="goal">
             <div class="goal-head"><span class="num">[3]</span>Recompilation correctness</div>
             <div class="goal-metric">metric: Recompilation Bytematch</div>
-            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly &mdash; normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
-<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own &mdash; the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
+            <div class="goal-body"><p>Does the decompiled code recompile to the same machine code? We run a uniform compilability fixup (define decompiler pseudo-types, strip illegal symbol-version tokens, declare missing symbols) so every decompiler gets a fair shot at building, recompile each function with the original toolchain, and compare the resulting assembly — normalizing link-time-dependent operands (call/jump targets, PC-relative offsets) so only real differences count.</p>
+<p>The leaderboard's <strong>Compiles</strong> column reports the first half of this on its own — the share of a decompiler's output that the fixup got to build at all (before any assembly comparison). It is measured only where a matching recompiler exists (x86); ARM/PE firmware and malware abstain rather than count as failures.</p>
 <details class="metric-viz" open>
 <summary>how bytematch works: fixup &rarr; recompile &rarr; normalized asm diff</summary>
 <div class="viz-wrap">
@@ -483,7 +483,7 @@ GED = <span class="n">3</span> &nbsp;&mdash;&nbsp; 1 node insertion + 2 edge ins
 
 <h3 class="sub">pipeline health (our own tooling)</h3>
 <p class="view-desc">GED depends on Joern parsing both the source and the decompiler output.
-When Joern fails on the <strong>source</strong>, that's our tooling &mdash; those
+When Joern fails on the <strong>source</strong>, that's our tooling — those
 functions are excluded from GED for every decompiler (never counted against
 them). When Joern fails on a single decompiler's <strong>output</strong>,
 that's reported here (per decompiler), not folded into the headline score.</p>
@@ -498,6 +498,12 @@ that's reported here (per decompiler), not folded into the headline score.</p>
     <section class="view" id="view-changelog" data-view="changelog">
         <h2 class="view-title">Changelog</h2>
         <p class="view-desc">Significant changes to DecBench that introduce or update results.</p>
+<h3 class="sub">2026-07-23</h3>
+<ul>
+<li>Added a third LLM/coding-agent decompiler backend: <strong>kimi-code</strong> (Kimi Code
+CLI, default model <code>kimi-code/k3</code>), benchmarked on the sample-set slice like
+codex/claude-code.</li>
+</ul>
 <h3 class="sub">2026-07-22</h3>
 <ul>
 <li><strong>DecBench goes live</strong> with support for 7 traditional decompilers, 2 LLMs (partial), and 3 defining metrics.</li>

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -92,11 +92,48 @@ def test_empty_states_are_parsed(content: Content) -> None:
 
 
 def test_inline_html_passes_through_unescaped(content: Content) -> None:
-    """The prose is final markup: tags and entities must survive rendering."""
-    body = content.view("leaderboard").body_html
-    assert "<em>at least one</em>" in body
-    assert "&mdash;" in body
-    assert "&amp;mdash;" not in body
+    """Prose is markdown now, but the scaffolds and hand-authored viz islands are
+    still final markup: their raw tags and entities must survive rendering
+    byte-for-byte (the renderer's verbatim text() must not re-escape them)."""
+    # A scaffold element (JS fills it) passes through verbatim — the view page's
+    # selector controls.
+    assert '<div class="controls">' in content.view("view").body_html
+    # The about page's .recovered callout is a raw-HTML styling hook, so its
+    # <strong> is passed through untouched (markdown is not parsed inside a
+    # raw-HTML block, so the tag is the only way to bold there).
+    assert "<strong>at least one</strong>" in content.view("about").outro_html
+    # The metric-viz islands keep their hand-authored entities — not double-escaped.
+    ged = next(g for g in content.view("about").goals if g.metric_key == "ged")
+    assert "&mdash;" in ged.body_html
+    assert "&amp;mdash;" not in ged.body_html
+
+
+def test_prose_renders_markdown_constructs(content: Content) -> None:
+    """View-body prose is authored as plain markdown: bold/italic/links/inline code
+    must render to real HTML, and literal unicode must not round-trip to entities.
+
+    Guards the markdown-first rule — the literal `**`/`*`/`[..]` must be gone, and
+    a bold run in a view body must become <strong>."""
+    lb = content.view("leaderboard").body_html
+    # *italic* -> <em>, and the literal markdown is consumed.
+    assert "<em>at least one</em>" in lb
+    assert "*at least one*" not in lb
+    # [text](url) -> <a href>.
+    assert '<a href="https://mahaloz.re/dec-history-pt1">the last 30 years</a>' in lb
+    # Literal unicode punctuation survives; it does NOT come back as an entity.
+    assert "—" in lb
+    assert "&mdash;" not in lb
+    # **bold** -> <strong> in a view body (the distance page).
+    di = content.view("distance").body_html
+    assert "<strong>GED</strong>" in di
+    assert "**GED**" not in di
+    # Inline `code` -> <code> (also the changelog injection path, which renders
+    # markdown bullets as lists).
+    injected = content.with_view("changelog", "# changelog\n\n- run `foo()` and **bar**.")
+    body = injected.view("changelog").body_html
+    assert "<code>foo()</code>" in body
+    assert "<strong>bar</strong>" in body
+    assert "<li>run <code>foo()</code> and <strong>bar</strong>.</li>" in body
 
 
 def test_convention_comments_are_stripped(content: Content) -> None:


### PR DESCRIPTION
Makes the site's editable text markdown-first, per maintainer request: prose is now plain markdown everywhere HTML isn't structurally required.

## What changed

- **leaderboard.md / distance.md / view.md / about.md** — prose converted to markdown (`**bold**`, `*italic*`, `[links](url)`, `` `code` ``, literal `—` `·` `≥`); no more inline `<strong>/<em>/<a>` or `&mdash;`-style entities in prose. This is a formatting conversion — the launch wording is preserved verbatim (verified by diffing rendered markup against the live pages).
- **Kept as HTML (load-bearing only):** id-carrying scaffolds the JS fills (`<table id=…>`, `<div id=…>`, the view page's selector controls), styling hooks (`.recovered`), and the three `metric-viz` islands on the about page (untouched per request).
- **Convention comments rewritten** in the content files: *write plain markdown; reach for HTML only for scaffolds/ids/islands* — so future edits stay easy.
- **List rendering fix:** the stylesheet had no `ul/ol/li` rules at all, so changelog bullets rendered as browser-default discs floating ~40px out of the terminal column. `.view` lists now use muted `-` dash markers on the `view-desc` rhythm (echoing the `>` heading prefix), consistent nesting, both themes.

## Verification

- 102 tests green (one new: markdown constructs render as `<strong>/<a>/<em>/<code>`; the inline-HTML passthrough test repointed at the remaining legit HTML).
- No renderer changes needed — the verbatim `text()` override already passes unicode through, and mistune's defaults handle the markdown constructs.
- Site rebuilt from the published data generation: `aggregates/dataset/samples.json` **byte-identical** to what's deployed — this PR changes markup only.
- Both-theme screenshots of all five affected pages reviewed, including the about page's metric visualizations (intact).

Note: `site/` is included so merging deploys directly; if main's `site/` moves before merge, rebase + rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTjse8cCxDGmE2qbxF3FXv