### PR TITLE
docs: record that preprocessed .i files are required (GED source CFGs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,6 +475,24 @@ label for the noinline variants.
   `function_results.json`, but anything else reading `scoreboard.decompilers`
   after a resume sees a partial list until the next full rebuild
   (`scripts/rebuild_function_data.py`).
+- **Preprocessed `.i` files are REQUIRED — GED's source CFGs come EXCLUSIVELY
+  from them.** `pipeline/evaluate.py` (via `project.preprocessed_sources`),
+  `scripts/run_benchmark.py`, and `pipeline/executor.py` (which globs
+  `compiled_dir/*.i`) all build the source-side CFGs by feeding `.i` files to
+  `utils/cfg.py extract_cfgs_from_source` (system headers stripped, then
+  pyjoern `parse_source`). `.i` over `.c` is deliberate: Joern needs
+  macro-expanded, ifdef-resolved code to parse completely — raw `.c` with
+  unexpanded includes parses incompletely. Without `.i` the pipeline takes the
+  "No preprocessed sources" branch and GED is silently None for every function
+  of the run — no error. byte_match/type_match don't use `.i`
+  (`requires_source_cfg = False`; gcc-recompile and DWARF respectively), and
+  sample source extraction only *falls back* to `.i` (see next bullet). So do
+  NOT disable `Project.emit_preprocessed` (default True,
+  `models/project.py`) or `-save-temps=obj` in the default `base_flags`
+  (`compilers/gcc.py`). The only `.i`-free evaluation path is the
+  published-dataset `--source-cfgs` flow (precomputed `source_cfgs/*.json`,
+  built FROM `.i` at publish time by `publish/cfg_export.py`) — and that path
+  cannot score type_match.
 - **Sample source extraction needs `.c`/`.i` next to the binary.** Compile now
   `rglob`s `.c` sources; older trees' samples used the preprocessed `.i` fallback
   (`SampleEntry.source_status` `"preprocessed"`). A rebuild via

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ This produces, under `results/sailr_full/`:
   **hardest** functions, per-decompiler **compile rates**)
 - `<opt>/<project>/{compiled,decompiled,evaluated}/` — intermediate artifacts
 
+The `compiled/` directories keep the preprocessed `.i` sources emitted at build
+time (`-save-temps=obj`) alongside the binaries — they are **required**, not
+build debris: GED's source-side CFGs are parsed exclusively from them, because
+Joern needs macro-expanded, ifdef-resolved code to parse completely (raw `.c`
+with unexpanded includes does not). Without the `.i` files, GED is silently
+skipped for the entire run.
+
 ### Re-scoring byte-match without re-decompiling
 
 Decompilation is the slow part. To re-score only byte-match over an existing tree


### PR DESCRIPTION
## Summary
Investigation of whether the preprocessed `.i` files are still needed by the evaluation pipeline. **Conclusion: yes — they are load-bearing for GED**, so no flags are removed; this PR documents the finding so the question doesn't recur.

## Findings
- The standard pipeline builds GED's source-side CFGs **exclusively** from `.i` files: `pipeline/evaluate.py` (via `project.preprocessed_sources`), `scripts/run_benchmark.py`, and `pipeline/executor.py` (globs `compiled_dir/*.i`) all feed `.i` to `utils/cfg.py extract_cfgs_from_source` → pyjoern. Without `.i`, the pipeline takes the "No preprocessed sources" branch and **GED is silently None for every function of the run — no error**.
- `.i` over `.c` is deliberate: Joern needs macro-expanded, ifdef-resolved code to parse completely; raw `.c` with unexpanded includes parses incompletely.
- `byte_match` and `type_match` do **not** use `.i` (`requires_source_cfg = False`; gcc-recompile and DWARF respectively).
- Sample-source extraction uses `.c` first; `.i` is only the fallback (`utils/source_extract.py`, status `"preprocessed"`).
- The only `.i`-free evaluation path is the published-dataset flow (`--source-cfgs` + `source_cfgs/*.json` precomputed **from** `.i` by `publish/cfg_export.py`) — and that path cannot score type_match.

## Changes
- `CLAUDE.md`: new Gotchas bullet ("Preprocessed `.i` files are REQUIRED…") with the generation knobs (`Project.emit_preprocessed`, `-save-temps=obj`) marked do-not-disable.
- `README.md`: short note that `compiled/` keeps `.i` files by design, not as build debris.

No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bc2JFopWxvwvyVWGQtJBt