### PR TITLE
docker: experimental MSVC (msvc-wine) compile container + zlib smoke

### DIFF
--- a/docker/msvc.Dockerfile
+++ b/docker/msvc.Dockerfile
@@ -1,0 +1,64 @@
+# EXPERIMENTAL MSVC (cl.exe under Wine) compile image for Windows/PE targets.
+#
+# Uses msvc-wine (https://github.com/mstorsjo/msvc-wine): vsdownload.py fetches
+# the MSVC Build Tools + Windows SDK from Microsoft's official servers (the
+# same manifests the Visual Studio installer uses), install.sh lays out Unix
+# wrapper scripts (cl/link/lib/nmake/rc/dumpbin/... in /opt/msvc/bin/<arch>)
+# that run the real Windows tools under Wine. LICENSING: the download requires
+# accepting the Visual Studio license (--accept-license below) and the
+# installed toolchain is NOT redistributable — build this image locally, never
+# push it to a registry.
+#
+# Like compile.Dockerfile this is a COMPILE-ONLY image: decompilation of the
+# produced PEs runs on the host (ghidra/ida/binja/angr load PE natively).
+# MSVC emits PDB/CodeView debug info, NOT DWARF — see docs/MSVC_SUPPORT.md for
+# what that means for the metrics. llvm-pdbutil (llvm package) is included for
+# PDB ground-truth inspection.
+#
+# Build (from the repo root; the MSVC download is several GB — expect 30-60 min):
+#         docker build -f docker/msvc.Dockerfile -t decbench-msvc .
+# Smoke:  docker run --rm -v "$PWD":/workspace -w /workspace \
+#           --user "$(id -u):$(id -g)" decbench-msvc \
+#           python3 scripts/msvc_compile_smoke.py /workspace/msvc_smoke_out
+#         (running as the host user creates a fresh throwaway Wine prefix on
+#         first use — ~10 s one-time; root already has one baked in. GOTCHA:
+#         wine refuses a $HOME the uid does not own — e.g. `-e HOME=/tmp` —
+#         and msvc-wine's fifo wrappers then HANG instead of failing; the smoke
+#         script self-provisions a wine-safe HOME for that reason.)
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wine wine64 winbind msitools ca-certificates \
+    python3 git wget curl unzip file binutils llvm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Initialize the (root) wine prefix; wait for wineserver to exit so the
+# prefix isn't corrupted mid-write (upstream msvc-wine Dockerfile convention).
+RUN $(command -v wine64 || command -v wine || false) wineboot --init && \
+    while pgrep wineserver > /dev/null; do sleep 1; done
+
+# Pin msvc-wine for reproducibility of the wrapper layout (the MSVC payload
+# itself is whatever Microsoft's manifest currently serves; vsdownload prints
+# the exact toolchain version at build time).
+ARG MSVC_WINE_REF=514f8ea34842cd6d831804d0e9658d3a32870ae1
+RUN git clone https://github.com/mstorsjo/msvc-wine.git /opt/msvc-wine && \
+    git -C /opt/msvc-wine checkout --detach "$MSVC_WINE_REF"
+
+# Download MSVC + Windows SDK (x86/x64 only — no arm target libs) and install
+# the Unix wrappers. This is the multi-GB layer; on a transient download
+# failure just re-run the build (earlier layers are cached).
+RUN PYTHONUNBUFFERED=1 /opt/msvc-wine/vsdownload.py --accept-license \
+        --architecture x86 x64 --dest /opt/msvc && \
+    /opt/msvc-wine/install.sh /opt/msvc && \
+    cp /opt/msvc-wine/msvcenv-native.sh /opt/msvc/
+
+# msvc-wine conventions: BIN points at the target-arch wrapper dir; putting it
+# on PATH makes cl/link/nmake/rc "just work" (each wrapper execs Wine itself).
+ENV BIN=/opt/msvc/bin/x64
+ENV PATH=/opt/msvc/bin/x64:$PATH
+ENV WINEDEBUG=-all
+
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/docs/MSVC_SUPPORT.md
+++ b/docs/MSVC_SUPPORT.md
@@ -1,0 +1,163 @@
+# MSVC / Windows-binary support (experimental)
+
+Status: **prototype** — a working compile container + smoke test, no pipeline
+integration yet. This documents what works today, what each metric needs, and
+the integration plan.
+
+DecBench's PE story so far is MinGW-only: the malware targets
+(`projects/malware/`) are C sources cross-compiled with `gcc-mingw-w64`, which
+emits **DWARF** into the PE — so the whole DWARF-based ground-truth stack
+(`decbench/utils/binfmt.py`) works unchanged. Real-world Windows software is
+built with **MSVC**, which emits **PDB/CodeView, never DWARF** — a different
+ground-truth universe. This prototype answers: can we build with *real* MSVC
+(`cl.exe`) on the Linux benchmark host, and what would metric coverage look
+like?
+
+## What works today
+
+### Compiling with real cl.exe in Docker (`docker/msvc.Dockerfile`)
+
+The `decbench-msvc` image uses [msvc-wine](https://github.com/mstorsjo/msvc-wine):
+`vsdownload.py` downloads the MSVC Build Tools + Windows SDK from Microsoft's
+official servers (the same manifests the Visual Studio installer uses) and
+`install.sh` wraps `cl`/`link`/`lib`/`nmake`/`rc`/... as Unix scripts running
+the real Windows tools under Wine. x86 + x64 target architectures are
+installed.
+
+```bash
+docker build -f docker/msvc.Dockerfile -t decbench-msvc .   # multi-GB download
+docker run --rm -v "$PWD":/workspace -w /workspace -e HOME=/tmp \
+  --user "$(id -u):$(id -g)" decbench-msvc \
+  python3 scripts/msvc_compile_smoke.py /workspace/msvc_smoke_out
+```
+
+The smoke test builds **zlib 1.3.1** with its own `win32/Makefile.msc` via
+`nmake` in two variants — the Makefile default (`-O2 -Oy- -Zi`, PDB via
+`link -debug`) and a `-Od -Zi` override — and verifies: x86-64 PEs are
+produced (`zlib1.dll`, `example.exe`, `minigzip.exe`), PDBs exist, **no**
+`.debug_*` sections exist, `llvm-pdbutil` can read functions/locals/types from
+the PDB, and `cl -P` emits preprocessed sources.
+
+**Verified 2026-07-23** on the benchmark host: image builds in ~15 min
+(2.5 GB download from Microsoft's servers, 6.62 GB image; MSVC 19.51.36252
+/ toolset 14.51.36231, Windows 11 SDK 10.0.26100.16), both zlib variants
+compile and link in seconds, and the smoke test passes end to end.
+
+Wine gotcha (handled by the smoke script): wine refuses a `$HOME` the
+invoking uid does not own (e.g. `-e HOME=/tmp` with `--user`), and msvc-wine's
+fifo-based wrappers then **hang** instead of failing — the script
+self-provisions a wine-safe HOME, so don't pass one.
+
+### Licensing
+
+`vsdownload.py --accept-license` accepts the Visual Studio license
+non-interactively (msvc-wine's maintainer documents this tradeoff; the same
+manifests drive Microsoft's own installer). The installed toolchain is **not
+redistributable**: build the image locally, never push it to a registry. This
+mirrors how the IDA/Binary Ninja backends already depend on local,
+non-redistributable installs.
+
+### Decompiling MSVC PEs
+
+Needs nothing new: the raw backends + executor already discover and load PE
+(ghidra/ida/binja/angr all decompile the MinGW malware PEs today). An MSVC PE
+is just another PE to them.
+
+## What the metrics need (the real gap: DWARF vs PDB)
+
+Every piece of decbench ground truth is DWARF-based today
+(`decbench/utils/binfmt.py`):
+
+| consumer | DWARF use today | MSVC-PE status |
+|---|---|---|
+| run driver function filter | `decl_file` (`project_source_functions`) | **missing** — needs PDB function names + module (compiland) provenance |
+| `type_match` | variable DIEs (name/type/location) | **missing** — needs a PDB variable reader (does not exist) |
+| `byte_match` recompile flags | `DW_AT_producer` flags | **must abstain** — no producer; recompiling with MinGW would not be "the same way" |
+| `byte_match` function bytes | DWARF `low_pc`/`high_pc` ranges | **missing** — needs PDB proc address + length |
+| GED source side | `.i` preprocessed sources + function identity | **available** — `cl -P` emits preprocessed TUs; names from the PDB |
+
+Verified host-side on the smoke `zlib1.dll`: `binfmt.detect` is
+debug-format-agnostic (PE header parse) and returns
+`BinInfo(fmt='pe', arch='x86-64', bits=64)`; `dwarf_info` returns `None` and
+`producer_flags` returns `[]` (no `.debug_*` sections). Caution:
+`recompiler_for` still answers `x86_64-w64-mingw32-gcc` for any x86-64 PE — on
+a host with MinGW installed byte_match would silently recompile an MSVC PE the
+*wrong* way, which is why integration must add the explicit abstention below.
+
+### What a PDB gives us (verified with llvm-pdbutil on the smoke PDBs)
+
+`/Zi` + `link -debug` PDBs for zlib1.dll: 183 functions (O2) / 201 (Od)
+including CRT, 196 struct type records, and per-proc locals (O2: 770
+`S_LOCAL`; Od: 826 `S_REGREL32`-style frame-relative records). Concretely for
+`adler32`: `S_GPROC32 [..] 'adler32', addr = 0001:0000, code size = 44, type =
+'0x1003 (unsigned long (unsigned long, co...)'`.
+
+* **Function names + addresses + code sizes**: `S_GPROC32`/`S_LPROC32` records
+  carry the name, `section:offset` address (→ RVA via section headers) and
+  code length — enough for the run driver's function filter, for
+  function-byte extraction, and for keying decompiled functions.
+* **Locals + parameters with types**: `S_LOCAL` (+ `S_DEFRANGE_*` locations)
+  and `S_REGREL32` records under each proc carry variable names + type indices
+  + param flags; the TPI stream resolves type indices to full records
+  (`LF_STRUCTURE`, ...). This is the type_match ground-truth equivalent.
+* **Compiland provenance**: module records name each object file (e.g.
+  ``Mod 0000 | `Z:\...\adler32.obj```) with per-module source-file lists — the
+  `decl_file` equivalent for filtering out CRT/SDK functions.
+
+So a `pdb_info()` sibling to `dwarf_info()` is *feasible*; nothing about the
+metrics' logic changes, only the ground-truth reader.
+
+### Metric coverage summary for MSVC PEs
+
+* **GED**: workable now-ish — source CFGs come from preprocessed sources
+  (`cl -P` verified working: 144 KB `adler32.i`, the `.i`-equivalent path the
+  pipeline already uses) and function identity from the PDB. No Joern/pyjoern
+  change needed (still parsing C).
+* **type_match**: needs a new PDB ground-truth module (CodeView symbol +
+  TPI type reader; `llvm-pdbutil` output or a python PDB parser). Medium
+  effort, well-scoped.
+* **byte_match**: **abstains** (non-scoring, exactly like ARM-on-host today —
+  the Union summary column already treats abstention as "not measurable", not
+  a failure). Honest alternative later: recompile with the *containerized*
+  cl.exe at matching `/O` flags — but flag recovery without `DW_AT_producer`
+  is heuristic, so abstention is the fair default.
+
+This is the same degraded-but-honest posture the cps/ARM targets already have
+(GED + type_match carry them, byte_match abstains).
+
+## Integration plan (follow-up, not in this branch)
+
+1. **`MSVCCompiler`** subclass of `decbench/compilers/base.py`: drives
+   `nmake`/`cl` via the `decbench-msvc` image (like cps/malware compile inside
+   `decbench-compile`), injects `/Zi` + the `/O` flag for the opt level
+   (`opt_gcc_flags()` needs an MSVC mapping: `O0→/Od`, `O2→/O2`), collects
+   `*.dll`/`*.exe` **and their `.pdb`s** plus `cl -P` preprocessed sources.
+2. **Project TOML** `projects/windows/zlib-msvc.toml` (new `windows/` family;
+   `gather_tomls()` in the run drivers would need to include it), labels
+   `["windows", "msvc"]`.
+3. **PDB ground-truth module** (`decbench/utils/pdbinfo.py`): functions
+   (name/RVA/length/compiland) + per-function variables (name/type/location),
+   used by the run driver's function filter, type_match, and byte_match's
+   function-byte extraction. Ship `llvm-pdbutil` on the host or vendor a
+   python CodeView parser.
+4. **byte_match**: explicit abstention for PE-without-DWARF. This is REQUIRED,
+   not optional: `recompiler_for` answers MinGW for any x86-64 PE, so on a
+   host with MinGW installed byte_match would recompile an MSVC PE the wrong
+   way (it only abstains today because the benchmark host lacks MinGW).
+5. Opt-level story: MSVC has no `-fno-inline` equivalent flag spelled the same
+   way; `O2-noinline` maps to `/O2 /Ob0`.
+
+## Known limitations / gotchas
+
+* The MSVC payload is whatever Microsoft's manifest currently serves
+  (`vsdownload.py` prints the exact version at image build); pin with
+  `--msvc-version` for reproducible corpora.
+* Wine prefix: the image bakes one for root; running `--user` (recommended, to
+  keep workspace files host-owned) auto-creates a throwaway prefix under
+  `$HOME` (~10 s once per container).
+* `nmake` spawns `cl.exe`/`link.exe` inside Wine; msvc-wine's wrappers handle
+  the environment — but heavily parallel builds under Wine are slower than
+  native; keep Windows targets small (zlib-scale) at first.
+* PDBs must be collected next to the binaries in `results/` (the PE only
+  stores a *path* to its PDB); the compile step must copy them like it copies
+  `.i` files.

--- a/scripts/msvc_compile_smoke.py
+++ b/scripts/msvc_compile_smoke.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Compile zlib with REAL MSVC (cl.exe under Wine) and report metric-readiness.
+
+Validates the experimental `decbench-msvc` image (docker/msvc.Dockerfile,
+msvc-wine): downloads zlib 1.3.1, builds it with `nmake -f win32/Makefile.msc`
+in two variants (the Makefile's default -O2 -Zi, plus a -Od -Zi override),
+then verifies the artifacts a benchmark integration would need:
+
+  * PE outputs exist (zlib1.dll / example.exe / minigzip.exe) and are x86-64;
+  * PDBs exist and NO DWARF `.debug_*` sections are present (MSVC emits
+    PDB/CodeView — decbench's DWARF-based ground truth does not apply);
+  * llvm-pdbutil can extract function names/addresses, locals and types from
+    the PDB (the future ground-truth path, see docs/MSVC_SUPPORT.md);
+  * `cl -P` emits preprocessed sources (the `.i` GED-parity path).
+
+Runs INSIDE the container (stdlib-only — the image has no decbench deps):
+
+    docker run --rm -v "$PWD":/workspace -w /workspace \\
+      --user "$(id -u):$(id -g)" decbench-msvc \\
+      python3 scripts/msvc_compile_smoke.py /workspace/msvc_smoke_out
+
+(The script self-provisions a Wine-safe $HOME — wine refuses a HOME the uid
+does not own, and msvc-wine's fifo wrappers HANG rather than fail on that.)
+
+Usage:
+    python3 scripts/msvc_compile_smoke.py [out_dir]
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+ZLIB_URLS = [
+    "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+    "https://zlib.net/zlib-1.3.1.tar.gz",
+]
+
+# PE COFF machine values we care about (mirrors decbench/utils/binfmt.py).
+_PE_MACHINES = {0x14C: "x86", 0x8664: "x86-64", 0xAA64: "aarch64", 0x1C0: "arm"}
+
+# variant name -> nmake extra args (None = Makefile.msc defaults: -O2 -Oy- -Zi)
+VARIANTS: dict[str, list[str]] = {
+    "O2-default": [],
+    "Od": ["CFLAGS=-nologo -MD -W3 -Od -Zi -Fdzlib"],
+}
+
+EXPECT_PE = ["zlib1.dll", "example.exe", "minigzip.exe"]
+
+
+def _pe_machine(path: Path) -> str | None:
+    """Return the PE machine name, or None if `path` is not a PE file."""
+    try:
+        with open(path, "rb") as f:
+            if f.read(2) != b"MZ":
+                return None
+            f.seek(0x3C)
+            (e_lfanew,) = struct.unpack("<I", f.read(4))
+            f.seek(e_lfanew)
+            if f.read(4) != b"PE\x00\x00":
+                return None
+            return _PE_MACHINES.get(struct.unpack("<H", f.read(2))[0], "other")
+    except (OSError, struct.error):
+        return None
+
+
+def _run(
+    cmd: list[str], cwd: Path | None = None, check: bool = True, timeout: int = 1200
+) -> subprocess.CompletedProcess:
+    """Run a command, echoing it; on failure print its output."""
+    print(f"  $ {' '.join(cmd)}")
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"command timed out after {timeout}s: {cmd[0]}") from exc
+    if check and proc.returncode != 0:
+        print(proc.stdout[-4000:])
+        print(proc.stderr[-4000:])
+        raise RuntimeError(f"command failed ({proc.returncode}): {cmd[0]}")
+    return proc
+
+
+def _ensure_wine_home() -> None:
+    """Give Wine a HOME the current uid owns (it refuses e.g. root-owned /tmp).
+
+    When the container runs with ``--user`` the inherited $HOME is often /tmp
+    or /root; wine then errors "'/tmp' is not owned by you" and msvc-wine's
+    fifo-based wrappers hang instead of failing. Self-provision a private HOME.
+    """
+    home = Path(os.environ.get("HOME", "/nonexistent"))
+    try:
+        owned = home.stat().st_uid == os.getuid() and os.access(home, os.W_OK)
+    except OSError:
+        owned = False
+    if not owned:
+        new_home = Path(tempfile.mkdtemp(prefix="msvc-wine-home-"))
+        os.environ["HOME"] = str(new_home)
+        print(f"HOME not usable for wine; using {new_home}")
+
+
+def _warmup_wine() -> None:
+    """Initialize the Wine prefix once (fresh $HOME when run with --user)."""
+    wine = shutil.which("wine64") or shutil.which("wine")
+    if wine:
+        subprocess.run([wine, "wineboot", "--init"], capture_output=True, timeout=300)
+        if shutil.which("wineserver"):
+            subprocess.run(["wineserver", "-w"], capture_output=True, timeout=300)
+
+
+def _find_bin() -> Path:
+    bin_dir = Path(os.environ.get("BIN", "/opt/msvc/bin/x64"))
+    if not (bin_dir / "cl").exists():
+        raise RuntimeError(f"MSVC wrapper dir not found: {bin_dir} (is this the msvc image?)")
+    return bin_dir
+
+
+def _download_zlib(work: Path) -> Path:
+    """Download + extract zlib, returning the source directory."""
+    tarball = work / "zlib.tar.gz"
+    if not tarball.exists():
+        for url in ZLIB_URLS:
+            try:
+                print(f"  downloading {url}")
+                urllib.request.urlretrieve(url, tarball)
+                break
+            except OSError as exc:
+                print(f"  download failed: {exc}")
+        else:
+            raise RuntimeError("could not download zlib from any mirror")
+    with tarfile.open(tarball) as tf:
+        tf.extractall(work)
+    src = next(p for p in work.iterdir() if p.is_dir() and p.name.startswith("zlib"))
+    return src
+
+
+def _build_variant(src: Path, out: Path, extra: list[str]) -> dict[str, str | None]:
+    """Copy the zlib tree to `out`, build with nmake, return {expected PE: machine}."""
+    if out.exists():
+        shutil.rmtree(out)
+    shutil.copytree(src, out)
+    _run(["nmake", "-f", "win32/Makefile.msc", *extra], cwd=out)
+    return {name: _pe_machine(out / name) for name in EXPECT_PE}
+
+
+def _no_dwarf(path: Path) -> bool:
+    """True if objdump reports no .debug_* sections (i.e. no DWARF)."""
+    proc = _run(["objdump", "-h", str(path)], check=False)
+    return proc.returncode == 0 and ".debug_" not in proc.stdout
+
+
+def _pdbutil() -> str | None:
+    for name in ("llvm-pdbutil", "llvm-pdbutil-18", "llvm-pdbutil-17"):
+        if shutil.which(name):
+            return name
+    return None
+
+
+def _pdb_summary(pdb: Path) -> dict[str, object]:
+    """Summarize what a PDB ground-truth reader could extract from `pdb`."""
+    tool = _pdbutil()
+    if tool is None:
+        return {"error": "llvm-pdbutil not installed"}
+    syms = _run([tool, "dump", "--symbols", str(pdb)], check=False)
+    types = _run([tool, "dump", "--types", str(pdb)], check=False)
+    if syms.returncode != 0:
+        return {"error": f"llvm-pdbutil failed: {syms.stderr[-500:]}"}
+    name_re = re.compile(r"S_[LG]PROC32\s+\[size = \d+\]\s+`([^`]+)`")
+    funcs = name_re.findall(syms.stdout)
+    locals_n = len(re.findall(r"\bS_LOCAL\b", syms.stdout))
+    regrel_n = len(re.findall(r"\bS_REGREL32\b", syms.stdout))
+    addr_n = len(re.findall(r"addr = \d{4}:\d+", syms.stdout))
+    struct_n = len(re.findall(r"\bLF_STRUCTURE\b", types.stdout)) if types.returncode == 0 else 0
+    return {
+        "functions": len(funcs),
+        "function_names_sample": sorted(set(funcs))[:8],
+        "func_addrs (sect:off)": addr_n,
+        "locals (S_LOCAL)": locals_n,
+        "locals (S_REGREL32)": regrel_n,
+        "struct type records": struct_n,
+    }
+
+
+def _preprocess_check(src: Path) -> bool:
+    """Verify `cl -P` can emit a preprocessed TU (the GED source path)."""
+    proc = _run(
+        ["cl", "-nologo", "-P", "-D_CRT_SECURE_NO_DEPRECATE", "adler32.c"], cwd=src, check=False
+    )
+    out = src / "adler32.i"
+    ok = proc.returncode == 0 and out.exists() and out.stat().st_size > 1000
+    if ok:
+        print(f"  cl -P -> adler32.i ({out.stat().st_size} bytes)")
+    return ok
+
+
+def main() -> int:
+    sys.stdout.reconfigure(line_buffering=True)  # type: ignore[union-attr]
+    out_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/msvc_smoke")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("=== MSVC (msvc-wine) zlib compile smoke ===")
+    bin_dir = _find_bin()
+    print(f"MSVC wrappers: {bin_dir}")
+    _ensure_wine_home()
+    _warmup_wine()
+    cl_banner = _run(["cl"], check=False).stderr.strip().splitlines()
+    if cl_banner:
+        print(f"cl banner: {cl_banner[0]}")
+
+    src = _download_zlib(out_dir)
+    print(f"zlib source: {src}")
+
+    failures: list[str] = []
+    pdb_reports: dict[str, dict[str, object]] = {}
+    for variant, extra in VARIANTS.items():
+        print(f"\n--- variant {variant} ---")
+        build = out_dir / f"build-{variant}"
+        try:
+            pes = _build_variant(src, build, extra)
+        except RuntimeError as exc:
+            failures.append(f"{variant}: build failed ({exc})")
+            continue
+        for name, machine in pes.items():
+            print(f"  {name}: {'PE ' + machine if machine else 'MISSING/not-PE'}")
+            if machine != "x86-64":
+                failures.append(f"{variant}: {name} not a x86-64 PE (got {machine})")
+        pdbs = sorted(p.name for p in build.glob("*.pdb"))
+        print(f"  PDBs: {pdbs or '(none)'}")
+        if not pdbs:
+            failures.append(f"{variant}: no PDB produced")
+        dll = build / "zlib1.dll"
+        if dll.exists():
+            if _no_dwarf(dll):
+                print("  zlib1.dll: no .debug_* sections (no DWARF, as expected for MSVC)")
+            else:
+                print("  zlib1.dll: UNEXPECTED .debug_* sections present")
+        link_pdb = build / "zlib1.pdb"
+        if link_pdb.exists():
+            pdb_reports[variant] = _pdb_summary(link_pdb)
+
+    print("\n--- PDB ground-truth extractability (llvm-pdbutil) ---")
+    for variant, report in pdb_reports.items():
+        print(f"  [{variant}] zlib1.pdb:")
+        for key, val in report.items():
+            print(f"    {key}: {val}")
+    if not pdb_reports:
+        failures.append("no PDB could be inspected")
+
+    print("\n--- cl -P preprocessing (GED source path) ---")
+    if not _preprocess_check(src):
+        failures.append("cl -P preprocessing failed")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+    print(f"VERDICT: {'PASS' if not failures else 'FAIL'}")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Prototype for **Windows/MSVC** benchmark targets — the one route that works on our Linux host: real `cl.exe` (MSVC Build Tools) under Wine via [msvc-wine](https://github.com/mstorsjo/msvc-wine), in a compile-only Docker image. Verified end-to-end by compiling **zlib** to PE + PDB. This lands the container + smoke script + a findings/integration doc; **no decbench Python is changed yet** (full metric integration is a scoped follow-up).

## What works (verified)
- `docker/msvc.Dockerfile` → `decbench-msvc` image (6.6 GB): **MSVC 19.51.36252** + **Windows 11 SDK 10.0.26100**, downloaded from Microsoft's official servers (`vsdownload.py --accept-license`), plus `llvm-pdbutil`. Style-matched to `docker/compile.Dockerfile`.
- `scripts/msvc_compile_smoke.py` builds zlib both ways (`Makefile.msc` default and `-Od -Zi`) → `zlib1.dll`/`example.exe` + PDBs, x86-64 PE. `binfmt.detect` sees the PE correctly.
- **PDB ground truth is fully extractable** (llvm-pdbutil): function names + addresses + code sizes + type signatures (`S_GPROC32`), locals/params with types and locations (`S_LOCAL`/`S_REGREL32`), struct type records, and per-`.obj` compiland provenance (the `decl_file` equivalent for CRT filtering). `cl -P` produces preprocessed `.i` for the GED path.

## Metric posture (documented in `docs/MSVC_SUPPORT.md`)
MSVC emits **PDB/CodeView, not DWARF**, so today's DWARF-based ground truth (`utils/binfmt.py`) sees nothing. Near-term: GED works (cl -P + PDB names); type_match needs a scoped PDB variable reader; byte_match must **abstain** for PE-without-DWARF (a MinGW recompile would not be "the same way") — the same degraded-but-fair posture the ARM/cps targets already have. One integration hazard flagged: `binfmt.recompiler_for` answers MinGW for any x86-64 PE, so the abstention is a required small change at integration time.

## Notes
- Licensing: the image downloads MSVC Build Tools under `--accept-license` (accepted for this research use).
- Two environment bugs found + worked around in the smoke script (documented): Ubuntu 24.04 needs the `wine` package not just `wine64`; Wine hangs on a non-owned `$HOME`, so the script self-provisions one.
- Recommend landing as experimental; a follow-up issue tracks the full integration (`MSVCCompiler`, `projects/windows/zlib-msvc.toml`, a PDB `utils/pdbinfo.py`, byte_match abstention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bc2JFopWxvwvyVWGQtJBt