### PR TITLE
refactor: reduce comments in code, and stricter rules to LLM-based code editing

### DIFF
--- a/decbench/__init__.py
+++ b/decbench/__init__.py
@@ -7,8 +7,7 @@ Three-metric evaluation:
 - Recompilation Bytematch: Assembly similarity after recompilation
 """
 
-# Two-digit versioning (major.minor). Must stay ABOVE the imports below:
-# models.scoreboard reads it at import time for the Scoreboard/footer version.
+# Must stay ABOVE the imports below: models.scoreboard reads it at import time.
 __version__ = "1.1"
 
 from decbench.models.project import Project

--- a/decbench/caching.py
+++ b/decbench/caching.py
@@ -114,7 +114,6 @@ class ContentCache:
         self.misses = 0
 
     def _path_for(self, key: str) -> Path:
-        # Shard by the first two hex chars to avoid huge flat directories.
         return self.root / key[:2] / f"{key}.json"
 
     def get(self, key: str) -> Any | None:
@@ -148,15 +147,12 @@ class ContentCache:
                 json.dump(value, f, separators=(",", ":"), default=_json_default)
             os.replace(tmp, path)
         except OSError:
-            # Cache is best-effort; never fail the run because of it.
             pass
 
     def stats(self) -> dict[str, int]:
         return {"hits": self.hits, "misses": self.misses}
 
 
-# Process-global cache instances, keyed by namespace, so repeated lookups in a
-# single worker share the in-memory layer.
 _CACHES: dict[str, ContentCache] = {}
 
 

--- a/decbench/cli.py
+++ b/decbench/cli.py
@@ -323,7 +323,6 @@ def list_metrics() -> None:
     from rich.console import Console
     from rich.table import Table
 
-    # Import to register
     import decbench.metrics  # noqa: F401
     from decbench.metrics.registry import MetricRegistry
 
@@ -420,7 +419,6 @@ def report(scoreboard_path, output, function_data) -> None:
 
     scoreboard = Scoreboard.from_toml(Path(scoreboard_path))
 
-    # Resolve the function data path: explicit -> sibling -> None.
     if function_data is not None:
         fd_path: Path | None = Path(function_data)
     else:
@@ -440,12 +438,9 @@ def report(scoreboard_path, output, function_data) -> None:
     else:
         console.print("[yellow]No function data found; generating static report.[/yellow]")
 
-    # Re-tag the dataset presets (unoptimized/optimized/inlined/large/sample-set)
-    # on every render so a preset rename or membership-rule change takes effect
-    # without a benchmark re-run. The sample-set is pinned to the tree's frozen
-    # manifest when one exists (the seeded draw no longer reproduces it once the
-    # records drift) — a fresh draw would tag functions the sample-set-only LLM
-    # backends never decompiled.
+    # Re-tag presets on every render so a rename or rule change takes effect without
+    # a benchmark re-run. The sample-set pins to the tree's frozen manifest: a fresh
+    # draw would tag functions the sample-set-only LLM backends never decompiled.
     if fd is not None:
         try:
             from decbench.results_store import load_sample_manifest
@@ -496,9 +491,6 @@ def site_build(results_path, output) -> None:
 
     if not scoreboard_path.exists():
         raise click.ClickException(f"No scoreboard.toml in {tree} — is this a results tree?")
-    # The site is data-driven: every view is computed from the per-function
-    # dataset, so without it there is nothing to build (unlike `decbench report`,
-    # which can still fall back to static scoreboard tables).
     if not fd_path.exists():
         raise click.ClickException(
             f"No function_results.json in {tree}. The site is built entirely from "
@@ -509,23 +501,11 @@ def site_build(results_path, output) -> None:
     scoreboard = Scoreboard.from_toml(scoreboard_path)
     fd = FunctionData.from_json(fd_path)
 
-    # Re-tag dataset presets on every render so renames/rule changes take effect
-    # on re-render instead of serving tags baked in by an older decbench. The
-    # sample-set is pinned to the tree's frozen manifest when one exists — the
-    # membership the LLM backends actually decompiled; a fresh seeded draw
-    # diverges from it once the records drift and near-zeroes their scores.
     from decbench.results_store import load_sample_manifest
     from decbench.scoring.datasets import assign_datasets
 
     assign_datasets(fd, sample_members=load_sample_manifest(tree))
 
-    # Materialize the View page's `sample-set` tier from THIS results tree: one
-    # side-by-side entry per `sample-set` function, with decompiled code read from
-    # the tree's decompiled/*.c artifacts and source via function_source_ex. The
-    # GED-tiered easy/medium/hard entries are built at benchmark time; this adds
-    # the sample-set slice at build time (it needs the on-disk tree, which only
-    # `site build` is guaranteed to have — `decbench report` takes a scoreboard
-    # path, so it stays unchanged). Skips gracefully on a bare results tree.
     from decbench.scoring.report_extras import build_sample_set_samples
 
     sample_set = build_sample_set_samples(fd, tree)
@@ -935,7 +915,6 @@ def improvements(
     if out_format == "json":
         click.echo(_json.dumps([c.to_dict() for c in shown], indent=2))
     else:
-        # click.echo (not rich) so wide tabular rows are not soft-wrapped.
         click.echo(
             render_text(
                 shown,
@@ -983,7 +962,6 @@ def download(config, dest, repo_path, include, revision) -> None:
     package (shipped from the HuggingFace dataset repo), so no heavy DecBench
     imports are pulled in.
     """
-    # Lazy import: the consumer package is optional and lives in the dataset repo.
     try:
         import decbench_data
     except ImportError:
@@ -995,7 +973,6 @@ def download(config, dest, repo_path, include, revision) -> None:
         )
         raise SystemExit(1) from None
 
-    # Prefer a plain function entrypoint; fall back to the package's CLI callable.
     entry = getattr(decbench_data, "download", None)
     if callable(entry):
         entry(
@@ -1022,7 +999,6 @@ def download(config, dest, repo_path, include, revision) -> None:
         argv += ["--include", include]
     if revision:
         argv += ["--revision", revision]
-    # click Command and argparse-style main both accept an argv list positionally.
     cli(argv)
 
 

--- a/decbench/compilers/base.py
+++ b/decbench/compilers/base.py
@@ -18,7 +18,6 @@ class CompileResult:
     success: bool = False
     error_message: str | None = None
 
-    # Extracted metadata
     functions: list[tuple[str, int]] = field(default_factory=list)
 
 

--- a/decbench/compilers/gcc.py
+++ b/decbench/compilers/gcc.py
@@ -35,24 +35,22 @@ class GCCCompiler(Compiler):
         self.gcc_path = gcc_path or self._find_gcc()
         self.target_arch = target_arch
 
-        # Default base flags for reproducible decompilation benchmarking.
-        # Inlining is governed by the optimization level (O2-noinline), not
+        # Inlining is governed by the optimization level (O2-noinline), not by these
         # base flags, so plain O2 stays a genuine O2.
         self.base_flags = base_flags or [
-            "-g",  # Debug symbols
-            "-fno-builtin",  # Don't use builtin optimizations
+            "-g",
+            "-fno-builtin",
         ]
 
     def _find_gcc(self) -> str | None:
         """Find GCC in PATH."""
-        # Try versioned GCC first
         for version in ["13", "12", "11", "10", "9", ""]:
             name = f"gcc-{version}" if version else "gcc"
             path = shutil.which(name)
             if path:
                 return path
 
-        return "gcc"  # Default, may fail if not found
+        return "gcc"
 
     def is_available(self) -> bool:
         """Check if GCC is available."""
@@ -76,7 +74,6 @@ class GCCCompiler(Compiler):
                 timeout=10,
             )
             if result.returncode == 0:
-                # First line contains version
                 return result.stdout.split("\n")[0]
         except Exception:
             pass
@@ -95,12 +92,10 @@ class GCCCompiler(Compiler):
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Output paths
         stem = source_path.stem
         object_path = output_dir / f"{stem}.o"
         preprocessed_path = output_dir / f"{stem}.i" if emit_preprocessed else None
 
-        # Build command
         flags = list(self.base_flags)
         flags.extend(opt_gcc_flags(optimization))
 
@@ -113,7 +108,7 @@ class GCCCompiler(Compiler):
         cmd = [
             self.gcc_path,
             *flags,
-            "-c",  # Compile only, no linking
+            "-c",
             "-o", str(object_path),
             str(source_path),
         ]
@@ -134,9 +129,7 @@ class GCCCompiler(Compiler):
                     error_message=result.stderr,
                 )
 
-            # Find preprocessed file (may be in different location)
             if emit_preprocessed and not preprocessed_path.exists():
-                # Check if it was created next to source
                 alt_path = source_path.with_suffix(".i")
                 if alt_path.exists():
                     shutil.move(str(alt_path), str(preprocessed_path))
@@ -173,15 +166,12 @@ class GCCCompiler(Compiler):
                 magic = f.read(4)
                 if magic != b"\x7fELF":
                     return False
-                # e_type is at offset 16, 2 bytes little-endian
                 f.seek(16)
                 e_type = struct.unpack("<H", f.read(2))[0]
-                # ET_EXEC = 2 (executable), ET_DYN = 3 (shared/PIE)
                 return e_type in (2, 3)
         except (OSError, struct.error):
             return False
 
-    # ELF e_machine -> short arch name (the ones we cross-compile for / against).
     _ELF_MACHINES = {
         0x28: "arm", 0xB7: "aarch64", 0x3E: "x86-64", 0x03: "x86",
         0xF3: "riscv", 0x08: "mips", 0x14: "ppc", 0x15: "ppc64",
@@ -194,12 +184,11 @@ class GCCCompiler(Compiler):
             with open(path, "rb") as f:
                 if f.read(4) != b"\x7fELF":
                     return None
-                f.seek(18)  # e_machine
+                f.seek(18)
                 return cls._ELF_MACHINES.get(struct.unpack("<H", f.read(2))[0], "other")
         except (OSError, struct.error):
             return None
 
-    # PE COFF Machine -> short arch name (for MinGW-built Windows malware).
     _PE_MACHINES = {0x14C: "x86", 0x8664: "x86-64", 0xAA64: "aarch64", 0x1C0: "arm"}
 
     @staticmethod
@@ -260,8 +249,6 @@ class GCCCompiler(Compiler):
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # project_root is where configure/make run from (the repo root).
-        # project_dir is where source files live (may be a subdirectory).
         if project_root is None:
             project_root = project_dir
         else:
@@ -269,7 +256,6 @@ class GCCCompiler(Compiler):
 
         results = []
 
-        # Set up environment with our compiler flags
         env = os.environ.copy()
         cflags = " ".join(self.base_flags + opt_gcc_flags(optimization))
         if extra_flags:
@@ -278,7 +264,6 @@ class GCCCompiler(Compiler):
         env["CFLAGS"] = cflags
         env["CC"] = self.gcc_path
 
-        # Run pre-commands (e.g., ./configure) from the project root
         if pre_commands:
             for cmd in pre_commands:
                 try:
@@ -291,10 +276,8 @@ class GCCCompiler(Compiler):
                         check=True,
                     )
                 except subprocess.CalledProcessError as e:
-                    # Pre-command failed, but continue
                     pass
 
-        # Use make if specified
         if make_command:
             try:
                 subprocess.run(
@@ -302,34 +285,25 @@ class GCCCompiler(Compiler):
                     shell=True,
                     cwd=project_root,
                     env=env,
-                    timeout=3600,  # 1h timeout for large serial builds (e.g. gnutls)
+                    timeout=3600,
                     check=True,
                 )
 
-                # Find linked ELF executables for decompilation.
-                # Decompilers need linked binaries (ET_EXEC/ET_DYN),
-                # not relocatable .o files (ET_REL).
                 for entry in project_dir.rglob("*"):
                     if not entry.is_file():
                         continue
                     if entry.is_symlink():
-                        # Library builds symlink lib.so -> lib.so.X -> lib.so.X.Y.Z;
-                        # only collect the real file once.
                         continue
                     if entry.suffix in (".o", ".a", ".i", ".s", ".c", ".h"):
                         continue
                     if not self._is_linked_binary(entry):
                         continue
-                    # For cross-compiled projects, skip incidental host tools
-                    # (e.g. x86 mkimage) and keep only the target-arch binaries.
-                    # Accepts ELF and PE (MinGW-built malware) machine names.
                     if self.target_arch and self._binary_machine(entry) != self.target_arch:
                         continue
 
                     dest_bin = output_dir / entry.name
                     shutil.copy2(entry, dest_bin)
 
-                    # Find matching .c and .i files via the .o file
                     obj_file = entry.with_suffix(".o")
                     c_file = entry.with_suffix(".c")
                     i_file = entry.with_suffix(".i")
@@ -338,7 +312,6 @@ class GCCCompiler(Compiler):
                         dest_i = output_dir / i_file.name
                         shutil.copy2(i_file, dest_i)
                     elif obj_file.exists():
-                        # .i file may be named after the .o file
                         alt_i = obj_file.with_suffix(".i")
                         if alt_i.exists() and alt_i != i_file:
                             dest_i = output_dir / alt_i.name
@@ -351,7 +324,6 @@ class GCCCompiler(Compiler):
                         success=True,
                     ))
 
-                # Also copy .i and .o files for source CFG extraction
                 for obj_file in project_dir.rglob("*.o"):
                     i_file = obj_file.with_suffix(".i")
                     if i_file.exists():
@@ -367,7 +339,6 @@ class GCCCompiler(Compiler):
                 ))
 
         else:
-            # Compile individual files
             source_files = list(project_dir.glob(source_pattern))
 
             for source_file in source_files:

--- a/decbench/dataset.py
+++ b/decbench/dataset.py
@@ -183,7 +183,6 @@ def save_dataset(
                 binary_relpath = rel_dir / stem
                 _copy(entry_path, dataset_root / binary_relpath)
 
-                # Sibling .i sources for this binary (same compiled dir).
                 source_relpaths: list[str] = []
                 for src in sorted(compiled_dir.glob("*.i")):
                     src_rel = rel_dir / src.name

--- a/decbench/decompilers/__init__.py
+++ b/decbench/decompilers/__init__.py
@@ -5,27 +5,17 @@ import contextlib
 from decbench.decompilers.base import Decompiler, DecompilerConfig
 from decbench.decompilers.registry import DecompilerRegistry, register_decompiler
 
-# Import plugin modules so @register_decompiler decorators run.
-# declib_dec registers the declib-backed backends under the ``*-declib``
-# names (angr-declib, ghidra-declib, ida-declib, binja-declib) so they remain
-# available for comparison. The ``raw`` subpackage registers the canonical
-# angr/ghidra/ida/binja names with native (declib-free) implementations. Heavy
-# decompiler imports happen lazily inside each plugin, so these imports are
-# cheap and never fail on a missing backend.
+# Imported for their @register_decompiler side effects. Heavy decompiler imports
+# happen lazily inside each plugin, so these never fail on a missing backend.
 with contextlib.suppress(ImportError):
     from decbench.decompilers import declib_dec  # noqa: F401
 
 with contextlib.suppress(ImportError):
     from decbench.decompilers import raw  # noqa: F401
 
-# Dockerized backends (Reko, RetDec, r2dec). r2dec can also run natively via
-# radare2; the others require a built Docker image (see docker/).
 with contextlib.suppress(ImportError):
     from decbench.decompilers import dockerized  # noqa: F401
 
-# LLM / coding-agent backends (Codex, Claude Code). They shell out to the
-# `codex` / `claude` CLIs; the imports are cheap (heavy work is at call time).
-# Meant to run on the `sample-set` slice only — see docs/decompilers.md.
 with contextlib.suppress(ImportError):
     from decbench.decompilers import llm_dec  # noqa: F401
 

--- a/decbench/decompilers/base.py
+++ b/decbench/decompilers/base.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 class DecompilerConfig(BaseModel):
     """Configuration for a decompiler."""
 
-    # Timeouts
     function_timeout_seconds: float = Field(
         default=600.0,
         description="Timeout per function in seconds",
@@ -25,17 +24,10 @@ class DecompilerConfig(BaseModel):
         description="Timeout per binary in seconds",
     )
 
-    # Output options
     dump_line_mappings: bool = Field(
         default=True,
         description="Generate line-to-address mappings",
     )
-    dump_early_metrics: bool = Field(
-        default=True,
-        description="Pre-compute metrics during decompilation",
-    )
-
-    # Decompiler-specific options
     extra_options: dict[str, Any] = Field(
         default_factory=dict,
         description="Decompiler-specific configuration options",
@@ -60,7 +52,6 @@ class Decompiler(ABC):
                 ...
     """
 
-    # Class attributes to be overridden
     name: str = "base"
     display_name: str = "Base Decompiler"
     version: str | None = None
@@ -72,10 +63,8 @@ class Decompiler(ABC):
             config: Configuration for the decompiler
         """
         self.config = config or DecompilerConfig()
-        # Set by the registry when a versioned spec (``name@version``) is
-        # resolved, so multiple versions of one decompiler run as distinct,
-        # comparable entries. ``requested_version`` is the pinned label from
-        # the spec; ``get_version()`` reports the realized/actual version.
+        # Set by the registry from a ``name@version`` spec. ``requested_version`` is the
+        # pinned label; ``get_version()`` reports the realized version.
         self.requested_version: str | None = None
         self._spec_id: str | None = None
 
@@ -157,27 +146,6 @@ class Decompiler(ABC):
             return result.functions[function_name].decompiled_code
 
         return None
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        """Discover functions in a binary.
-
-        Default implementation returns empty list.
-        Override to provide function discovery.
-
-        Args:
-            binary_path: Path to the binary
-
-        Returns:
-            List of (function_name, address) tuples
-        """
-        return []
-
-    def cleanup(self) -> None:
-        """Clean up any resources used by the decompiler.
-
-        Called after decompilation is complete.
-        """
-        pass
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r})"

--- a/decbench/decompilers/declib_dec.py
+++ b/decbench/decompilers/declib_dec.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 
 _l = logging.getLogger(__name__)
 
-# CRT/compiler-generated functions that are not user code
 _SKIP_NAMES = frozenset({
     "_start", "__libc_start_main", "__libc_csu_init", "__libc_csu_fini",
     "_init", "_fini", "__do_global_dtors_aux", "register_tm_clones",
@@ -44,7 +43,6 @@ _SKIP_NAMES = frozenset({
     "_dl_relocate_static_pie", "__gmon_start__", "__stack_chk_fail",
 })
 
-# Name prefixes for thunks/imports that should not be benchmarked
 _SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
 
 
@@ -97,44 +95,17 @@ class DeclibDecompiler(Decompiler):
 
     name = "declib"
     display_name = "declib"
-    # declib backend identifier passed to DecompilerInterface.discover()
     force_decompiler: str = ""
-    # backends that benefit from a persistent project/cache directory
     _uses_project_dir: bool = False
 
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
-
-    #
-    # Decompiler interface
-    #
 
     def is_available(self) -> bool:  # pragma: no cover - overridden
         raise NotImplementedError
 
     def get_version(self) -> str | None:  # pragma: no cover - overridden
         raise NotImplementedError
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        """Discover functions using the declib backend."""
-        if not self.is_available():
-            return []
-
-        elf_base = _elf_min_vaddr(binary_path)
-        deci = None
-        try:
-            deci = self._make_deci(binary_path, None)
-            return [
-                (name, lifted_addr + elf_base)
-                for name, lifted_addr in self._enumerate_functions(
-                    deci, binary_path, elf_base
-                )
-            ]
-        except Exception as e:
-            _l.error("Failed to discover functions in %s: %s", binary_path, e)
-            return []
-        finally:
-            self._shutdown(deci)
 
     def decompile_binary(
         self,
@@ -175,7 +146,6 @@ class DeclibDecompiler(Decompiler):
             )
 
             if functions is not None:
-                # Caller addresses are in ELF/DWARF space; declib wants lifted.
                 target_funcs = [
                     (name, addr - elf_base) for name, addr in functions
                 ]
@@ -188,10 +158,8 @@ class DeclibDecompiler(Decompiler):
                 filtered = [
                     (n, a) for (n, a) in target_funcs if n in function_names
                 ]
-                # Only apply the filter if it actually matched something — if
-                # decompiler names don't line up with source names (e.g. a
-                # stripped/renamed binary), fall back to decompiling everything
-                # rather than producing an empty result.
+                # Apply the filter only if it matched: when decompiler names don't line up with
+                # source names, decompiling everything beats producing an empty result.
                 if filtered:
                     _l.debug(
                         "declib/%s: filtered %d/%d functions to source set for %s",
@@ -281,13 +249,6 @@ class DeclibDecompiler(Decompiler):
 
         return result
 
-    def cleanup(self) -> None:
-        """Per-binary interfaces are shut down inline; nothing persistent."""
-
-    #
-    # declib helpers
-    #
-
     def _make_deci(
         self, binary_path: Path, project_dir: Path | None
     ) -> DecompilerInterface:
@@ -316,7 +277,7 @@ class DeclibDecompiler(Decompiler):
         """Per-(binary, backend) cache dir; avoids project lock collisions."""
         if not self._uses_project_dir:
             return None
-        # NOTE: Ghidra forbids path elements starting with '.'
+        # Ghidra forbids path elements starting with '.'.
         base = output_dir if output_dir is not None else binary_path.parent
         return base / f"declib_{self.name}_projects" / binary_path.stem
 
@@ -347,9 +308,6 @@ class DeclibDecompiler(Decompiler):
             if not name or name in _SKIP_NAMES:
                 continue
             if text_range is not None:
-                # PLT stubs/import thunks live outside .text; inside .text we
-                # trust the section filter and never drop by name prefix (a
-                # user function may legitimately be called e.g. "j_compress").
                 file_addr = int(lifted_addr) + elf_base
                 if not (text_range[0] <= file_addr < text_range[1]):
                     continue
@@ -370,15 +328,12 @@ class DeclibDecompiler(Decompiler):
             lifted_addr, map_lines=self.config.dump_line_mappings
         )
         if (dec is None or not dec.text) and self.config.dump_line_mappings:
-            # Line mapping can fail independently of decompilation; retry
-            # without it rather than losing the function entirely.
             dec = deci.decompile(lifted_addr, map_lines=False)
         if dec is None or not dec.text:
             return None
 
         code = self._normalize_code(dec.text)
 
-        # declib line_map: {line_number: iterable[lifted_addr]} (set or list)
         line_mappings: list[LineMapping] = []
         if dec.line_map:
             for line_num, addrs in sorted(dec.line_map.items()):
@@ -427,9 +382,8 @@ class DeclibDecompiler(Decompiler):
 
         header = full_func.header
         if header is not None and header.args:
-            # declib keys args by positional index; preserve ABI order so the
-            # type metric can match arguments positionally (works even when
-            # the decompiler invents names like a0/a1).
+            # Preserve ABI order so the type metric can match arguments positionally, even
+            # when the decompiler invents names like a0/a1.
             for position, key in enumerate(sorted(header.args)):
                 arg = header.args[key]
                 variables.append(
@@ -471,7 +425,6 @@ class IDADeclibDecompiler(DeclibDecompiler):
     force_decompiler = "ida"
     _uses_project_dir = True
 
-    # IDA-specific C dialect -> standard C (order matters: __int64 first)
     _CODE_REPLACEMENTS = (
         ("unsigned __int64", "unsigned long long"),
         ("__int64", "long long"),
@@ -484,9 +437,7 @@ class IDADeclibDecompiler(DeclibDecompiler):
         ("_BYTE", "char"),
         ("_BOOL8", "long long"),
         ("_BOOL4", "int"),
-        # _Bool (not bool): compiles without <stdbool.h> when recompiled
         ("_BOOL", "_Bool"),
-        # Calling-convention/attribute annotations gcc cannot parse
         ("__cdecl ", ""),
         ("__fastcall ", ""),
         ("__stdcall ", ""),
@@ -570,8 +521,6 @@ class BinjaDeclibDecompiler(DeclibDecompiler):
 
     def is_available(self) -> bool:
         try:
-            # License errors raise non-ImportError exceptions; treat any
-            # failure as unavailable.
             import binaryninja  # noqa: F401
 
             return True

--- a/decbench/decompilers/dockerized.py
+++ b/decbench/decompilers/dockerized.py
@@ -61,11 +61,9 @@ from decbench.models.decompilation import (
 
 _l = logging.getLogger(__name__)
 
-# Repo root: decbench/decompilers/dockerized.py -> repo root is parents[2].
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOCKER_DIR = _REPO_ROOT / "docker"
 
-# CRT/compiler-generated functions that are not user code (mirrors declib_dec).
 _SKIP_NAMES = frozenset(
     {
         "_start",
@@ -85,13 +83,7 @@ _SKIP_NAMES = frozenset(
     }
 )
 
-# Name prefixes for thunks/imports that should not be benchmarked.
 _SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
-
-
-# --------------------------------------------------------------------------- #
-# ELF helpers (symbol table -> ELF-file-space function addresses)
-# --------------------------------------------------------------------------- #
 
 
 def _elf_text_range(binary_path: Path) -> tuple[int, int] | None:
@@ -130,7 +122,6 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
     try:
         with open(binary_path, "rb") as f:
             elf = ELFFile(f)
-            # Prefer the full .symtab; .dynsym rarely has STT_FUNC for static fns.
             for sec in elf.iter_sections():
                 if not isinstance(sec, SymbolTableSection):
                     continue
@@ -148,7 +139,6 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
                             continue
                     elif name.startswith(_SKIP_PREFIXES):
                         continue
-                    # First definition wins (some names appear in both tables).
                     out.setdefault(name, addr)
     except Exception as e:  # noqa: BLE001
         _l.debug("Failed to enumerate symbols for %s: %s", binary_path, e)
@@ -157,13 +147,6 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
     return sorted(out.items(), key=lambda kv: kv[1])
 
 
-# --------------------------------------------------------------------------- #
-# Whole-program C -> per-function splitting
-# --------------------------------------------------------------------------- #
-
-# Matches a C function *definition* opening line: an identifier immediately
-# followed by '(' and an eventual '{'. Captures the function name. Deliberately
-# permissive: decompiler output is not clean C.
 _FUNC_DEF_RE = re.compile(
     r"^[A-Za-z_][\w\s\*\(\),:<>\[\]&]*?\b([A-Za-z_]\w*)\s*\([^;{}]*\)\s*\{",
     re.MULTILINE,
@@ -191,7 +174,6 @@ def split_c_functions(combined_c: str) -> dict[str, str]:
             i += 1
             continue
         name = m.group(1)
-        # Accumulate from this line until braces balance back to zero.
         depth = 0
         opened = False
         chunk: list[str] = []
@@ -199,7 +181,6 @@ def split_c_functions(combined_c: str) -> dict[str, str]:
         while j < n:
             cur = lines[j]
             chunk.append(cur)
-            # Count braces, ignoring those in strings/char-literals crudely.
             stripped = _strip_c_literals(cur)
             depth += stripped.count("{")
             depth -= stripped.count("}")
@@ -209,7 +190,6 @@ def split_c_functions(combined_c: str) -> dict[str, str]:
                 break
             j += 1
         snippet = "".join(chunk).rstrip() + "\n"
-        # Keep the first definition of a given name.
         results.setdefault(name, snippet)
         i = j + 1
     return results
@@ -221,17 +201,10 @@ def _strip_c_literals(line: str) -> str:
     Crude but good enough to stop ``"}"`` inside a string from unbalancing the
     brace counter. Not a real lexer.
     """
-    # Drop line comments.
     line = re.sub(r"//.*", "", line)
-    # Blank out double-quoted strings and single-quoted chars.
     line = re.sub(r'"(?:\\.|[^"\\])*"', '""', line)
     line = re.sub(r"'(?:\\.|[^'\\])*'", "''", line)
     return line
-
-
-# --------------------------------------------------------------------------- #
-# Dockerized base
-# --------------------------------------------------------------------------- #
 
 
 class DockerizedDecompiler(Decompiler):
@@ -245,19 +218,14 @@ class DockerizedDecompiler(Decompiler):
     name = "dockerized"
     display_name = "Dockerized Decompiler"
 
-    #: Docker image tag this backend runs, e.g. ``"decbench/retdec:latest"``.
     image: str = ""
-    #: Dockerfile basename under ``docker/`` used to build :attr:`image`.
     dockerfile: str = ""
-    #: Per-binary container timeout (seconds). Configurable via config below.
     container_timeout: float = 1800.0
 
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
         if config is not None and config.binary_timeout_seconds:
             self.container_timeout = float(config.binary_timeout_seconds)
-
-    # -- availability / build ------------------------------------------- #
 
     @staticmethod
     def _docker_bin() -> str | None:
@@ -315,18 +283,15 @@ class DockerizedDecompiler(Decompiler):
         ]
         if no_cache:
             cmd.append("--no-cache")
-        cmd.append(str(_DOCKER_DIR))  # build context = docker/ dir
+        cmd.append(str(_DOCKER_DIR))
         _l.info("Building %s: %s", cls.image, " ".join(cmd))
         proc = subprocess.run(cmd)
         return proc.returncode
 
     def get_version(self) -> str | None:
-        # Image tag is the best version proxy without running the container.
         if not self.image:
             return None
         return self.image.rsplit(":", 1)[-1] if ":" in self.image else "latest"
-
-    # -- decompilation -------------------------------------------------- #
 
     def _container_decompile(self, binary_path: Path, work_dir: Path) -> str:
         """Run the container and return whole-program C as a string.
@@ -447,8 +412,6 @@ class DockerizedDecompiler(Decompiler):
         output_dir: Path | None,
     ) -> DecompilationResult:
         """Assemble a :class:`DecompilationResult` from whole-program C."""
-        # Determine the function set + addresses from the ELF symbol table so
-        # addresses are ELF-file-space and match DWARF.
         if functions is not None:
             name_to_addr = {n: a for n, a in functions}
         else:
@@ -504,18 +467,9 @@ class DockerizedDecompiler(Decompiler):
             output_dir=output_dir,
         )
 
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        """Discover functions from the ELF symbol table (no container needed)."""
-        return elf_function_symbols(binary_path)
-
     def _normalize_code(self, code: str) -> str:
         """Hook for dialect normalization. Default identity."""
         return code
-
-
-# --------------------------------------------------------------------------- #
-# RetDec
-# --------------------------------------------------------------------------- #
 
 
 @register_decompiler("retdec")
@@ -531,8 +485,6 @@ class RetDecDecompiler(DockerizedDecompiler):
     dockerfile = "retdec.Dockerfile"
 
     def _container_decompile(self, binary_path: Path, work_dir: Path) -> str:
-        # The image's ENTRYPOINT runs retdec-decompiler; emit C to /work/out.c.
-        # retdec-decompiler writes <output>.c plus several sidecar files.
         proc = self._run_docker(
             args=[f"/in/{binary_path.name}", "-o", "/work/out.c"],
             binary_path=binary_path,
@@ -541,16 +493,10 @@ class RetDecDecompiler(DockerizedDecompiler):
         out_c = work_dir / "out.c"
         if out_c.is_file():
             return out_c.read_text(errors="replace")
-        # Some retdec builds write directly next to the input; nothing to read.
         raise RuntimeError(
             f"retdec produced no out.c (rc={proc.returncode}): "
             f"{proc.stderr[-500:] if proc.stderr else ''}"
         )
-
-
-# --------------------------------------------------------------------------- #
-# Reko
-# --------------------------------------------------------------------------- #
 
 
 @register_decompiler("reko")
@@ -568,8 +514,6 @@ class RekoDecompiler(DockerizedDecompiler):
     dockerfile = "reko.Dockerfile"
 
     def _container_decompile(self, binary_path: Path, work_dir: Path) -> str:
-        # The image ships /opt/reko/decompile.sh which runs Reko on the binary
-        # and consolidates the emitted C into /work/out.c.
         proc = self._run_docker(
             args=[f"/in/{binary_path.name}", "/work/out.c"],
             binary_path=binary_path,
@@ -584,26 +528,13 @@ class RekoDecompiler(DockerizedDecompiler):
         )
 
 
-# --------------------------------------------------------------------------- #
-# r2dec (radare2's r2dec decompiler)
-# --------------------------------------------------------------------------- #
-
-# r2 flag names that are NOT user code (the ELF/PE entrypoint aliases). Imports
-# and PLT/reloc stubs are dropped by ``_r2_is_import``; the .text-range + CRT
-# filter (raw_common.should_skip_function) handles the rest.
 _R2_ENTRY_NAMES = frozenset({"entry0", "entry1", "entry.init0", "entry.fini0", "entry.preinit0"})
 
-# C keywords that would spuriously match the definition regex (``if (x) {``).
 _C_KEYWORDS = frozenset({"if", "while", "for", "switch", "return", "do", "else", "sizeof", "case"})
 
-# A C function *definition* opener. Tolerates r2's dotted pseudo-names
-# (``fcn.00003bed``, which the built-in ``pdc`` emits verbatim) as well as the
-# sanitized ``fcn_00003bed`` r2dec's ``pdd`` uses. The captured identifier is the
-# one that actually appears in the emitted code — we key each function by it so
-# the run driver's address-relabel (which rewrites the name in the code AND the
-# key) lines the decompiled CFG up with the source for GED. The parameter list is
-# matched **non-greedily** so an ``ident (...)`` inside a comment cannot swallow
-# text up to the real function's ``) {``.
+# Tolerates both r2 pseudo-name spellings (``fcn.00003bed`` from ``pdc`` and
+# ``fcn_00003bed`` from ``pdd``). The parameter list is matched non-greedily so
+# an ``ident (...)`` inside a comment cannot swallow text up to the real ``) {``.
 _R2_DEF_RE = re.compile(r"\b([A-Za-z_][\w.]*)\s*\([^;{}]*?\)\s*\{")
 
 
@@ -702,10 +633,7 @@ class R2DecDecompiler(DockerizedDecompiler):
     image = "decbench/r2dec:latest"
     dockerfile = "r2dec.Dockerfile"
 
-    # r2pipe open flags: -2 silences stderr; apply relocs; no ANSI color.
     _R2_FLAGS = ["-2", "-e", "bin.relocs.apply=true", "-e", "scr.color=0"]
-
-    # -- availability / path selection ---------------------------------- #
 
     @staticmethod
     def _native_available() -> bool:
@@ -787,8 +715,6 @@ class R2DecDecompiler(DockerizedDecompiler):
             return "native"
         return super().get_version()
 
-    # -- entry point ---------------------------------------------------- #
-
     def decompile_binary(
         self,
         binary_path: Path,
@@ -805,8 +731,6 @@ class R2DecDecompiler(DockerizedDecompiler):
         return self._decompile_native(
             binary_path, functions, output_dir, function_names, progress_path
         )
-
-    # -- shared discovery / narrowing / assembly ------------------------ #
 
     @staticmethod
     def _discover(
@@ -831,7 +755,7 @@ class R2DecDecompiler(DockerizedDecompiler):
             name = fn.get("name") or ""
             raw = fn.get("addr")
             if raw is None:
-                raw = fn.get("offset")  # older r2 aflj schema
+                raw = fn.get("offset")
             if not name or raw is None:
                 continue
             if _r2_is_import(name) or name in _R2_ENTRY_NAMES:
@@ -977,8 +901,6 @@ class R2DecDecompiler(DockerizedDecompiler):
         with contextlib.suppress(Exception):
             result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
 
-    # -- native r2pipe path --------------------------------------------- #
-
     def _decompile_native(
         self,
         binary_path: Path,
@@ -1017,7 +939,6 @@ class R2DecDecompiler(DockerizedDecompiler):
             baddr = self._r2_baddr(r)
             used_cmd = self._probe_decompile_cmd(r)
             if functions is not None:
-                # Explicit (name, ELF-addr) allowlist: define + decompile each.
                 for name, fa in functions:
                     raw = int(fa) - elf_base + baddr
                     with contextlib.suppress(Exception):
@@ -1058,8 +979,6 @@ class R2DecDecompiler(DockerizedDecompiler):
         self._write_artifacts(result, output_dir, binary_path)
         return result
 
-    # -- docker (real r2dec) path --------------------------------------- #
-
     def _decompile_docker(
         self,
         binary_path: Path,
@@ -1077,9 +996,6 @@ class R2DecDecompiler(DockerizedDecompiler):
         elf_base = raw_common.elf_min_vaddr(binary_path)
         text_range = raw_common.elf_text_range(binary_path)
 
-        # Address filter the container applies (DWARF low_pc / ELF-file space).
-        # From the int address set the driver passes, or an explicit (name, addr)
-        # allowlist — so a filtered call never decompiles the whole binary.
         addr_targets: list[int] | None = None
         ints: set[int] = set()
         if function_names:
@@ -1122,8 +1038,6 @@ class R2DecDecompiler(DockerizedDecompiler):
                 error = str(e)
                 _l.error("%s docker failed on %s: %s", self.name, binary_path, e)
 
-        # Normalize container entries -> discovered triples, then narrow (the
-        # container already filtered by address, so this is a defensive re-check).
         by_addr: dict[int, tuple[str, str]] = {}
         discovered: list[tuple[str, int, int]] = []
         addr_targets = _addr_targets_of(function_names)
@@ -1166,12 +1080,9 @@ class R2DecDecompiler(DockerizedDecompiler):
             timed_out=timed_out,
             error=error,
         )
-        # Whole-container run is atomic, so this is a single best-effort checkpoint.
         raw_common.dump_progress(progress_path, result)
         self._write_artifacts(result, output_dir, binary_path)
         return result
-
-    # -- r2 helpers ----------------------------------------------------- #
 
     @staticmethod
     def _r2_baddr(r: Any) -> int:

--- a/decbench/decompilers/llm_dec.py
+++ b/decbench/decompilers/llm_dec.py
@@ -58,35 +58,13 @@ from decbench.models.decompilation import (
 
 _l = logging.getLogger(__name__)
 
-# Per-binary hard cap on how many functions a single decompile call will send to
-# the agent. The sample-set takes at most a handful of functions per binary, so
-# this is a runaway guard: even if the driver's sample-set gate is forgotten and
-# the backend is pointed at a gnulib-heavy binary with hundreds of source
-# functions, it will never issue more than this many (very expensive) agent
-# calls for one binary. Override with DECBENCH_LLM_MAX_FUNCS or the ``max_funcs``
-# config key.
 _DEFAULT_MAX_FUNCS = 8
 
-# Per-function wall-clock budget for one agent invocation (seconds). Manual
-# decompilation of one function — read disassembly, reason, write C — is slow;
-# the run driver's per-binary budget must comfortably exceed this times the
-# per-binary function count. Override with DECBENCH_LLM_TIMEOUT or ``timeout``.
 _DEFAULT_TIMEOUT = 900
 
-# The single-function C output file the agent is told to write, inside its
-# per-function working directory. Reading a known file is far more reliable than
-# scraping the agent's chat transcript; stdout is only the fallback.
 _OUTFILE = "decompiled.c"
 
 
-# ---------------------------------------------------------------------------
-# The shared decompilation prompt (the "common prompt for LLM systems").
-# ---------------------------------------------------------------------------
-#: The task/system instruction shared by every LLM decompiler backend. It states
-#: the goal (reconstruct original-source-faithful C), the hard tool policy (no
-#: decompilers; simple disassemblers like objdump only), the method, and the
-#: file-based output contract. Per-function specifics (binary, address, arch, a
-#: disassembly hint, the output path) are appended by :meth:`_build_prompt`.
 LLM_DECOMPILE_PROMPT = """\
 You are an expert reverse engineer performing MANUAL decompilation by hand.
 
@@ -136,10 +114,6 @@ def _creds_present(*candidates: Path) -> bool:
     return any(p.is_file() for p in candidates)
 
 
-# Matches a function *definition* header: ``name(params) {``. Anchored on the
-# name-before-parens rather than the return type, so a preceding prose line
-# cannot bleed into the match (the name/params/brace are the reliable part; the
-# return type is recovered by extending to the start of the name's line).
 _FUNC_HEADER_RE = re.compile(r"\b([A-Za-z_]\w*)\s*\([^;{}]*\)\s*\{")
 
 
@@ -242,8 +216,7 @@ def _disasm_hint(binary_path: Path, addr: int, max_bytes: int = 640) -> str:
         fmt = binfmt.detect(binary_path)
         if fmt is None:
             return ""
-        # ARM: DWARF low_pc is even, but a Thumb function's real entry has the
-        # T-bit set; disassemble as Thumb when the address is odd.
+        # An odd DWARF low_pc is a Thumb entry (T-bit set), not a byte offset.
         thumb = fmt.arch == "arm" and bool(addr & 1)
         am = binfmt.capstone_arch_mode(fmt, thumb=thumb)
         if am is None:
@@ -253,7 +226,6 @@ def _disasm_hint(binary_path: Path, addr: int, max_bytes: int = 640) -> str:
         for insn in md.disasm(blob, addr & ~1 if thumb else addr):
             lines.append(f"  0x{insn.address:x}: {insn.mnemonic} {insn.op_str}".rstrip())
             if insn.mnemonic in ("ret", "retq", "bx", "pop") and len(lines) > 3:
-                # Stop shortly after a plausible epilogue return.
                 break
             if len(lines) >= 80:
                 break
@@ -271,26 +243,20 @@ class _AgentDecompiler(Decompiler):
     parsing, checkpointing, and result assembly — lives here.
     """
 
-    # Subclass contract.
-    cli: str = ""  # the CLI binary name (must be on PATH)
-    default_model: str = ""  # model id used when config/env do not override
-    #: Credential files (relative to $HOME) that indicate the CLI is logged in.
+    cli: str = ""
+    default_model: str = ""
     cred_files: tuple[str, ...] = ()
-    #: Env vars that also count as valid credentials (e.g. an API key).
     cred_env: tuple[str, ...] = ()
 
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
         self._version_cache: str | None = None
 
-    # --- configuration -----------------------------------------------------
-
     def _settings(self) -> dict[str, Any]:
         """Per-version config (``decompilers.toml``), with a ``default`` fallback."""
         s = version_settings(self.name, self.requested_version)
         if not s and self.requested_version is None:
             s = version_settings(self.name, "default")
-        # extra_options (from DecompilerConfig) win over the TOML file.
         merged = dict(s)
         merged.update(self.config.extra_options or {})
         return merged
@@ -304,7 +270,6 @@ class _AgentDecompiler(Decompiler):
         return val if val not in (None, "") else default
 
     def _model(self) -> str:
-        # A pinned spec (codex@gpt-5.6) makes the version label the model id.
         if self.requested_version:
             return str(self.requested_version)
         return str(self._opt("model", "DECBENCH_LLM_MODEL", self.default_model))
@@ -332,8 +297,6 @@ class _AgentDecompiler(Decompiler):
         img = self._opt("docker_image", "DECBENCH_LLM_DOCKER_IMAGE", "")
         return str(img) or None
 
-    # --- availability / version -------------------------------------------
-
     def is_available(self) -> bool:
         if shutil.which(self.cli) is None:
             return False
@@ -355,17 +318,13 @@ class _AgentDecompiler(Decompiler):
             )
             out = (proc.stdout or proc.stderr or "").strip().splitlines()
             if out:
-                # e.g. "codex-cli 0.144.1" / "2.1.215 (Claude Code)"
                 toks = out[0].split()
                 ver = next((t for t in toks if any(c.isdigit() for c in t)), out[0])
         except Exception:  # noqa: BLE001
             ver = ""
         self._version_cache = ver
-        # Report the model too, so scoreboard versions distinguish gpt-5.6 etc.
         model = self._model()
         return f"{model} ({ver})" if ver else (model or None)
-
-    # --- subclass hooks ----------------------------------------------------
 
     def _agent_argv(self, workdir: Path, prompt: str, model: str) -> list[str]:
         """Return the CLI argv (run with ``cwd=workdir``). Subclass implements."""
@@ -374,8 +333,6 @@ class _AgentDecompiler(Decompiler):
     def _agent_env(self) -> dict[str, str]:
         """Environment for the agent subprocess. Subclass may extend."""
         return dict(os.environ)
-
-    # --- the decompile entrypoint -----------------------------------------
 
     def decompile_binary(
         self,
@@ -396,9 +353,6 @@ class _AgentDecompiler(Decompiler):
             decompiler=DecompilerMetadata(
                 decompiler_name=self.id,
                 decompiler_version=self.get_version(),
-                # slice_scoped: this backend only ever attempts an explicit
-                # target slice (the sample-set manifest); functions outside it
-                # were never attempted and must not be stamped decompiled=False.
                 extra={
                     "backend": self.name,
                     "via": "llm-agent",
@@ -445,15 +399,11 @@ class _AgentDecompiler(Decompiler):
                         decompiled_code=code,
                         line_count=code.count("\n") + 1,
                         metadata=common.extract_metrics(code),
-                        # Structured cost capture (data page's cost section):
-                        # per-function wall time incl. tool use, and the call's
-                        # token usage when the session log parsed. Best-effort.
                         time_seconds=elapsed,
                         llm_tokens=tokens,
                     )
                 else:
                     failed.append(name)
-                # Checkpoint partials so a hard-timeout kill still credits finished work.
                 result.decompiler.failed_functions = list(failed)
                 result.decompiler.total_time_seconds = time.time() - started
                 common.dump_progress(progress_path, result)
@@ -464,8 +414,6 @@ class _AgentDecompiler(Decompiler):
             t0 = time.time()
             try:
                 out = self._decompile_one(binary_path, name, addr, output_dir)
-                # Tolerant unpack: a subclass/test override may still return the
-                # bare code string from before the cost-capture tuple existed.
                 if isinstance(out, tuple):
                     code, elapsed, tokens = out
                 else:
@@ -476,10 +424,6 @@ class _AgentDecompiler(Decompiler):
                 elapsed = time.time() - t0
             _record(name, addr, code, elapsed, tokens)
 
-        # A binary's sampled functions are independent agent calls, so run them
-        # concurrently — a single-binary/multi-function project otherwise decompiles
-        # one function at a time while the run's other workers sit idle. Pool size
-        # via DECBENCH_LLM_FN_WORKERS / the ``fn_workers`` config key.
         workers = min(self._fn_workers(), len(targets))
         if workers <= 1:
             for name, addr in targets:
@@ -491,8 +435,6 @@ class _AgentDecompiler(Decompiler):
         result.decompiler.failed_functions = failed
         result.decompiler.total_time_seconds = time.time() - started
         return result
-
-    # --- helpers -----------------------------------------------------------
 
     def _select_targets(
         self,
@@ -511,8 +453,6 @@ class _AgentDecompiler(Decompiler):
             return [(n, int(a)) for n, a in functions]
         if function_names:
             return [(f"sub_{int(a):x}", int(a)) for a in sorted(function_names)]
-        # No filter given (e.g. a bare `decbench run`). Enumerate real symbols in
-        # .text; a stripped binary yields nothing, which is the intended guard.
         try:
             from decbench.decompilers.dockerized import elf_function_symbols
 
@@ -546,11 +486,8 @@ class _AgentDecompiler(Decompiler):
         t0 = time.time()
         with tempfile.TemporaryDirectory(prefix=f"llmdec_{self.name}_") as tmp:
             workdir = Path(tmp)
-            # Copy the (stripped) binary in under a NEUTRAL name so the agent gets
-            # no identity signal from the filename. The original name (e.g. `grep`,
-            # `gzip`, `nuttx`) would tell an LLM exactly which open-source program
-            # it is looking at and let it recall the source from memory instead of
-            # reverse-engineering — an advantage a mechanical decompiler never gets.
+            # Neutral filename: the real name would let the agent recall the upstream
+            # source from memory instead of reverse-engineering it.
             local = workdir / "target.bin"
             shutil.copy2(binary_path, local)
             outfile = workdir / _OUTFILE
@@ -581,8 +518,6 @@ class _AgentDecompiler(Decompiler):
             if not code:
                 code = _extract_c(stdout)
             final = _rename_func(_sanitize(code), name) if code else None
-            # Capture the trace BEFORE the temp dir (and the agent's session file
-            # under it, for claude) is torn down.
             elapsed = time.time() - t0
             session = self._save_trace(
                 output_dir,
@@ -596,8 +531,6 @@ class _AgentDecompiler(Decompiler):
                 elapsed=elapsed,
                 timed_out=timed_out,
             )
-            # Structured cost capture, best-effort: a token-parse failure must
-            # never break the decompilation itself.
             tokens: dict[str, int] | None = None
             if session is not None:
                 try:
@@ -661,9 +594,6 @@ class _AgentDecompiler(Decompiler):
                 f"## Reconstructed C\n\n```c\n{code or '(none — failed)'}\n```\n"
             )
             (trace_dir / f"{label}.md").write_text(body)
-            # The CLI's own session log carries every shell command it ran (the
-            # authoritative record for auditing tool use). claude: session JSONL
-            # under its config; codex: the rollout named by the session id.
             session = trace_dir / f"{label}.session.jsonl"
             self._copy_session_jsonl(workdir, transcript, session)
             return session if session.is_file() else None
@@ -713,7 +643,6 @@ class _AgentDecompiler(Decompiler):
             "-w",
             "/work",
         ]
-        # Mount whatever host credential dirs exist, read-only.
         token_dirs = (
             (home / ".codex", "/root/.codex"),
             (home / ".claude", "/root/.claude"),
@@ -737,7 +666,6 @@ class _AgentDecompiler(Decompiler):
             "HOME=/root",
             image,
         ]
-        # Inside the container the workdir is /work, so rebuild the argv against it.
         argv = self._agent_argv(Path("/work"), prompt, model)
         return docker + argv, {"env": env}
 
@@ -790,9 +718,7 @@ class CodexDecompiler(_AgentDecompiler):
     name = "codex"
     display_name = "OpenAI Codex CLI"
     cli = "codex"
-    # ``gpt-5.6-sol`` is the gpt-5.6 variant a ChatGPT-account login exposes to
-    # Codex (bare ``gpt-5.6`` / ``gpt-5.6-codex`` are rejected there with a 400).
-    # Override per config/spec for an API-key login that allows other ids.
+    # A ChatGPT-account login only accepts the ``-sol`` variant; bare ids 400.
     default_model = "gpt-5.6-sol"
     cred_files = (".codex/auth.json",)
     cred_env = ("OPENAI_API_KEY",)
@@ -813,10 +739,8 @@ class CodexDecompiler(_AgentDecompiler):
 
     def _agent_env(self) -> dict[str, str]:
         env = dict(os.environ)
-        # Run under an ISOLATED CODEX_HOME whose skills/ dir is empty, so the
-        # `decompiler` skill (which drives IDA/Ghidra/Binary Ninja via DecLib) is
-        # not available — the LLM cannot fall back to a real decompiler even if it
-        # wanted to. Auth (auth.json) + config.toml are synced from ~/.codex.
+        # Isolated CODEX_HOME with an empty skills/ dir enforces the decompiler
+        # ban; auth.json + config.toml are synced in from ~/.codex.
         env["CODEX_HOME"] = str(self._isolated_codex_home())
         return env
 
@@ -827,12 +751,11 @@ class CodexDecompiler(_AgentDecompiler):
         override = self._opt("codex_home", "DECBENCH_CODEX_HOME", "")
         home = Path(override) if override else Path.home() / ".cache" / "decbench" / "codex-home"
         home.mkdir(parents=True, exist_ok=True)
-        (home / "skills").mkdir(exist_ok=True)  # empty -> no `decompiler` skill
+        (home / "skills").mkdir(exist_ok=True)
         src = Path.home() / ".codex"
         for fn in ("auth.json", "config.toml"):
             s, d = src / fn, home / fn
-            # Sync from ~/.codex only when it is newer, so codex's own in-place
-            # token refresh (into the isolated auth.json) is not clobbered.
+            # Newer-only, so codex's in-place token refresh is not clobbered.
             if s.is_file() and (not d.exists() or s.stat().st_mtime > d.stat().st_mtime):
                 with contextlib.suppress(Exception):
                     shutil.copy2(s, d)
@@ -873,10 +796,8 @@ class ClaudeCodeDecompiler(_AgentDecompiler):
             prompt,
             "--output-format",
             "text",
-            # Let the agent run objdump and write the output file without prompts.
             "--dangerously-skip-permissions",
-            # Disable ALL skills so the `decompiler` skill (which drives real
-            # decompilers) is unavailable — enforces the decompiler ban.
+            # Disabling all skills enforces the decompiler ban.
             "--disable-slash-commands",
             "--add-dir",
             str(workdir),
@@ -887,25 +808,15 @@ class ClaudeCodeDecompiler(_AgentDecompiler):
 
     def _agent_env(self) -> dict[str, str]:
         env = super()._agent_env()
-        # If the benchmark is launched from *inside* a Claude Code session, the
-        # `CLAUDE_CODE_*` / bridge / session env vars leak into a nested `claude`
-        # subprocess, which then tries to reattach to the parent session's daemon
-        # and hangs indefinitely. Strip them so the nested CLI starts as an
-        # independent instance. (Auth via ANTHROPIC_API_KEY / ~/.claude is kept.)
+        # Inherited CLAUDE_CODE_* vars make a nested CLI reattach to the parent
+        # session's daemon and hang forever; strip them.
         for k in list(env):
             if k.startswith("CLAUDE_CODE_") or k in ("CLAUDECODE", "CLAUDE_PID", "CLAUDE_EFFORT"):
                 env.pop(k, None)
-        # Point the nested CLI at an ISOLATED config dir so it uses its own
-        # daemon/session state and can never contend with (or be blocked by) an
-        # interactive Claude Code session running as the same user. Override the
-        # location with DECBENCH_CLAUDE_CONFIG_DIR.
         cfg = self._isolated_config_dir()
         env["CLAUDE_CONFIG_DIR"] = str(cfg)
-        # Prefer the subscription OAuth login (the copied credentials) over
-        # ANTHROPIC_API_KEY: a set API key SHADOWS the OAuth login, and here that
-        # path was pathologically slow (a trivial `-p` call took >150s vs ~3s on
-        # OAuth). So drop the key when OAuth credentials are present. Force the
-        # API-key path instead with DECBENCH_CLAUDE_USE_API_KEY=1.
+        # A set API key shadows the OAuth login and is far slower here, so drop it
+        # when OAuth credentials exist (DECBENCH_CLAUDE_USE_API_KEY=1 forces it).
         if (cfg / ".credentials.json").is_file() and not os.environ.get(
             "DECBENCH_CLAUDE_USE_API_KEY"
         ):
@@ -933,7 +844,7 @@ class ClaudeCodeDecompiler(_AgentDecompiler):
             with contextlib.suppress(Exception):
                 tmp = dst.with_suffix(".json.tmp")
                 shutil.copy2(creds, tmp)
-                tmp.replace(dst)  # atomic — no torn read for a concurrent claude
+                tmp.replace(dst)
         return cfg
 
     def _copy_session_jsonl(self, workdir: Path, transcript: str, dest: Path) -> None:
@@ -960,15 +871,9 @@ class KimiCodeDecompiler(_AgentDecompiler):
     name = "kimi-code"
     display_name = "Kimi Code"
     cli = "kimi"
-    # ``kimi-code/k3`` is the Kimi K3 model alias a Kimi Code OAuth (membership)
-    # login exposes; such logins also carry ``kimi-code/kimi-for-coding``
-    # (-highspeed). Pin via spec/config, e.g. ``-d kimi-code@kimi-code/k3``.
     default_model = "kimi-code/k3"
-    # Kimi Code reads NO credential from the shell environment (an exported
-    # ``KIMI_API_KEY`` is ignored): auth is the OAuth store under
-    # ``$KIMI_CODE_HOME/credentials/`` or an ``api_key`` in ``config.toml``. The
-    # single env channel it honors is the ``KIMI_MODEL_*`` family (synthesized
-    # provider) — all three are handled in is_available().
+    # Kimi Code ignores ``KIMI_API_KEY``: auth is the OAuth store under
+    # ``$KIMI_CODE_HOME/credentials/``, config.toml, or ``KIMI_MODEL_*``.
     cred_files = ()
     cred_env = ()
 
@@ -985,11 +890,8 @@ class KimiCodeDecompiler(_AgentDecompiler):
         creds = home / "credentials"
         if creds.is_dir() and any(creds.glob("*.json")):
             return True
-        # The env-synthesized provider — the only credential channel read from env.
         if os.environ.get("KIMI_MODEL_NAME") and os.environ.get("KIMI_MODEL_API_KEY"):
             return True
-        # An API-key provider written into config.toml ([providers.*] api_key /
-        # [providers.*.env] KIMI_API_KEY). Presence check only; never logged.
         cfg = home / "config.toml"
         return cfg.is_file() and "api_key" in cfg.read_text(errors="replace")
 
@@ -1000,12 +902,8 @@ class KimiCodeDecompiler(_AgentDecompiler):
             prompt,
             "--output-format",
             "text",
-            # Point skill discovery at an EMPTY directory: --skills-dir replaces
-            # the auto-discovered user and project skill dirs for this launch,
-            # so a `decompiler` skill (which drives real decompilers) cannot
-            # load. ``-p`` already runs under the auto permission policy (no
-            # approval prompts) — the kimi equivalent of claude's
-            # --dangerously-skip-permissions.
+            # --skills-dir replaces the auto-discovered skill dirs, so pointing it at
+            # an empty directory enforces the decompiler ban.
             "--skills-dir",
             str(self._empty_skills_dir()),
         ]
@@ -1015,10 +913,6 @@ class KimiCodeDecompiler(_AgentDecompiler):
 
     def _agent_env(self) -> dict[str, str]:
         env = dict(os.environ)
-        # Run under an ISOLATED KIMI_CODE_HOME so benchmark calls never touch
-        # the user's live sessions/state; credentials + config.toml are synced
-        # from ~/.kimi-code, and its skills/ dir stays empty as
-        # defense-in-depth behind --skills-dir.
         env["KIMI_CODE_HOME"] = str(self._isolated_kimi_home())
         return env
 
@@ -1031,12 +925,9 @@ class KimiCodeDecompiler(_AgentDecompiler):
             Path(override) if override else Path.home() / ".cache" / "decbench" / "kimi-code-home"
         )
         home.mkdir(parents=True, exist_ok=True)
-        (home / "skills").mkdir(exist_ok=True)  # empty -> no Kimi-specific user skills
-        (home / "no-skills").mkdir(exist_ok=True)  # the --skills-dir target
+        (home / "skills").mkdir(exist_ok=True)
+        (home / "no-skills").mkdir(exist_ok=True)
         src = self._real_home()
-        # Sync config.toml (providers/models) and the OAuth credential store
-        # from ~/.kimi-code only when the host copy is newer, so kimi's own
-        # in-place token refresh (into the isolated copies) is not clobbered.
         s, d = src / "config.toml", home / "config.toml"
         if s.is_file() and (not d.exists() or s.stat().st_mtime > d.stat().st_mtime):
             with contextlib.suppress(Exception):

--- a/decbench/decompilers/raw/__init__.py
+++ b/decbench/decompilers/raw/__init__.py
@@ -15,10 +15,8 @@ implementations remain available for comparison under ``angr-declib`` etc.
 
 from __future__ import annotations
 
-# Import each backend module so the @register_decompiler decorators run.
-# Heavy native imports (angr, pyghidra, idapro, binaryninja) happen lazily
-# inside each plugin, so importing this package is cheap and never fails on
-# a missing decompiler.
+# Imported for their @register_decompiler side effects. The heavy native imports
+# happen lazily inside each plugin, so a missing decompiler never breaks this.
 from decbench.decompilers.raw import (
     angr_raw,  # noqa: F401
     binja_raw,  # noqa: F401

--- a/decbench/decompilers/raw/angr_raw.py
+++ b/decbench/decompilers/raw/angr_raw.py
@@ -46,10 +46,6 @@ class RawAngrDecompiler(Decompiler):
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
-    #
-    # Decompiler interface
-    #
-
     def is_available(self) -> bool:
         try:
             import angr  # noqa: F401
@@ -67,22 +63,6 @@ class RawAngrDecompiler(Decompiler):
             return str(angr.__version__)
         except Exception:  # noqa: BLE001
             return "unknown"
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        """Discover (name, ELF-space addr) for benchmarkable functions."""
-        if not self.is_available():
-            return []
-        try:
-            import angr
-
-            proj = angr.Project(str(binary_path), auto_load_libs=False)
-            proj.analyses.CFGFast(normalize=True)
-            elf_base = common.elf_min_vaddr(binary_path)
-            text_range = common.elf_text_range(binary_path)
-            return self._enumerate(proj, elf_base, text_range)
-        except Exception as e:  # noqa: BLE001
-            _l.error("angr-raw: failed to discover functions in %s: %s", binary_path, e)
-            return []
 
     def decompile_binary(
         self,
@@ -139,9 +119,8 @@ class RawAngrDecompiler(Decompiler):
             cfg = proj.analyses.CFGFast(normalize=True)
 
             if functions is not None:
-                # Caller addresses are ELF-space; angr keys functions by the
-                # binary's own (loaded) address, which for a non-PIE static
-                # ELF equals the ELF-space address. We look up by address.
+                # angr keys functions by loaded address, which equals the caller's ELF-space
+                # address for a non-PIE static ELF.
                 target_funcs = [(n, a) for (n, a) in functions]
             else:
                 target_funcs = self._enumerate(proj, elf_base, text_range)
@@ -195,10 +174,6 @@ class RawAngrDecompiler(Decompiler):
 
         return result
 
-    #
-    # angr helpers
-    #
-
     def _enumerate(
         self,
         proj: Any,
@@ -243,7 +218,6 @@ class RawAngrDecompiler(Decompiler):
     ) -> FunctionDecompilation | None:
         """Decompile one function -> FunctionDecompilation (ELF-space addr)."""
         load_base = self._angr_load_base(proj)
-        # ELF-space -> angr loaded address.
         angr_addr = (file_addr - elf_base) + load_base
         try:
             func = proj.kb.functions.get_by_addr(angr_addr)
@@ -306,7 +280,6 @@ class RawAngrDecompiler(Decompiler):
         if cfunc is None:
             return variables
 
-        # --- Arguments, in ABI/positional order. ---
         arg_list = getattr(cfunc, "arg_list", None) or []
         for position, cvar in enumerate(arg_list):
             simvar = getattr(cvar, "unified_variable", None) or getattr(cvar, "variable", None)
@@ -330,7 +303,6 @@ class RawAngrDecompiler(Decompiler):
                 )
             )
 
-        # --- Locals (stack & register), excluding the args already emitted. ---
         try:
             local_map = cfunc.get_unified_local_vars()
         except Exception:  # noqa: BLE001

--- a/decbench/decompilers/raw/binja_raw.py
+++ b/decbench/decompilers/raw/binja_raw.py
@@ -48,10 +48,6 @@ class RawBinjaDecompiler(Decompiler):
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
-    #
-    # Decompiler interface
-    #
-
     def is_available(self) -> bool:
         """Whether a licensed, importable Binary Ninja is present.
 
@@ -88,8 +84,6 @@ class RawBinjaDecompiler(Decompiler):
         """
         import binaryninja
 
-        # ``load`` runs analysis and is the modern entry point; fall back to the
-        # older BinaryViewType API if ``load`` is unavailable.
         if hasattr(binaryninja, "load"):
             bv = binaryninja.load(str(binary_path))
         else:
@@ -98,23 +92,6 @@ class RawBinjaDecompiler(Decompiler):
             with contextlib.suppress(Exception):
                 bv.update_analysis_and_wait()
         return bv
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        if not self.is_available():
-            return []
-        elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
-        bv = None
-        try:
-            bv = self._load(binary_path)
-            return self._enumerate(bv, elf_base, text_range)
-        except Exception as e:  # noqa: BLE001
-            _l.error("binja-raw: failed to discover functions in %s: %s", binary_path, e)
-            return []
-        finally:
-            if bv is not None:
-                with contextlib.suppress(Exception):
-                    bv.file.close()
 
     def decompile_binary(
         self,
@@ -222,10 +199,6 @@ class RawBinjaDecompiler(Decompiler):
 
         return result
 
-    #
-    # Binary Ninja helpers
-    #
-
     @staticmethod
     def _binja_load_base(bv: Any) -> int:
         """The address binja loaded the binary at (its start/origin)."""
@@ -245,7 +218,6 @@ class RawBinjaDecompiler(Decompiler):
         out: list[tuple[str, int]] = []
         for func in bv.functions:
             try:
-                # Skip thunks / trampolines when binja flags them.
                 if getattr(func, "is_thunk", False):
                     continue
                 name = str(func.name or "")
@@ -302,7 +274,6 @@ class RawBinjaDecompiler(Decompiler):
                 cursor = bn.LinearViewCursor(lvo)
                 cursor.seek_to_begin()
                 lines: list[str] = []
-                # Bound the walk so a pathological function can't spin forever.
                 for _ in range(100000):
                     for ln in cursor.lines:
                         lines.append(str(ln))
@@ -310,22 +281,16 @@ class RawBinjaDecompiler(Decompiler):
                         break
                 return "\n".join(lines).strip("\n")
 
-            # Force HLIL (and thus pseudo-C) generation for THIS function before
-            # rendering. Even after full binary analysis, binja 3.1's linear-view
-            # language representation returns the literal 'Loading...' placeholder
-            # until the function's HLIL is generated (it's lazy per-function).
-            # Touching func.hlil forces that computation so the render yields real
-            # C — without this, ~all functions in large binaries (e.g. bash: 2486
-            # of 2499) render as Loading and get dropped.
+            # binja generates HLIL lazily per function, so linear view returns a literal
+            # 'Loading...' placeholder until it is touched — without this, nearly every
+            # function in a large binary renders as Loading and gets dropped.
             with contextlib.suppress(Exception):
                 _ = func.hlil
                 _ = len(list(func.hlil.instructions))
 
             text = _walk()
-            # If the body is STILL the 'Loading...' placeholder (not C), force
-            # this function's analysis and re-render once; a still-placeholder
-            # body is treated as a FAILURE (return "") rather than emitting junk
-            # that pollutes GED/byte_match.
+            # A still-placeholder body is a FAILURE rather than junk that would pollute
+            # GED/byte_match.
             if not text.strip() or "Loading..." in text:
                 with contextlib.suppress(Exception):
                     func.view.update_analysis_and_wait()
@@ -335,7 +300,6 @@ class RawBinjaDecompiler(Decompiler):
         except Exception:  # noqa: BLE001
             pass
 
-        # Fallback: stringify HLIL directly (not valid C, but better than empty).
         try:
             return "\n".join(str(line) for line in func.hlil.lines)
         except Exception:  # noqa: BLE001

--- a/decbench/decompilers/raw/common.py
+++ b/decbench/decompilers/raw/common.py
@@ -12,7 +12,8 @@ its output contract exactly *without* depending on declib:
 * ``SKIP_NAMES`` / ``SKIP_PREFIXES`` — CRT/compiler-generated functions and
   thunk/import name prefixes that are never benchmarked.
 * ``should_skip_function`` / ``in_text`` — the name + section filter that
-  ``declib_dec._enumerate_functions`` applies.
+  ``declib_dec._enumerate_functions`` applies. Address comparisons tolerate the
+  ARM Thumb T-bit (DWARF ``low_pc`` is even; angr reports Thumb entries odd).
 * ``narrow_to_source`` — the optional ``function_names`` restriction (with the
   same "fall back to everything if nothing matched" behaviour as declib_dec).
 * ``dump_progress`` — the atomic partial-result pickle used by the run driver
@@ -27,7 +28,6 @@ from __future__ import annotations
 
 import logging
 import pickle
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -36,8 +36,6 @@ if TYPE_CHECKING:
 
 _l = logging.getLogger(__name__)
 
-# CRT/compiler-generated functions that are not user code. Copied verbatim
-# from declib_dec so the raw backends discover the same benchmarkable set.
 SKIP_NAMES = frozenset(
     {
         "_start",
@@ -57,7 +55,6 @@ SKIP_NAMES = frozenset(
     }
 )
 
-# Name prefixes for thunks/imports that should not be benchmarked.
 SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
 
 
@@ -81,14 +78,13 @@ def _pe_image_base(binary_path: Path) -> int | None:
             sig = f.read(4)
             if sig != b"PE\x00\x00":
                 return None
-            # COFF header is 20 bytes; the Optional Header magic follows it.
             opt = pe_off + 4 + 20
             f.seek(opt)
             magic = int.from_bytes(f.read(2), "little")
-            if magic == 0x10B:  # PE32: ImageBase is a u32 at opt+28
+            if magic == 0x10B:
                 f.seek(opt + 28)
                 return int.from_bytes(f.read(4), "little")
-            if magic == 0x20B:  # PE32+: ImageBase is a u64 at opt+24
+            if magic == 0x20B:
                 f.seek(opt + 24)
                 return int.from_bytes(f.read(8), "little")
             return None
@@ -177,9 +173,8 @@ def should_skip_function(
     if not name or name in SKIP_NAMES:
         return True
     if text_range is not None:
-        # PLT stubs / import thunks live outside .text. Inside .text we trust
-        # the section filter and never drop by name prefix (a user function may
-        # legitimately be called e.g. "j_compress").
+        # Inside .text, trust the section filter and never drop by name prefix — a user
+        # function may legitimately be called e.g. "j_compress".
         if not in_text(file_addr, text_range):
             return True
     elif name.startswith(SKIP_PREFIXES):
@@ -228,39 +223,6 @@ def _addr_matches(addr: int, target_addrs: set[int]) -> bool:
     return addr in target_addrs or (addr & ~1) in target_addrs or (addr | 1) in target_addrs
 
 
-def missing_targets(
-    enumerated_addrs: Iterable[int],
-    target_addrs: set[int] | None,
-    text_range: tuple[int, int] | None,
-) -> list[int]:
-    """DWARF target addresses that a backend's auto-analysis did NOT discover.
-
-    Used by the raw backends to *force-create* functions at addresses the tool
-    missed on stripped firmware (vector/pointer-table functions), so DecBench
-    measures decompilation quality rather than boundary discovery. Covered
-    addresses are compared with Thumb even/odd normalization; results are the
-    canonical (DWARF, even) target addresses, filtered to ``.text`` and to
-    plausible code (drops a bogus ``low_pc`` of 0 seen in some DWARF).
-    """
-    if not target_addrs:
-        return []
-    covered: set[int] = set()
-    for a in enumerated_addrs:
-        covered.add(a)
-        covered.add(a & ~1)
-        covered.add(a | 1)
-    out: list[int] = []
-    for t in sorted(target_addrs):
-        if t == 0:
-            continue
-        if t in covered or (t & ~1) in covered:
-            continue
-        if not in_text(t, text_range):
-            continue
-        out.append(t)
-    return out
-
-
 def extract_metrics(code: str) -> dict[str, Any]:
     """Extract basic structure metrics (matches ``declib_dec._extract_metrics``)."""
     return {
@@ -305,7 +267,6 @@ def line_starts(text: str) -> list[int]:
 
 def pos_to_line(pos: int, starts: list[int]) -> int:
     """Convert a 0-based character position into a 1-based line number."""
-    # Binary search for the last line start <= pos.
     import bisect
 
     idx = bisect.bisect_right(starts, pos) - 1
@@ -326,15 +287,4 @@ def merge_line_addresses(
         if not addrs:
             continue
         out.append(LineMapping(line_number=int(line_num), addresses=sorted(int(a) for a in addrs)))
-    return out
-
-
-def iter_unique(items: Iterable[Any]) -> list[Any]:
-    """Stable de-duplication helper (preserves first-seen order)."""
-    seen: set[Any] = set()
-    out: list[Any] = []
-    for it in items:
-        if it not in seen:
-            seen.add(it)
-            out.append(it)
     return out

--- a/decbench/decompilers/raw/dewolf_driver.py
+++ b/decbench/decompilers/raw/dewolf_driver.py
@@ -57,11 +57,10 @@ def main() -> int:
     bv.update_analysis_and_wait()
     load_base = int(bv.start)
 
-    # ELF-file-space address for a binja function start (mirrors binja_raw).
     def elf_addr(start: int) -> int:
         return (int(start) - load_base) + elf_base
 
-    # Thumb functions (ARM) can carry the low bit set; compare with it cleared.
+    # ARM Thumb functions can carry the low bit set; compare with it cleared.
     def matches(addr: int) -> bool:
         if target_addrs is None:
             return True
@@ -81,9 +80,8 @@ def main() -> int:
     _emit({"type": "meta", "load_base": load_base, "count": len(selected)})
 
     options: Options = Decompiler.create_options()
-    # Keep a single stubborn function from wedging the whole binary: bound the
-    # logic-engine timeouts (dewolf's dominant slow path — sympy/z3 on complex
-    # conditions). These are milliseconds.
+    # Bound dewolf's dominant slow path (sympy/z3 on complex conditions) so one
+    # stubborn function cannot wedge the binary. In milliseconds.
     for key in ("logic.engine.dead_path_timeout", "logic.engine.dead_loop_timeout"):
         with contextlib.suppress(Exception):
             options.set(key, 2000)
@@ -93,8 +91,6 @@ def main() -> int:
         name = str(func.name or f"sub_{func.start:x}")
         started = time.time()
         try:
-            # dewolf accepts a function identifier: the binja Function works
-            # directly (its frontend resolves name/address/object).
             _task, code = decompiler.decompile(func, options)
             if code and code.strip():
                 _emit(

--- a/decbench/decompilers/raw/dewolf_raw.py
+++ b/decbench/decompilers/raw/dewolf_raw.py
@@ -70,10 +70,6 @@ class RawDewolfDecompiler(Decompiler):
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
-    #
-    # Config resolution
-    #
-
     def _settings(self) -> dict:
         """Per-version settings, falling back to the ``default`` entry.
 
@@ -123,10 +119,6 @@ class RawDewolfDecompiler(Decompiler):
             env["PATH"] = astyle + os.pathsep + env.get("PATH", "")
         return env
 
-    #
-    # Decompiler interface
-    #
-
     def is_available(self) -> bool:
         python = self._python()
         if not python or not Path(python).exists():
@@ -169,7 +161,6 @@ class RawDewolfDecompiler(Decompiler):
         failed_functions: list[str] = []
         lock = threading.Lock()
 
-        # The driver filters by address itself; pass the int targets through.
         target_addrs = sorted(
             a for a in (function_names or set()) if isinstance(a, int) and not isinstance(a, bool)
         )
@@ -202,16 +193,10 @@ class RawDewolfDecompiler(Decompiler):
             )
             common.dump_progress(progress_path, partial)
 
-        # Function-level sharding: dewolf decompiles a binary's functions
-        # SEQUENTIALLY in one Binary Ninja session, so a binary with many
-        # functions pins a single core for a long time. Binary Ninja parallelizes
-        # across PROCESSES, so we split the target addresses into up to
-        # ``_shard_count`` shards and run one driver per shard concurrently — each
-        # its own BN session on a disjoint address subset — then merge. Only shard
-        # when there are enough functions to amortize each shard's BN-load cost
-        # (>= 2x the shard count); tiny binaries and the no-filter case run one
-        # driver. The driver subprocesses inherit this task's process group, so
-        # the run driver's per-binary-timeout killpg reaps them all.
+        # dewolf decompiles sequentially in one Binary Ninja session, but BN
+        # parallelizes across PROCESSES, so split the targets into shards and run one
+        # driver each. Only worth it above 2x the shard count (BN load cost). The
+        # drivers inherit this process group, so the run driver's killpg reaps them.
         if target_addrs and len(target_addrs) >= 2 * self._shard_count():
             k = self._shard_count()
             shard_args = [json.dumps(target_addrs[i::k]) for i in range(k)]

--- a/decbench/decompilers/raw/ghidra_raw.py
+++ b/decbench/decompilers/raw/ghidra_raw.py
@@ -58,10 +58,6 @@ class RawGhidraDecompiler(Decompiler):
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
-    #
-    # Version / install-dir resolution
-    #
-
     def _settings(self) -> dict:
         """Per-version settings from ``decompilers.toml`` (may be empty)."""
         from decbench.decompilers.spec import version_settings
@@ -158,12 +154,10 @@ class RawGhidraDecompiler(Decompiler):
                 str(Path(java_home) / "bin") + os.pathsep + os.environ.get("PATH", "")
             )
 
-        # Make Java run headless before the JVM boots.
         opts = os.environ.get("_JAVA_OPTIONS", "")
         if "java.awt.headless" not in opts:
             os.environ["_JAVA_OPTIONS"] = (opts + " -Djava.awt.headless=true").strip()
-        # A stale DISPLAY (e.g. an old SSH X-forward) triggers the AWT error
-        # even in "headless" Ghidra; drop it for this process.
+        # A stale DISPLAY triggers the AWT error even in headless Ghidra.
         os.environ.pop("DISPLAY", None)
 
         launcher = self._launcher()
@@ -194,10 +188,6 @@ class RawGhidraDecompiler(Decompiler):
         finally:
             shutil.rmtree(project_dir, ignore_errors=True)
 
-    #
-    # Decompiler interface
-    #
-
     def is_available(self) -> bool:
         if self._install_dir() is None:
             return False
@@ -220,21 +210,6 @@ class RawGhidraDecompiler(Decompiler):
         except Exception:  # noqa: BLE001
             pass
         return "unknown"
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        if not self.is_available():
-            return []
-        elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
-        try:
-            launcher = self._ensure_started()
-
-            with self._open_program(launcher, binary_path) as flat:
-                program = flat.getCurrentProgram()
-                return self._enumerate(program, elf_base, text_range)
-        except Exception as e:  # noqa: BLE001
-            _l.error("ghidra-raw: failed to discover functions in %s: %s", binary_path, e)
-            return []
 
     def decompile_binary(
         self,
@@ -305,7 +280,6 @@ class RawGhidraDecompiler(Decompiler):
                 ifc.openProgram(program)
                 monitor = ConsoleTaskMonitor()
                 timeout_s = int(self.config.function_timeout_seconds)
-                # Map name -> ghidra Function for the enumerated set.
                 by_name = self._functions_by_name(program)
 
                 for func_name, file_addr in enumerated:
@@ -365,10 +339,6 @@ class RawGhidraDecompiler(Decompiler):
             result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
 
         return result
-
-    #
-    # Ghidra helpers
-    #
 
     def _enumerate(
         self,
@@ -512,7 +482,6 @@ class RawGhidraDecompiler(Decompiler):
                     )
                 )
 
-        # Re-index arguments by sorted ordinal so arg_index is dense ABI order.
         params.sort(key=lambda t: t[0])
         for position, (_ord, vi) in enumerate(params):
             vi.arg_index = position

--- a/decbench/decompilers/raw/ida_raw.py
+++ b/decbench/decompilers/raw/ida_raw.py
@@ -36,8 +36,8 @@ from decbench.models.decompilation import (
 
 _l = logging.getLogger(__name__)
 
-# IDA-specific C dialect -> standard C (order matters: __int64 before __int).
-# Matches declib_dec.IDADeclibDecompiler so byte_match can recompile the output.
+# Order matters (__int64 before __int). Mirrors declib_dec.IDADeclibDecompiler
+# so byte_match can recompile the output.
 _CODE_REPLACEMENTS = (
     ("unsigned __int64", "unsigned long long"),
     ("__int64", "long long"),
@@ -71,10 +71,6 @@ class RawIDADecompiler(Decompiler):
     def __init__(self, config: DecompilerConfig | None = None):
         super().__init__(config)
 
-    #
-    # Decompiler interface
-    #
-
     def is_available(self) -> bool:
         """Whether a real, working IDA 9+ idalib is importable.
 
@@ -107,23 +103,6 @@ class RawIDADecompiler(Decompiler):
             return str(idaapi.IDA_SDK_VERSION)
         except Exception:  # noqa: BLE001
             return "unknown"
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        if not self.is_available():
-            return []
-        elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
-        try:
-            import idapro
-
-            idapro.open_database(str(binary_path), run_auto_analysis=True)
-            try:
-                return self._enumerate(elf_base, text_range)
-            finally:
-                idapro.close_database(save=False)
-        except Exception as e:  # noqa: BLE001
-            _l.error("ida-raw: failed to discover functions in %s: %s", binary_path, e)
-            return []
 
     def decompile_binary(
         self,
@@ -228,10 +207,6 @@ class RawIDADecompiler(Decompiler):
 
         return result
 
-    #
-    # IDA helpers
-    #
-
     @staticmethod
     def _ida_image_base() -> int:
         """The address IDA loaded the binary at (its image base)."""
@@ -264,7 +239,6 @@ class RawIDADecompiler(Decompiler):
             f = ida_funcs.get_func(ea)
             if f is None:
                 continue
-            # Skip thunks (IDA flags them as FUNC_THUNK).
             if f.flags & ida_funcs.FUNC_THUNK:
                 continue
             name = ida_name.get_ea_name(ea) or ""
@@ -283,7 +257,6 @@ class RawIDADecompiler(Decompiler):
         """Decompile one function with Hex-Rays -> FunctionDecompilation."""
         import ida_hexrays
 
-        # ELF-space -> IDA EA.
         ida_ea = (file_addr - elf_base) + self._ida_image_base()
         cfunc = ida_hexrays.decompile(ida_ea)
         if cfunc is None:
@@ -401,16 +374,11 @@ class RawIDADecompiler(Decompiler):
 
             for line_no in range(len(sv)):
                 line = sv[line_no].line
-                # Find the item anchored at the start of this line, if any.
                 anchor = ida_hexrays.ctree_anchor_t()
-                # Strip color tags to compute positions is non-trivial; instead
-                # use the citem-to-ea map via the function's eamap when present.
-                _ = (line, anchor, ida_lines)  # documented best-effort path
+                _ = (line, anchor, ida_lines)
         except Exception:  # noqa: BLE001
             return []
 
-        # Fall back to the function-wide EA map when available: maps EA ->
-        # list of citems; we instead need item -> line, which IDA does not
-        # expose cleanly here, so we leave line mappings empty rather than
-        # emit incorrect data.
+        # IDA exposes EA -> citems but not citem -> line, so leave line mappings empty
+        # rather than emit incorrect data.
         return common.merge_line_addresses(line_to_addrs)

--- a/decbench/decompilers/raw/kuna_raw.py
+++ b/decbench/decompilers/raw/kuna_raw.py
@@ -69,20 +69,12 @@ class RawKunaDecompiler(Decompiler):
         super().__init__(config)
         self._payload_cache: dict[str, Any] = {}
 
-    #
-    # Locating the binary (mirrors ghidra_raw's GHIDRA_INSTALL_DIR / docker's which)
-    #
-
     @staticmethod
     def _kuna_bin() -> str | None:
         env = os.environ.get("KUNA_BIN")
         if env and Path(env).is_file():
             return env
         return shutil.which("kuna")
-
-    #
-    # Decompiler interface
-    #
 
     def is_available(self) -> bool:
         return self._kuna_bin() is not None
@@ -102,23 +94,6 @@ class RawKunaDecompiler(Decompiler):
             return out.splitlines()[0] if out else "unknown"
         except Exception:  # noqa: BLE001
             return "unknown"
-
-    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
-        """Enumerate (name, ELF-file-space addr) for the benchmarkable functions."""
-        if not self.is_available():
-            return []
-        try:
-            payload = self._run_decompile_all(binary_path)
-        except Exception as e:  # noqa: BLE001
-            _l.error("kuna-raw: discover failed on %s: %s", binary_path, e)
-            return []
-        text_range = common.elf_text_range(binary_path)
-        out = [
-            (str(r.get("name") or ""), int(r.get("address") or 0))
-            for r in self._records(payload)
-        ]
-        out = [(n, a) for (n, a) in out if not common.should_skip_function(n, a, text_range)]
-        return sorted(out, key=lambda x: x[1])
 
     def decompile_binary(
         self,
@@ -168,7 +143,6 @@ class RawKunaDecompiler(Decompiler):
                 ),
             )
 
-        # 1. One CLI invocation for the whole binary (load + analyze once).
         try:
             payload = self._run_decompile_all(binary_path)
         except subprocess.TimeoutExpired as e:
@@ -179,8 +153,6 @@ class RawKunaDecompiler(Decompiler):
             _l.error("kuna-raw failed on %s: %s", binary_path, e)
             return self._error_result(binary_path, start, str(e))
 
-        # 2. Index by name, filter to the benchmarkable + source-narrowed set
-        #    (skip-set -> functions allowlist -> narrow_to_source), assemble.
         records = {str(r.get("name") or ""): r for r in self._records(payload)}
         enumerated = sorted(
             (
@@ -222,32 +194,19 @@ class RawKunaDecompiler(Decompiler):
             result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
         return result
 
-    #
-    # kuna CLI plumbing
-    #
-
     def _build_command(self, binary_path: Path) -> list[str]:
         kuna = self._kuna_bin()
         assert kuna is not None
         cmd = [kuna, "decompile-all", str(binary_path), "--json"]
-        # Per-FUNCTION watchdog: kuna decompile-all is load-once/decompile-many
-        # and emits its JSON only at the very end, so a single hanging function
-        # would otherwise stall the whole binary until the per-binary wall-clock
-        # SIGKILLs the process (losing EVERY function). --max-fn-seconds caps one
-        # function's decompile; an over-budget function becomes its own error
-        # record and the batch continues, so the per-binary budget can be generous
-        # (see DECOMPILER_TIMEOUT in run_benchmark.py). Default matches kuna's own
-        # default (120s); DECBENCH_KUNA_MAX_FN_SECONDS overrides ('0' disables).
+        # Per-function watchdog. kuna emits its JSON only at the very end, so without a
+        # per-function cap one hanging function stalls the binary until the wall-clock
+        # SIGKILL loses EVERY function. '0' disables.
         max_fn = os.environ.get("DECBENCH_KUNA_MAX_FN_SECONDS", "120")
         if max_fn:
             cmd += ["--max-fn-seconds", str(int(max_fn))]
-        # Optional decompiler mode (reliable|aggressive). Default (reliable) is the
-        # honest baseline; expose aggressive only as an explicit opt-in so kuna is
-        # not benchmarked with speculative passes the other backends don't get.
         mode = os.environ.get("DECBENCH_KUNA_MODE")
         if mode:
             cmd += ["--mode", mode]
-        # Any kuna stage-model `--option NAME VALUE` flags passed through config.
         for key, value in (self.config.extra_options or {}).items():
             cmd += ["--option", str(key), str(value)]
         return cmd
@@ -294,10 +253,8 @@ class RawKunaDecompiler(Decompiler):
             return self._payload_cache[key]
         cmd = self._build_command(binary_path)
         _l.debug("kuna run: %s", " ".join(cmd))
-        # start_new_session=True makes kuna lead its own process group so a
-        # timeout (or any other failure) can SIGKILL the WHOLE tree. It also
-        # means an outer harness killpg can no longer reach it — this backend
-        # must own the kill on every exit path.
+        # kuna leads its own process group, so an outer harness killpg can no longer
+        # reach it — this backend must own the kill on every exit path.
         p = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -308,8 +265,6 @@ class RawKunaDecompiler(Decompiler):
         try:
             stdout, stderr = p.communicate(timeout=self._timeout_seconds())
         finally:
-            # TimeoutExpired or ANY other exception: reap the group, then let
-            # the exception propagate unchanged so callers behave identically.
             if p.poll() is None:
                 self._kill_group(p)
         if p.returncode != 0 and not (stdout or "").strip():
@@ -329,14 +284,14 @@ class RawKunaDecompiler(Decompiler):
         self, rec: dict[str, Any], name: str, file_addr: int
     ) -> FunctionDecompilation | None:
         code = rec.get("code")
-        if not code:  # null (a per-function error) or empty -> failed
+        if not code:
             return None
         return FunctionDecompilation(
             name=name,
             address=file_addr,
             decompiled_code=str(code),
             line_count=str(code).count("\n") + 1,
-            line_mappings=[],  # no metric consumes these; kuna omits them
+            line_mappings=[],
             variables=self._variables(rec),
             metadata=common.extract_metrics(str(code)),
         )

--- a/decbench/decompilers/registry.py
+++ b/decbench/decompilers/registry.py
@@ -99,40 +99,8 @@ class DecompilerRegistry:
                 if instance.is_available():
                     available.append(name)
             except Exception:
-                # Skip decompilers that fail to instantiate
                 pass
         return available
-
-    @classmethod
-    def get_all(
-        cls,
-        names: list[str] | None = None,
-        config: DecompilerConfig | None = None,
-        only_available: bool = True,
-    ) -> dict[str, Decompiler]:
-        """Get multiple decompiler instances.
-
-        Args:
-            names: List of decompiler names, or None for all
-            config: Optional configuration (applied to all)
-            only_available: Only return available decompilers
-
-        Returns:
-            Dictionary mapping names to decompiler instances
-        """
-        if names is None:
-            names = cls.list_registered()
-
-        result = {}
-        for name in names:
-            try:
-                dec = cls.get(name, config)
-                if not only_available or dec.is_available():
-                    result[name] = dec
-            except (KeyError, Exception):
-                pass
-
-        return result
 
     @classmethod
     def clear(cls) -> None:

--- a/decbench/evalkit/export.py
+++ b/decbench/evalkit/export.py
@@ -32,7 +32,6 @@ _l = logging.getLogger(__name__)
 
 KIT_FORMAT_VERSION = 1
 
-# Verbatim in functions.json: the space contributors must report addresses in.
 ADDRESS_SPACE_NOTE = (
     "Virtual addresses as encoded in the binary's own headers (ELF: program-header "
     "vaddrs at the preferred/link base; PE: ImageBase + RVA). Report addresses in "
@@ -57,9 +56,9 @@ class _KitBinary:
 
     project: str
     opt: str
-    stem: str  # manifest/checkpoint key (Path(file).stem)
-    path: Path  # the real on-disk binary (unstripped)
-    functions: dict[str, int]  # DWARF name -> low_pc
+    stem: str
+    path: Path
+    functions: dict[str, int]
     anon: str = ""
 
 
@@ -174,8 +173,7 @@ def _strip_into(src: Path, dst: Path) -> None:
     proc = subprocess.run([*cmd, str(dst)], capture_output=True, text=True)
     if proc.returncode != 0:
         raise EvalKitError(f"strip failed for {src.name}: {proc.stderr.strip() or proc.stdout}")
-    # Ship non-executable: some kit binaries are real malware and the README
-    # says never to run them — don't hand out a chmod +x that invites it.
+    # Non-executable on purpose: some kit binaries are real malware.
     dst.chmod(0o644)
 
 
@@ -183,12 +181,11 @@ def _lief_sections(path: Path) -> dict[str, bytes]:
     """Section name -> content via LIEF (parses ELF and PE alike)."""
     import lief
 
-    with contextlib.suppress(Exception):  # LIEF chatters on stderr otherwise
+    with contextlib.suppress(Exception):
         lief.logging.disable()
     binary = lief.parse(str(path))
     if binary is None:
         raise EvalKitError(f"LIEF cannot parse {path}")
-    # LIEF types section names as str | bytes; decode defensively.
     return {
         sec.name.decode() if isinstance(sec.name, bytes) else sec.name: bytes(sec.content)
         for sec in binary.sections
@@ -215,8 +212,8 @@ def _pe_debug_leftovers(path: Path) -> list[str]:
     if getattr(binary.header, "numberof_symbols", 0):
         leftovers.append("COFF symbol table")
     raw = path.read_bytes()
-    # The string table sits right after the symbol table; its first 4 bytes are
-    # its own size. Without a symbol table pointer there is nothing to resolve.
+    # The string table follows the symbol table and its first 4 bytes are its own
+    # size, so without a symbol table pointer there is nothing to resolve.
     ptr = int(getattr(binary.header, "pointerto_symbol_table", 0) or 0)
     nsyms = int(getattr(binary.header, "numberof_symbols", 0) or 0)
     strtab_off = ptr + nsyms * 18 if ptr else 0
@@ -341,10 +338,8 @@ def export_kit(
     if not bins:
         raise EvalKitError("nothing to export: no manifest entry resolved to a binary+address")
 
-    # Anonymous identity assignment: deterministic for a given (manifest, seed).
-    # Byte-identical duplicates (e.g. crazyflie's cf2.elf/firmware.elf) stay
-    # SEPARATE anon binaries on purpose — each keeps its own per-binary identity
-    # in the tree, so merging them would corrupt the de-anonymized mapping.
+    # Byte-identical duplicates stay SEPARATE anon binaries on purpose: each keeps
+    # its own per-binary identity, so merging would corrupt the de-anonymized map.
     bins.sort(key=lambda b: (b.project, b.opt, b.path.name))
     random.Random(seed).shuffle(bins)
     for i, b in enumerate(bins):
@@ -352,7 +347,7 @@ def export_kit(
 
     binaries_dir = kit_dir / "binaries"
     results_dir = kit_dir / "results"
-    for stale in (binaries_dir, results_dir):  # stale kit content is worse than none
+    for stale in (binaries_dir, results_dir):
         if stale.exists():
             shutil.rmtree(stale)
     binaries_dir.mkdir(parents=True)
@@ -399,8 +394,8 @@ def export_kit(
     }
     (kit_dir / "functions.json").write_text(json.dumps(functions_json, indent=2) + "\n")
     (kit_dir / "README.md").write_text(templates.kit_readme(dataset, len(bins), n_functions))
-    # package.py is the kit_package module source VERBATIM — it must stay
-    # standalone (stdlib-only, no decbench imports) so contributors can run it.
+    # Shipped verbatim, so it must stay standalone (stdlib-only, no decbench
+    # imports) for contributors to run.
     (kit_dir / "package.py").write_text(Path(kit_package.__file__).read_text())
     (results_dir / "README.md").write_text(templates.results_readme())
     (results_dir / "results.example.json").write_text(templates.results_example(public))

--- a/decbench/evalkit/ingest.py
+++ b/decbench/evalkit/ingest.py
@@ -54,8 +54,6 @@ KIT_FORMAT_VERSION = 1
 
 _DEC_ID_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 
-# Default overlay-refresh columns (mirrors scripts/reeval_ged.py DECOMPILERS);
-# next_steps appends the new dec_id so a reeval pass covers every column.
 _REEVAL_DEFAULTS = (
     "angr",
     "ghidra",
@@ -68,9 +66,8 @@ _REEVAL_DEFAULTS = (
     "claude-code",
 )
 
-# The LLM backends are absent from scripts/reeval_bytematch.py's tuple by design
-# (their byte_match rides on inline checkpoint values), so the byte_match
-# refresh command must not name them.
+# The LLM backends' byte_match rides on inline checkpoint values, so the
+# byte_match refresh command must not name them.
 _LLM_BASENAMES = ("codex", "claude-code", "kimi-code")
 
 
@@ -93,11 +90,11 @@ class _Entry:
     """One submitted binary, fully resolved and ready to merge."""
 
     project: str
-    opt: str  # OptimizationLevel value, e.g. "O0"
-    stem: str  # tree/checkpoint binary key
-    binary: Path  # the unstripped on-disk binary
+    opt: str
+    stem: str
+    binary: Path
     result: DecompilationResult
-    addrs: set[int]  # kept DWARF low_pcs (restricts source-CFG extraction)
+    addrs: set[int]
 
 
 @dataclass
@@ -112,9 +109,6 @@ def _warn(warnings: list[str], msg: str) -> None:
     _l.warning("%s", msg)
 
 
-# --------------------------------------------------------------------------- #
-# Submission loading
-# --------------------------------------------------------------------------- #
 def _open_submission(submission: Path, stack: contextlib.ExitStack) -> tuple[dict, Path]:
     """Load the packaged ``results.json`` and the directory holding its ``.c`` files.
 
@@ -130,7 +124,6 @@ def _open_submission(submission: Path, stack: contextlib.ExitStack) -> tuple[dic
         try:
             with zipfile.ZipFile(submission) as zf:
                 for name in zf.namelist():
-                    # package.py emits flat archives; be defensive anyway.
                     if name.startswith(("/", "..")) or ".." in Path(name).parts:
                         raise EvalKitError(f"unsafe path in {submission.name}: {name!r}")
                 zf.extractall(tmp)
@@ -149,7 +142,6 @@ def _open_submission(submission: Path, stack: contextlib.ExitStack) -> tuple[dic
 
     results_path = root / "results.json"
     if not results_path.is_file():
-        # A zip may nest one top-level folder if it was re-zipped by hand.
         nested = [d / "results.json" for d in sorted(root.iterdir()) if d.is_dir()]
         hits = [p for p in nested if p.is_file()]
         if len(hits) == 1:
@@ -239,9 +231,6 @@ def _parse_addr(value: object) -> int | None:
     return None
 
 
-# --------------------------------------------------------------------------- #
-# C snippet extraction
-# --------------------------------------------------------------------------- #
 def _extract_definition(text: str, name: str) -> str | None:
     """Locate ``name(...) { ... }`` directly when ``split_c_functions`` missed it.
 
@@ -253,7 +242,7 @@ def _extract_definition(text: str, name: str) -> str | None:
     for m in re.finditer(r"\b" + re.escape(name) + r"\s*\(", text):
         n = len(text)
         depth = 0
-        j = m.end() - 1  # at the opening paren
+        j = m.end() - 1
         while j < n:
             ch = text[j]
             if ch == "(":
@@ -269,7 +258,7 @@ def _extract_definition(text: str, name: str) -> str | None:
         while k < n and text[k] in " \t\r\n":
             k += 1
         if k >= n or text[k] != "{":
-            continue  # a call or prototype, not a definition
+            continue
         depth = 0
         e = k
         while e < n:
@@ -284,7 +273,6 @@ def _extract_definition(text: str, name: str) -> str | None:
         if e >= n:
             continue
         start = text.rfind("\n", 0, m.start()) + 1
-        # Pull in a return type that sits on its own preceding line(s).
         lines = text[:start].splitlines(keepends=True)
         while lines:
             prev = lines[-1].strip()
@@ -295,9 +283,6 @@ def _extract_definition(text: str, name: str) -> str | None:
     return None
 
 
-# --------------------------------------------------------------------------- #
-# Per-entry build
-# --------------------------------------------------------------------------- #
 def _build_entry(
     tree: Path,
     manifest: set[tuple[str, str, str, str]],
@@ -322,7 +307,7 @@ def _build_entry(
     opt = ident.get("opt")
     stem = ident.get("binary")
     file_name = ident.get("file")
-    # Explicit per-name isinstance checks (not all(...)) so mypy narrows to str.
+    # Per-name checks rather than all(...) so mypy narrows each to str.
     if (
         not isinstance(project, str)
         or not project
@@ -349,8 +334,6 @@ def _build_entry(
         raise EvalKitError(f"submission is missing the listed file {c_name}")
     c_text = c_path.read_text(errors="replace")
 
-    # The unstripped on-disk binary: prefer the FULL original filename (lossless
-    # for multi-dot names like libacl.so.1.1.2301), fall back to the stem.
     try:
         binary = resolve.discover_binary(tree, opt, project, file_name or stem)
     except FileNotFoundError:
@@ -405,13 +388,9 @@ def _build_entry(
             )
             continue
         if dwarf_name != sub_name:
-            # Same semantics as the run driver's _relabel_to_dwarf: rename the
-            # function's OWN identifier inside its own snippet; call sites to
-            # sibling functions keep their submitted names (as they do for every
-            # stripped-binary backend).
             code = re.sub(r"\b" + re.escape(sub_name) + r"\b", dwarf_name, code)
             counters.relabeled += 1
-        low_pc = name2addr.get(dwarf_name, addr)  # export shipped name_to_addr addresses
+        low_pc = name2addr.get(dwarf_name, addr)
         prev = kept.get(dwarf_name)
         if prev is not None:
             _warn(
@@ -451,15 +430,10 @@ def _build_entry(
     )
 
 
-# --------------------------------------------------------------------------- #
-# Checkpoints
-# --------------------------------------------------------------------------- #
 def _load_checkpoint(path: Path) -> dict:
     """Load (or initialize) a per-project checkpoint pickle."""
     if not path.exists():
         return {"decompile": {}, "evaluate": {}}
-    # Register plugin/metric modules so the pickle resolves every class
-    # (mirrors results_store.load_checkpoints).
     import decbench.decompilers  # noqa: F401
     import decbench.metrics  # noqa: F401
 
@@ -560,9 +534,6 @@ def _opt_key(section: dict, opt: str) -> Any:
     return enum_key
 
 
-# --------------------------------------------------------------------------- #
-# Inline evaluation (all imports lazy — evaluate=False never reaches here)
-# --------------------------------------------------------------------------- #
 def _stems_for_addrs(binary: Path, addrs: set[int], stems: set[str]) -> set[str]:
     """The ``.i`` TU stems whose DWARF subprograms cover ``addrs``.
 
@@ -584,7 +555,6 @@ def _stems_for_addrs(binary: Path, addrs: set[int], stems: set[str]) -> set[str]
     try:
         for cu in dw.iter_CUs():
             lp = dw.line_program_for_CU(cu)
-            # DWARF v4/v5 decl_file indexing — see resolve._dwarf_addr_to_name.
             version = 4
             if lp is not None:
                 version = lp.header.get("version", cu.header.get("version", 4))
@@ -656,7 +626,7 @@ def _evaluate_group(
             for e in entries:
                 got = _stems_for_addrs(e.binary, e.addrs, set(i_by_stem))
                 if not got:
-                    needed = set(i_by_stem)  # unknown TU: parse everything
+                    needed = set(i_by_stem)
                     break
                 needed |= got
             for stem in sorted(needed):
@@ -680,15 +650,9 @@ def _evaluate_group(
     return out
 
 
-# --------------------------------------------------------------------------- #
-# Follow-up commands
-# --------------------------------------------------------------------------- #
 def _next_steps(tree: Path, dec_id: str) -> str:
     """The exact follow-up commands to publish the new column."""
     reeval = ",".join((*_REEVAL_DEFAULTS, dec_id))
-    # byte_match's overlay script excludes the LLM backends by design (their
-    # byte_match rides on inline checkpoint values), so its list is the shared
-    # defaults minus those, plus the new column.
     bm_reeval = ",".join((*(d for d in _REEVAL_DEFAULTS if d not in _LLM_BASENAMES), dec_id))
     return (
         f"Next steps to publish '{dec_id}':\n"
@@ -718,9 +682,6 @@ def _next_steps(tree: Path, dec_id: str) -> str:
     )
 
 
-# --------------------------------------------------------------------------- #
-# Entry point
-# --------------------------------------------------------------------------- #
 def ingest_submission(
     submission: Path,
     tree: Path,
@@ -804,8 +765,6 @@ def ingest_submission(
             f"binaries; none for: {shown}{more}",
         )
 
-    # Load every touched checkpoint and refuse duplicate ingest up front, before
-    # any artifact or checkpoint is written.
     by_project: dict[str, list[_Entry]] = {}
     for e in entries:
         by_project.setdefault(e.project, []).append(e)
@@ -827,14 +786,12 @@ def ingest_submission(
         _l.info("force: overwriting %d existing %s slice(s)", len(conflicts), dec_id)
         _purge_stale_slices(tree, ckpts, dec_id, seen_slices, warnings)
 
-    # Artifacts: the same layout the run driver writes.
     for e in entries:
         dec_out = tree / e.opt / e.project / "decompiled"
         dec_out.mkdir(parents=True, exist_ok=True)
         e.result.to_c_file(dec_out / f"{dec_id}_{e.stem}.c")
         e.result.to_toml(dec_out / f"{dec_id}_{e.stem}.toml")
 
-    # Optional inline evaluation (the only path that may import pyjoern).
     evals: dict[tuple[str, str], dict[str, dict[str, MetricResult]]] = {}
     if evaluate:
         import decbench.metrics  # noqa: F401 — register the metric plugins
@@ -850,12 +807,9 @@ def ingest_submission(
                 tree, project, opt, ents, metric_names, needs_source, warnings
             )
 
-    # Additive checkpoint merge, then one atomic write per project. The
-    # checkpoint is RE-READ here rather than reusing the copy loaded before the
-    # conflict check: inline evaluation can run for hours, and writing back a
-    # snapshot from before it would silently revert anything another process
-    # (e.g. a concurrent run_benchmark on other decompilers) checkpointed in the
-    # meantime. The purge is re-applied to the fresh copy for the same reason.
+    # Re-read the checkpoint rather than reusing the pre-conflict-check copy: inline
+    # evaluation can run for hours, and writing back the older snapshot would revert
+    # anything a concurrent process checkpointed meanwhile.
     for project, ents in by_project.items():
         ckpt = _load_checkpoint(ckpt_dir / f"{project}.pkl")
         if conflicts:
@@ -864,9 +818,8 @@ def ingest_submission(
             dsec = ckpt["decompile"]
             okey = _opt_key(dsec, e.opt)
             dsec.setdefault(okey, {}).setdefault(e.stem, {})[dec_id] = e.result
-            # Clear any prior metric results for this column FIRST: a re-ingest
-            # with --no-evaluate (or one whose evaluation failed) must not leave
-            # the previous submission's numbers attached to the new code.
+            # Clear first, so a re-ingest with --no-evaluate cannot leave the previous
+            # submission's numbers attached to the new code.
             esec = ckpt["evaluate"]
             ekey = _opt_key(esec, e.opt)
             esec.setdefault(ekey, {}).setdefault(e.stem, {}).pop(dec_id, None)

--- a/decbench/evalkit/kit_package.py
+++ b/decbench/evalkit/kit_package.py
@@ -29,7 +29,6 @@ from pathlib import Path
 
 KIT_FORMAT_VERSION = 1
 
-# results/ files that are part of the kit itself, not the submission.
 _KIT_OWNED = {"README.md", "results.example.json", "results.json"}
 
 
@@ -150,8 +149,8 @@ def validate_and_package(kit_root: Path, out_path: Path | None = None, quiet: bo
         entries = {}
 
     packaged: dict = {}
-    covered_binaries: dict = {}  # anon binary -> .c file claiming it
-    covered_addrs: dict = {}  # anon binary -> set of claimed addresses
+    covered_binaries: dict = {}
+    covered_addrs: dict = {}
     listed_c: set = set()
     n_functions = 0
 
@@ -203,9 +202,8 @@ def validate_and_package(kit_root: Path, out_path: Path | None = None, quiet: bo
                     '(use a hex string like "0x1234")'
                 )
                 continue
-            # ARM/Thumb tools report entry points with the low bit set; the kit
-            # README promises the odd form is tolerated, so normalize to the
-            # even target instead of rejecting it (ingest applies the same rule).
+            # The kit README promises the odd (Thumb LSB) form is tolerated, so normalize
+            # to the even target instead of rejecting it — ingest applies the same rule.
             if addr not in public[anon] and (addr & ~1) in public[anon]:
                 addr &= ~1
             if addr not in public[anon]:
@@ -224,8 +222,6 @@ def validate_and_package(kit_root: Path, out_path: Path | None = None, quiet: bo
             if not _word_present(c_text, fn_name):
                 warnings.append(f"{where}: identifier {fn_name} not found in results/{c_name}")
             out_funcs[fn_name] = f"0x{addr:x}"
-        # (duplicate function names within one file are impossible past JSON
-        # parsing — the duplicate-key hook rejects them at load time)
 
         covered_addrs[anon] = set(seen_addrs)
         n_functions += len(out_funcs)
@@ -237,9 +233,6 @@ def validate_and_package(kit_root: Path, out_path: Path | None = None, quiet: bo
             "functions": out_funcs,
         }
 
-    # Coverage + stray-file warnings (never fatal). Partial submissions are
-    # explicitly allowed, so uncovered binaries are summarized in ONE line — a
-    # per-binary warning would bury the real ones under hundreds of lines.
     uncovered = sorted(set(public) - set(covered_binaries))
     if uncovered:
         shown = ", ".join(uncovered[:5])
@@ -277,8 +270,6 @@ def validate_and_package(kit_root: Path, out_path: Path | None = None, quiet: bo
     out_json = {
         "kit_format_version": functions_json.get("kit_format_version", KIT_FORMAT_VERSION),
         "dataset": functions_json.get("dataset", "sample-set"),
-        # Carried through so ingest can detect that the benchmark's frozen
-        # manifest was re-drawn after this kit was exported.
         "manifest_sha256": functions_json.get("manifest_sha256"),
         "packaged_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "decompiler": {"name": dec_name, "version": dec_version},

--- a/decbench/evalkit/resolve.py
+++ b/decbench/evalkit/resolve.py
@@ -69,9 +69,8 @@ def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
             files: list[str | None] = []
             if stems is not None:
                 lp = dw.line_program_for_CU(cu)
-                # DW_AT_decl_file indexing is 1-based pre-DWARF5 (entry 0
-                # unused) and 0-based in DWARF5 (entry 0 = primary source);
-                # prepend a placeholder only for pre-v5 so the index lines up.
+                # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
+                # makes the index line up either way.
                 version = 4
                 if lp is not None:
                     version = lp.header.get("version", cu.header.get("version", 4))

--- a/decbench/metrics/base.py
+++ b/decbench/metrics/base.py
@@ -50,9 +50,8 @@ class Metric(ABC):
     requires_source_cfg: bool = False
     requires_decompiled_cfg: bool = False
 
-    # Bump when a metric's computation semantics change so stale cache entries
-    # from an older code version are never reused. Override per-metric when its
-    # specific inputs/formula change.
+    # Bump this whenever a metric's computation semantics change, or the
+    # content-addressed cache will serve values from the older formula.
     cache_version: str = "1"
 
     def __init__(self, config: MetricConfig | None = None):
@@ -81,7 +80,6 @@ class Metric(ABC):
             try:
                 return MetricValue(**hit)
             except Exception:
-                # Corrupt/incompatible cache entry: fall through and recompute.
                 pass
 
         value = compute()
@@ -131,10 +129,8 @@ class Metric(ABC):
                     decompiled_cfg=decompiled_cfg,
                     **kwargs,
                 )
-                # A non-finite value means "unmeasurable for everyone" (e.g. GED
-                # with an empty-prototype/degenerate source CFG). ABSTAIN — don't
-                # record it — so it's excluded from this metric's denominator
-                # uniformly for all decompilers, rather than counted as a failure.
+                # A non-finite value means "unmeasurable for everyone". Abstain so it leaves
+                # this metric's denominator uniformly instead of counting as a failure.
                 if not math.isfinite(value.value):
                     continue
                 function_results[func_name] = value

--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -25,12 +25,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Branch/call mnemonics whose operand is a code address. After single-function
-# recompilation that target is an *unlinked* relative displacement (or a
-# different absolute, since we disassemble the original at its real vaddr and the
-# recompiled object at 0), so the printed target is layout/linker-dependent and
-# must be normalized away before diffing — otherwise every call/jump counts as a
-# mismatch even when the control flow is identical.
+# Branch/call mnemonics whose operand is a code address. That target is
+# layout/linker-dependent after single-function recompilation, so it must be
+# normalized away or identical control flow counts as a mismatch.
 _BRANCH_MNEMONICS = frozenset(
     {
         "call",
@@ -63,7 +60,6 @@ _BRANCH_MNEMONICS = frozenset(
         "jpe",
         "jpo",
         "jcxz",
-        # ARM / AArch64 branches.
         "b",
         "bl",
         "blx",
@@ -87,21 +83,10 @@ _BRANCH_MNEMONICS = frozenset(
     }
 )
 
-# An immediate literal, optionally ARM-style ``#``-prefixed (and possibly
-# negative), hex OR decimal: ``0x40``, ``#0x40``, ``#-0x40``, and the bare
-# decimal form capstone prints for small displacements/targets (``call 4``).
 _HEX_TOKEN = re.compile(r"#?-?(?:0x[0-9a-fA-F]+|\d+)")
-# A PC/IP-relative *memory* operand: x86 ``[rip + 0x..]`` / ``[rip - 0x..]`` and
-# AArch64 literal loads ``[pc, #0x..]``. The displacement encodes a data/GOT
-# offset fixed up at link time, so it is layout-dependent and gets a placeholder.
-# The displacement is OPTIONAL and may be decimal: in an *unlinked* object the
-# relocation slot is 0 and capstone prints a bare ``[rip]`` (and small
-# displacements print as decimal, e.g. ``[rip + 7]``) — without matching those,
-# every global/string access in a recompiled object mismatches its linked
-# original purely because of linking.
+# The displacement is OPTIONAL and may be decimal: an unlinked object has a zero
+# relocation slot, which capstone prints as a bare ``[rip]``.
 _PC_REL_MEM = re.compile(r"\[(rip|pc)(?:\s*[+\-,]\s*#?-?(?:0x[0-9a-fA-F]+|\d+))?\]")
-# AArch64 PC-relative *address* computations whose immediate is the (page)
-# target itself — capstone prints e.g. ``adrp x0, #0x400000``.
 _PC_REL_MNEMONICS = frozenset({"adrp", "adr"})
 
 
@@ -114,13 +99,7 @@ def _normalize_operands(mnemonic: str, op_str: str) -> str:
     same. We blank those so the diff measures *real* assembly differences, not
     relocation noise — the central fairness fix for this metric.
     """
-    # PC-relative data references: [rip + 0x..] / [pc, #0x..] -> [<base>+X]
     op_str = _PC_REL_MEM.sub(lambda m: f"[{m.group(1)}+X]", op_str)
-    # Blank the immediate when it IS a link-dependent address: AArch64 adrp/adr
-    # (the immediate is the PC-relative target), or a DIRECT branch/call target
-    # (a bare address, no memory operand). An indirect ``call [rax + 0x20]``
-    # displacement is a base-independent struct/vtable offset — a real difference
-    # we keep — so memory-operand branches are excluded.
     if mnemonic in _PC_REL_MNEMONICS or (mnemonic in _BRANCH_MNEMONICS and "[" not in op_str):
         op_str = _HEX_TOKEN.sub("X", op_str)
     return op_str
@@ -144,7 +123,6 @@ def _disassemble_bytes(data: bytes, address: int = 0, arch_mode: tuple | None = 
 
         lines: list[str] = []
         for insn in cs.disasm(data, address):
-            # Skip nops (alignment padding varies between compilations)
             if insn.mnemonic == "nop":
                 continue
 
@@ -152,14 +130,9 @@ def _disassemble_bytes(data: bytes, address: int = 0, arch_mode: tuple | None = 
             line = f"{insn.mnemonic} {op_str}".strip()
             lines.append(line)
 
-        # Drop x86-64 varargs AL-zeroing (``mov eax, 0`` / ``xor eax, eax``
-        # immediately before a call): the SysV ABI makes callers zero AL for
-        # variadic/unprototyped callees, so its presence tracks whether a
-        # *prototype* was in scope at compile time — for recompiled decompiler
-        # output the prototype is our injected scaffolding, not the
-        # decompiler's logic. Applied to BOTH listings uniformly. ONLY on
-        # x86-64: i386 (regparm) and Win64 have no AL-varargs convention, so a
-        # ``xor eax, eax`` before a call there is a real register argument.
+        # AL-zeroing before a call tracks whether a prototype was in scope, which for
+        # recompiled output is our scaffolding rather than the decompiler's logic. Only
+        # on x86-64: elsewhere a ``xor eax, eax`` before a call is a real argument.
         if arch_mode == (capstone.CS_ARCH_X86, capstone.CS_MODE_64):
             lines = [
                 ln
@@ -225,7 +198,6 @@ def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> tuple
         return shared / total, a_only + b_only
 
     except ImportError:
-        # Fall back to simple set-based Jaccard
         set_a = set(lines_a)
         set_b = set(lines_b)
         intersection = set_a & set_b
@@ -233,23 +205,6 @@ def _compute_jaccard_similarity(lines_a: list[str], lines_b: list[str]) -> tuple
         if not union:
             return 1.0, 0
         return len(intersection) / len(union), len(set_a ^ set_b)
-
-
-def _compile_function(
-    code: str,
-    func_name: str,
-    compiler: str = "gcc",
-    flags: list[str] | None = None,
-) -> Path | None:
-    """Compile a single function's decompiled code to an object file.
-
-    Thin wrapper over :func:`decbench.metrics.fixup.compile_with_fixup` (which
-    maximizes the odds the code builds). Returns the object path or ``None``.
-    """
-    from decbench.metrics.fixup import compile_with_fixup
-
-    result = compile_with_fixup(code, func_name, compiler, flags)
-    return result.obj_path
 
 
 @register_metric("byte_match")
@@ -275,16 +230,6 @@ class ByteMatchMetric(Metric):
     requires_source_cfg = False
     requires_decompiled_cfg = False
 
-    # v5: rip/pc-relative normalization also covers the unlinked-object bare
-    # ``[rip]`` (zero/decimal displacement) form; direct branch/call targets
-    # normalize decimal as well as hex; x86-64-only varargs AL-zeroing before
-    # calls is dropped from both listings; fixup gains width-correct IDA/Ghidra
-    # pseudo-types, semantically-correct helper macros, sibling/libc prototypes,
-    # struct synthesis, positional repairs and a malformed-decl backout, and
-    # producer_flags now carries codegen ``-f`` flags. (NOTE: a bare ``[rip]``
-    # conflates reads of *different* globals — the same accepted precision limit
-    # the linked-side hex displacement always had; symbol identity isn't
-    # compared.)
     cache_version = "5"
 
     def __init__(self, config: MetricConfig | None = None):
@@ -319,12 +264,9 @@ class ByteMatchMetric(Metric):
 
         from decbench.utils import binfmt
 
-        # Recompile THE SAME WAY THE SOURCE WAS COMPILED: pick the toolchain and
-        # arch/opt flags that match the original binary's own format+arch
-        # (PE -> MinGW, ARM -> arm-none-eabi, x86 -> gcc; flags from the DWARF
-        # producer), instead of a fixed host gcc. If that toolchain isn't
-        # installed, we can't match it — return a non-scoring result rather than
-        # comparing against a wrong-arch recompile.
+        # Recompile the way the source was compiled (PE -> MinGW, ARM -> arm-none-eabi,
+        # x86 -> gcc, flags from the DWARF producer). Without that toolchain, return a
+        # non-scoring result rather than comparing against a wrong-arch recompile.
         info = binfmt.detect(original_binary_path)
         if info is None:
             return MetricValue(value=0.0, metadata={"error": "Unrecognized binary format"})
@@ -337,13 +279,9 @@ class ByteMatchMetric(Metric):
                     "reason": f"no matching toolchain ({recompiler}) for {info.fmt}/{info.arch}",
                 },
             )
-        # producer flags (e.g. -m32 -march=... -O2, or -mcpu=cortex-m4 -mthumb)
-        # so the recompile matches; then compile to an object.
         flags = binfmt.producer_flags(original_binary_path) + ["-c", "-fno-builtin", "-w"]
         arch_mode = binfmt.capstone_arch_mode(info)
 
-        # Extract original function bytes ONCE; reuse for both the cache key and
-        # the comparison.
         original_bytes = binfmt.function_bytes(
             original_binary_path, decompiled.name, decompiled.address
         )
@@ -353,9 +291,6 @@ class ByteMatchMetric(Metric):
                 metadata={"error": "Could not extract original function bytes"},
             )
 
-        # Sibling prototypes (the decompiler's OWN recovered signatures for the
-        # binary's other functions) shape the fixup's injected decls, so they
-        # are part of the cache key.
         context_decls: dict[str, str] | None = kwargs.get("context_decls")
         key_inputs = [
             decompiled.decompiled_code,
@@ -387,9 +322,6 @@ class ByteMatchMetric(Metric):
         from decbench.metrics.fixup import compile_with_fixup
         from decbench.utils import binfmt
 
-        # Compile decompiled code the same way as source (matching toolchain),
-        # running the fixup/self-repair pass so the maximum number of functions
-        # build (otherwise non-compiling code is a flat 0 and dominates).
         fix = compile_with_fixup(
             decompiled.decompiled_code,
             decompiled.name,
@@ -409,7 +341,6 @@ class ByteMatchMetric(Metric):
                 },
             )
 
-        # The fixup pass places the object in its own temp dir; clean the dir.
         obj_dir = obj_path.parent
         fixup_meta = {
             "compilable": True,
@@ -417,8 +348,6 @@ class ByteMatchMetric(Metric):
             "fixup_injected": len(fix.injected),
         }
         try:
-            # Extract recompiled function bytes (.text of the single-function
-            # object — ELF or COFF/MinGW).
             recompiled_bytes = binfmt.object_text_bytes(obj_path, decompiled.name)
 
             if recompiled_bytes is None:
@@ -427,7 +356,6 @@ class ByteMatchMetric(Metric):
                     metadata={**fixup_meta, "error": "Could not extract recompiled bytes"},
                 )
 
-            # First check exact byte match
             if recompiled_bytes == original_bytes:
                 return MetricValue(
                     value=1.0,
@@ -441,7 +369,6 @@ class ByteMatchMetric(Metric):
                     },
                 )
 
-            # Disassemble (with the binary's own arch) and compute similarity
             original_asm = _disassemble_bytes(original_bytes, decompiled.address, arch_mode)
             recompiled_asm = _disassemble_bytes(recompiled_bytes, 0, arch_mode)
 
@@ -450,7 +377,6 @@ class ByteMatchMetric(Metric):
                     original_asm, recompiled_asm
                 )
             else:
-                # Fallback: raw byte comparison ratio
                 min_len = min(len(original_bytes), len(recompiled_bytes))
                 max_len = max(len(original_bytes), len(recompiled_bytes))
                 if max_len == 0:
@@ -462,7 +388,6 @@ class ByteMatchMetric(Metric):
                     similarity = matching / max_len
                 changed_lines = abs(len(original_bytes) - len(recompiled_bytes))
 
-            # A perfect match requires similarity == 1.0
             return MetricValue(
                 value=1.0 if similarity == 1.0 else similarity,
                 raw_value=similarity,
@@ -470,8 +395,6 @@ class ByteMatchMetric(Metric):
                     **fixup_meta,
                     "exact_match": False,
                     "jaccard_similarity": similarity,
-                    # Absolute edit distance (# changed asm lines) for the report's
-                    # 'distance' view; does not affect the (unchanged) jaccard score.
                     "changed_lines": changed_lines,
                     "original_size": len(original_bytes),
                     "recompiled_size": len(recompiled_bytes),
@@ -499,12 +422,8 @@ class ByteMatchMetric(Metric):
 
         original_binary_path = decompilation.binary_path
 
-        # ABSTAIN (emit no per-function results) when the matching recompile
-        # toolchain isn't installed for this binary's format/arch — e.g. ARM
-        # firmware (cps) or PE malware decompiled on an x86 host without the
-        # cross/mingw gcc. Scoring those 0 would be unfair ("couldn't measure" is
-        # not "wrong"); abstaining drops byte_match for the binary so GED +
-        # type_match carry it (per-metric denominators already differ).
+        # Abstain rather than score 0 when the matching toolchain isn't installed:
+        # "couldn't measure" is not "wrong", and GED + type_match still carry the binary.
         if original_binary_path is not None:
             from decbench.utils import binfmt
 
@@ -524,8 +443,6 @@ class ByteMatchMetric(Metric):
                         ],
                     )
 
-        # The decompiler's own signatures for this binary's functions: used by
-        # the fixup to give internal calls real prototypes.
         from decbench.metrics.fixup import derive_context_decls
 
         context_decls = derive_context_decls(

--- a/decbench/metrics/fixup.py
+++ b/decbench/metrics/fixup.py
@@ -57,49 +57,22 @@ import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
-# gcc localizes diagnostics and (by default) quotes identifiers with Unicode
-# curly quotes (' ') — force the C locale so it emits plain ASCII quotes that the
-# repair regexes below can match. (The regexes also accept curly quotes as a
-# fallback, in case a toolchain ignores the locale.)
+# Forces ASCII quoting in gcc diagnostics so the repair regexes below match.
 _C_LOCALE_ENV = {**os.environ, "LC_ALL": "C", "LANG": "C", "LANGUAGE": "C"}
-_Q = r"['‘’“”]"  # ascii ' or " plus curly variants
+_Q = r"['‘’“”]"
 
-# Strip a leading ``Namespace::`` qualifier (e.g. ``GLIBC_2.2.5::stderr`` ->
-# ``stderr``). Decompiled C never uses real C++ scope resolution, so any ``::``
-# is a symbol-version artifact we can safely drop. Also strip a BARE leading
-# ``::`` (IDA's "global shadowed by a local" disambiguator, ``::s``).
 _NS_QUALIFIER = re.compile(r"\b[A-Za-z_][\w.$]*::")
 _BARE_SCOPE = re.compile(r"(?<![\w)\]>]):{2}(?=\s*[A-Za-z_])")
 
-# Decompiler-specific function/type ANNOTATIONS that aren't valid C in the place
-# they appear (Binary Ninja's ``__noreturn``/``__pure`` suffixes, IDA/Ghidra
-# ``__cdecl``/``__fastcall``/``__thiscall`` calling-conv keywords, ``__packed``).
-# Dropping them lets the body still compile; they don't affect the recovered
-# logic the byte-match is measuring. The keyword-only forms are string-protected
-# (they must not be stripped out of a string literal like ``puts("__cdecl")``).
 _ANNOTATION_KEYWORDS = re.compile(
     r"\b__(?:noreturn|pure|const|packed|noreturn__|hidden|usercall|userpurge"
     r"|cdecl|stdcall|fastcall|thiscall|vectorcall)\b"
 )
-# The parametrized forms carry a string literal INSIDE the annotation, so the
-# pattern must span it — these run on the whole text (they can't occur as
-# ordinary program data).
 _ANNOTATION_CALLS = re.compile(r'\b__convention\s*\([^)]*\)|\b__(?:reg|stack)\s*\("[^"]*"\)')
 
-# Binary Ninja register-location annotations in parameter lists: ``char arg3 @
-# rax``. A bare ``@`` never occurs in valid C.
 _AT_REG = re.compile(r"\s@\s*\w+")
-# Binary Ninja unsigned-shift dialect: ``u>>``/``u<<`` (+ compound assign).
-# Binja renders it spaced on BOTH sides — ``x u>> y`` — so require whitespace
-# before the ``u`` and after the operator. That leaves a variable named ``u``
-# (``u>>2``, ``u >> 2``, ``return u>>foo``) untouched.
 _U_SHIFT = re.compile(r"(?<=\s)u(>>=|>>|<<=|<<)(?=\s)")
-# Width-unknown deref through a bare void cast: ``*(void *)EXPR`` — never valid
-# C (void lvalue). ``*(void **)`` (valid) is not matched: the cast must close
-# right after a single ``*``.
 _VOID_DEREF = re.compile(r"\*\s*\(\s*void\s*\*\s*\)")
-# Ghidra sub-piece notation ``x._<off>_<size>_`` (read <size> bytes at byte
-# offset <off> of x) — not C; desugared to a byte-offset deref (lvalue-capable).
 _SUBPIECE = re.compile(r"\b([A-Za-z_]\w*)\._(\d+)_([1248])_")
 _SUBPIECE_TYPES = {
     "1": "unsigned char",
@@ -107,21 +80,12 @@ _SUBPIECE_TYPES = {
     "4": "unsigned int",
     "8": "unsigned long",
 }
-# angr computed goto printed as a cast call: ``goto (long long)(EXPR);``.
 _GOTO_CAST = re.compile(r"\bgoto\s*\(\s*[^()]*\)\s*\(")
-# angr array return types: ``unsigned int [166] f(...)`` / ``struct s *[2] f(``.
 _ARRAY_RET = re.compile(r"^([A-Za-z_][\w \t]*?(?:\*+[ \t]*)?)\[\d+\][ \t]+(\w+[ \t]*\()", re.M)
-# Binary Ninja integer literals with a float-ish suffix: ``-1f`` (not ``0x1f``,
-# not a real float suffix like ``2.5f``).
 _INT_F_SUFFIX = re.compile(r"(?<![\w.])(\d+)f\b")
 
-# Duplicate ``typedef struct X {...} X;`` blocks (angr emits the same tag twice
-# with different member sets — can never compile; keep the fullest one).
 _STRUCT_TYPEDEF = re.compile(r"typedef\s+struct\s+(\w+)\s*\{[^{}]*\}\s*\1\s*;")
 
-# String/char literals: rewrites must never fire inside them (a ``@`` or ``::``
-# in a printf format is program data, and changing it would change the measured
-# code, not fix its syntax).
 _STRING_OR_CHAR = re.compile(r'"(?:[^"\\\n]|\\.)*"|\'(?:[^\'\\\n]|\\.)*\'')
 
 
@@ -137,12 +101,8 @@ def _sub_outside_strings(pattern: re.Pattern, repl, code: str) -> str:
     return "".join(out)
 
 
-# Minimal, conflict-safe scaffolding. Only fixed-width int + size types; nothing
-# that defines FILE/struct names a decompiler might also define.
 _MINIMAL_INCLUDES = "#include <stdint.h>\n#include <stddef.h>\n"
 
-# Sensible C type for a Ghidra/IDA/angr pseudo-type, chosen so the *width* (and
-# thus most codegen) matches. Anything unknown falls back to ``long``.
 _TYPE_GUESS: dict[str, str] = {
     "undefined": "unsigned char",
     "undefined1": "unsigned char",
@@ -169,9 +129,8 @@ _TYPE_GUESS: dict[str, str] = {
     "ulonglong": "unsigned long long",
     "longlong": "long long",
     "pointer": "void *",
-    # IDA's underscore-prefixed cast types (``*(_DWORD *)p``). These MUST be
-    # width-correct: a generic ``long`` fallback silently turns every 4-byte
-    # store/load into an 8-byte one, wrecking the recompiled codegen.
+    # These MUST stay width-correct: a ``long`` fallback would silently widen
+    # every 4-byte store/load to 8 bytes and wreck the recompiled codegen.
     "_byte": "unsigned char",
     "_word": "unsigned short",
     "_dword": "unsigned int",
@@ -199,17 +158,13 @@ _TYPE_GUESS: dict[str, str] = {
     "unkuint10": "long double",
 }
 
-# Type names whose typedef is NOT a plain scalar alias.
 _SPECIAL_TYPEDEFS: dict[str, str] = {
-    # ``code *`` must be a *function* pointer so ``(*(code *)p)(...)`` compiles.
     "code": "typedef long code();",
-    # IDA emits ``gcc_va_list va; va[0]`` — the real va_list is an array type.
     "va_list": "typedef __builtin_va_list va_list;",
     "gcc_va_list": "typedef __builtin_va_list gcc_va_list;",
     "__gnuc_va_list": "typedef __builtin_va_list __gnuc_va_list;",
-    "_Bool": "",  # never needed, keep the guess table from firing
+    "_Bool": "",
 }
-# IDA SIMD types with their member spellings (``v.m128i_i32[1]``).
 for _simd, _members in (
     (
         "__m128i",
@@ -228,8 +183,6 @@ for _simd, _members in (
 ):
     _SPECIAL_TYPEDEFS[_simd] = f"typedef union {{ {_members} }} {_simd};"
 
-# A name that is clearly a pseudo-TYPE even when gcc reports it as a plain
-# undeclared identifier (cast position hides the type-ness).
 _PSEUDO_TYPE_NAME = re.compile(
     r"^(?:undefined\d*|u?int\d+|u(?:char|short|int|long)|s?byte|[dq]word|word"
     r"|bool|code|float\d+|ulonglong|longlong|_(?:byte|word|dword|qword|oword"
@@ -237,10 +190,6 @@ _PSEUDO_TYPE_NAME = re.compile(
     re.IGNORECASE,
 )
 
-# IDA/Ghidra/kuna DATA-name prefixes encode the referenced width; injecting the
-# right width (and array-ness) makes the recompiled global access match the
-# original. These are DEFINED (not extern) so PIE codegen stays a direct
-# rip-relative access like the original's, not a GOT indirection.
 _DATA_NAME = re.compile(
     r"^(byte|word|dword|qword|off|unk|flt|dbl|xmmword|asc|stru|s|DAT|_DAT|PTR|dat)_[0-9a-fA-F_]+$"
 )
@@ -262,8 +211,6 @@ _DATA_PREFIX_TYPE = {
     "PTR": "void *",
     "dat": "long",
 }
-# Prefixes that name a data BLOCK (string/unknown region) — declare as an array
-# so ``name[i]``/decay codegen (lea) matches the original data symbol.
 _DATA_ARRAY_PREFIXES = {"asc", "s", "unk", "stru"}
 
 
@@ -283,7 +230,6 @@ def _known_protos() -> dict[str, str]:
         protos[name] = decl
 
     for d in (
-        # stdio
         "int printf(const char *, ...);",
         "int fprintf(void *, const char *, ...);",
         "int sprintf(char *, const char *, ...);",
@@ -325,7 +271,6 @@ def _known_protos() -> dict[str, str]:
         "int setvbuf(void *, char *, int, unsigned long);",
         "void setbuf(void *, char *);",
         "void *tmpfile(void);",
-        # string
         "unsigned long strlen(const char *);",
         "int strcmp(const char *, const char *);",
         "int strncmp(const char *, const char *, unsigned long);",
@@ -352,7 +297,6 @@ def _known_protos() -> dict[str, str]:
         "int memcmp(const void *, const void *, unsigned long);",
         "void *memchr(const void *, int, unsigned long);",
         "void *mempcpy(void *, const void *, unsigned long);",
-        # stdlib
         "void *malloc(unsigned long);",
         "void *calloc(unsigned long, unsigned long);",
         "void *realloc(void *, unsigned long);",
@@ -385,7 +329,6 @@ def _known_protos() -> dict[str, str]:
         "void srandom(unsigned int);",
         "int mkstemp(char *);",
         "char *realpath(const char *, char *);",
-        # unistd / fcntl / sys
         "int open(const char *, int, ...);",
         "int close(int);",
         "long read(int, void *, unsigned long);",
@@ -436,7 +379,6 @@ def _known_protos() -> dict[str, str]:
         "int link(const char *, const char *);",
         "int symlink(const char *, const char *);",
         "long readlink(const char *, char *, unsigned long);",
-        # errno / ctype / locale
         "int *__errno_location(void);",
         "const unsigned short **__ctype_b_loc(void);",
         "const int **__ctype_tolower_loc(void);",
@@ -455,7 +397,6 @@ def _known_protos() -> dict[str, str]:
         "int iscntrl(int);",
         "int isgraph(int);",
         "char *setlocale(int, const char *);",
-        # time
         "long time(long *);",
         "long clock(void);",
         "int gettimeofday(void *, void *);",
@@ -467,7 +408,6 @@ def _known_protos() -> dict[str, str]:
         "unsigned long strftime(char *, unsigned long, const char *, const void *);",
         "int nanosleep(const void *, void *);",
         "int clock_gettime(int, void *);",
-        # getopt / err / assert / setjmp
         "int getopt(int, char *const *, const char *);",
         "int getopt_long(int, char *const *, const char *, const void *, int *);",
         "int getopt_long_only(int, char *const *, const char *, const void *, int *);",
@@ -482,11 +422,9 @@ def _known_protos() -> dict[str, str]:
         "int __sigsetjmp(void *, int);",
         "void longjmp(void *, int);",
         "void siglongjmp(void *, int);",
-        # dirent
         "void *opendir(const char *);",
         "void *readdir(void *);",
         "int closedir(void *);",
-        # glibc fortify variants (original -D_FORTIFY_SOURCE builds call these)
         "int __printf_chk(int, const char *, ...);",
         "int __fprintf_chk(void *, int, const char *, ...);",
         "int __sprintf_chk(char *, int, unsigned long, const char *, ...);",
@@ -535,12 +473,6 @@ def _helper_macros() -> dict[str, str]:
         " < (unsigned long)(x))",
         "__CFSUB__": "#define __CFSUB__(x, y) ((unsigned long)(x) < (unsigned long)(y))",
         "__CFSHL__": "#define __CFSHL__(x, y) (((x) >> (8 * sizeof(x) - (y))) & 1)",
-        # Signed-overflow flags (IDA semantics: SIGNED overflow regardless of
-        # operand signedness). Extract the overflow bit POSITIONALLY as the MSB
-        # of the classic ``(~(x^y)) & (x^sum)`` term at the operands' common
-        # width, shifted down as an unsigned value — sign-agnostic and
-        # width-generic, so it fires even when x/y are unsigned (a bare
-        # ``(long)`` cast zero-extends an unsigned operand and folds to 0).
         "__OFADD__": "#define __OFADD__(x, y) __extension__({ __typeof__((x) + (y)) _x = (x),"
         " _y = (y), _s = _x + _y;"
         " (int)(((~(_x ^ _y)) & (_x ^ _s)) >> (8 * sizeof(_s) - 1)) & 1; })",
@@ -556,7 +488,6 @@ def _helper_macros() -> dict[str, str]:
         "__SPAIR64__": "#define __SPAIR64__(h, l) ((long long)(((unsigned long long)"
         "(unsigned int)(h) << 32) | (unsigned int)(l)))",
     }
-    # IDA BYTEn/WORDn/DWORDn (+ signed variants): byte/word/dword n of a value.
     for n in range(1, 16):
         m[f"BYTE{n}"] = f"#define BYTE{n}(x) (*((unsigned char *)&(x) + {n}))"
         m[f"SBYTE{n}"] = f"#define SBYTE{n}(x) (*((signed char *)&(x) + {n}))"
@@ -566,7 +497,6 @@ def _helper_macros() -> dict[str, str]:
     for n in range(1, 4):
         m[f"DWORD{n}"] = f"#define DWORD{n}(x) (*((unsigned int *)&(x) + {n}))"
         m[f"SDWORD{n}"] = f"#define SDWORD{n}(x) (*((int *)&(x) + {n}))"
-    # IDA rotate helpers (width-suffixed).
     for n, t in (
         (1, "unsigned char"),
         (2, "unsigned short"),
@@ -580,7 +510,6 @@ def _helper_macros() -> dict[str, str]:
         m[f"__ROR{n}__"] = (
             f"#define __ROR{n}__(x, y) ((({t})(x) >> (y))" f" | (({t})(x) << ({bits} - (y))))"
         )
-    # Ghidra pcode helpers: CONCATxy / SUBxy / ZEXTxy / SEXTxy (x, y = byte widths).
     widths = {
         1: "unsigned char",
         2: "unsigned short",
@@ -593,9 +522,8 @@ def _helper_macros() -> dict[str, str]:
         for b in (1, 2, 3, 4, 5, 6, 7, 8):
             total = a + b
             rt = widths.get(total) or ("unsigned long long" if total < 8 else "unsigned __int128")
-            # Mask y to b BYTES: an odd b (3/5/6/7) has no integer type, so a
-            # cast can't truncate it — do it explicitly so upper bits of y never
-            # leak into the concatenation (Ghidra pcode CONCAT truncates y).
+            # An odd byte width (3/5/6/7) has no integer type to cast through,
+            # so mask explicitly — pcode CONCAT truncates y.
             ymask = (
                 f"(({rt})(y) & ((({rt})1 << {8 * b}) - 1))"
                 if b < 8
@@ -650,8 +578,6 @@ def sanitize_tokens(code: str) -> str:
     code = _sub_outside_strings(_NS_QUALIFIER, "", code)
     code = _sub_outside_strings(_BARE_SCOPE, "", code)
     code = _sub_outside_strings(_ANNOTATION_KEYWORDS, "", code)
-    # NOT string-protected: ``__convention("regparm")`` / ``__reg("rdx")`` carry
-    # a string literal INSIDE the annotation, so the pattern must span it.
     code = _ANNOTATION_CALLS.sub("", code)
     code = _sub_outside_strings(_AT_REG, "", code)
     code = _sub_outside_strings(_U_SHIFT, r"\1", code)
@@ -675,8 +601,6 @@ def _type_guess(name: str) -> str:
     low = name.lower()
     if low in _TYPE_GUESS:
         return _TYPE_GUESS[low]
-    # u?intN width hints. N <= 8 is a BYTE count (Ghidra/kuna: int8 = 8 bytes);
-    # 16/32/64 are bit counts (int32 = 4 bytes).
     m = re.fullmatch(r"u?int(\d+)", low)
     if m:
         n = int(m.group(1))
@@ -699,7 +623,6 @@ def _typedef_decl(name: str, code: str) -> str:
         return special
     if name == "bool":
         return "typedef _Bool bool;"
-    # A cast that is *called through* needs a function type: ``(*(X *)p)(...)``.
     if re.search(rf"\(\s*\*\s*\(\s*{re.escape(name)}\s*\*+\s*\)[^)]*\)\s*\(", code):
         return f"typedef long {name}();"
     return f"typedef {_type_guess(name)} {name};"
@@ -766,8 +689,6 @@ def derive_context_decls(function_codes: dict[str, str]) -> dict[str, str]:
             brace = stripped.find("{")
             head_lines.append(stripped[:brace] if brace != -1 else stripped)
             head = " ".join(head_lines)
-            # A signature is complete at its balanced closing paren (long
-            # parameter lists wrap over many lines) or at the body brace.
             if brace != -1 or ("(" in head and head.count("(") == head.count(")")):
                 done = brace != -1 or head.rstrip().endswith(")")
                 break
@@ -776,10 +697,6 @@ def derive_context_decls(function_codes: dict[str, str]) -> dict[str, str]:
         if not done:
             continue
         sig = " ".join(head_lines).strip()
-        # Reject anything that is not a plausible single C signature: error
-        # prose ("Decompilation Failed! ..."), comment continuations, glyphs,
-        # unbalanced parens — a malformed injected decl breaks the whole TU for
-        # every CALLER of this function, which is far worse than no prototype.
         if (
             not sig
             or len(sig) > 400
@@ -795,11 +712,6 @@ def derive_context_decls(function_codes: dict[str, str]) -> dict[str, str]:
             or "decompilation failed" in sig.lower()
         ):
             continue
-        # Must be a single clean declarator: ``<ret> name(<params>)`` where the
-        # function name is immediately followed by the parameter-list paren group
-        # AND that group closes at the very end of the signature. This rejects
-        # doubled/garbled signatures (e.g. dewolf's ``char* f(...)(...)``) that
-        # happen to have balanced parens overall.
         nm = re.search(rf"\b{re.escape(name)}\s*\(", sig)
         if not nm:
             continue
@@ -831,22 +743,15 @@ class FixupResult:
     error: str | None = None
 
 
-# Diagnostic patterns gcc emits that we know how to repair. ``_RE_IMPLICIT_FUNC``
-# matches the *warning* form too — the compile deliberately runs without ``-w``
-# so implicit-declaration warnings can drive prototype injection (gcc 11 treats
-# them as warnings, and ``-w`` would hide them entirely).
 _RE_UNKNOWN_TYPE = re.compile(rf"unknown type name {_Q}([A-Za-z_]\w*){_Q}")
 _RE_IMPLICIT_FUNC = re.compile(rf"implicit declaration of function {_Q}([A-Za-z_]\w*){_Q}")
 _RE_UNDECLARED = re.compile(rf"{_Q}([A-Za-z_]\w*){_Q} undeclared")
 _RE_NOT_A_FUNC = re.compile(rf"called object {_Q}([A-Za-z_]\w*){_Q}[^\n]*is not a function")
-# A conflict caused by one of OUR injected declarations.
 _RE_CONFLICT = re.compile(
     r"(?:conflicting types for|redefinition of|redeclared as|previous declaration of) "
     rf"{_Q}([A-Za-z_]\w*){_Q}"
 )
-# A prototype we injected doesn't fit the call site -> downgrade to unprototyped.
 _RE_BAD_ARGS = re.compile(rf"too (?:many|few) arguments to function {_Q}([A-Za-z_]\w*){_Q}")
-# Deref/void diagnostics repaired by positional edits or decl upgrades.
 _RE_DEREF_ERR = re.compile(
     r"(\d+):(\d+): error: (?:void value not ignored as it ought to be"
     r"|invalid use of void expression"
@@ -871,7 +776,6 @@ _RE_PTR_ARROW = re.compile(rf"{_Q}\*(\w+){_Q} is a pointer; did you mean to use 
 _RE_ARRAY_ASSIGN = re.compile(r"error: assignment to expression with array type")
 _RE_EXPECT_EXPR = re.compile(rf"error: expected expression before {_Q}(\w+){_Q}")
 _RE_SUBSCRIPTED = re.compile(r"error: subscripted value is neither array nor pointer")
-# ``NN | <source line>`` context lines gcc prints under each diagnostic.
 _RE_ERR_SNIPPET = re.compile(r"error: ([^\n]+)\n\s*\d+ \|([^\n]*)")
 
 
@@ -952,8 +856,6 @@ def _apply_edits(code: str, hdr_lines: int, edits: list[tuple[int, int, object]]
             if c < len(line) and line[c] == "*" and not line.startswith("(unsigned long *)", c + 1):
                 lines[ln] = line[: c + 1] + "(unsigned long *)" + line[c + 1 :]
             elif line[col : col + 1] == "=" or (c < len(line) and line[c] != "*"):
-                # A void-deref STORE (``*a5 = x``): the caret sits on the ``=``;
-                # the star is BEFORE it — scan back over the lvalue identifier.
                 b = col - 1
                 while b >= 0 and line[b] in " \t":
                     b -= 1
@@ -1000,14 +902,12 @@ def compile_with_fixup(
     """
     if flags is None:
         flags = ["-O2", "-c", "-fno-builtin"]
-    # Run WITHOUT -w: implicit-function-declaration diagnostics (warnings in
-    # gcc 11) drive prototype injection, and -w would suppress them.
+    # No -w: implicit-declaration warnings are what drive prototype injection.
     flags = [f for f in flags if f != "-w"]
 
     code = sanitize_tokens(code)
     decls: dict[str, str] = {}
     structs: dict[str, list[str]] = {}
-    # Track which names we injected (so we can withdraw on a conflict we caused).
     obj_dir = Path(tempfile.mkdtemp(prefix="decbench_bm_"))
     obj_path = obj_dir / f"{func_name}.o"
 
@@ -1015,8 +915,6 @@ def compile_with_fixup(
         return [d for d in decls.values() if d] + [f"struct {n} {{...}}" for n in structs]
 
     def fail(src: str, iteration: int, error: str) -> FixupResult:
-        # Only the SUCCESS path hands the temp dir to the caller; every failure
-        # must clean it up here or we leak an empty dir per non-compiling func.
         shutil.rmtree(obj_dir, ignore_errors=True)
         return FixupResult(None, src, False, iteration, injected(), error)
 
@@ -1031,11 +929,6 @@ def compile_with_fixup(
             return fail(src, iteration, "compiler-not-found")
 
         if proc.returncode == 0 and obj_path.exists():
-            # SUCCESS. One improvement pass: give implicitly-declared calls the
-            # best prototype we know (sibling signature / libc / helper macro /
-            # ``long f();``) — implicit-int callees mis-shape call-site codegen
-            # (AL zeroing, bogus sign-extensions). If the injections break the
-            # build, back them out and recompile the known-good source.
             new = {}
             for name in set(_RE_IMPLICIT_FUNC.findall(proc.stderr)):
                 if name != func_name and name not in decls:
@@ -1049,8 +942,6 @@ def compile_with_fixup(
                     proc2 = None
                 if proc2 is not None and proc2.returncode == 0 and obj_path.exists():
                     return FixupResult(obj_path, src2, True, iteration + 1, injected())
-                # Try once more after withdrawing just the decls gcc objects to
-                # (conflicts / arg-count mismatches from an imperfect proto).
                 err2 = proc2.stderr if proc2 is not None else ""
                 for name in set(_RE_CONFLICT.findall(err2)) | set(_RE_BAD_ARGS.findall(err2)):
                     if name in new:
@@ -1062,7 +953,6 @@ def compile_with_fixup(
                     proc3 = None
                 if proc3 is not None and proc3.returncode == 0 and obj_path.exists():
                     return FixupResult(obj_path, src3, True, iteration + 2, injected())
-                # Back out the whole improvement pass; recompile the good TU.
                 for name in new:
                     decls.pop(name, None)
                 src = _build_source(code, decls, structs)
@@ -1077,15 +967,6 @@ def compile_with_fixup(
         pairs = _errors_with_snippets(last_err)
         added = False
 
-        # 0) A PARSE error that lands in the SCAFFOLDING region (before ``code``)
-        #    means one of OUR injected decls is itself syntactically malformed —
-        #    most likely a context_decls sibling prototype that survived
-        #    derivation but doesn't parse. Withdraw whichever injected decl owns
-        #    that line; leaving it in blocks every subsequent repair (and would
-        #    score a function 0 for a defect in a *sibling's* signature). Only
-        #    STRUCTURAL parse errors trigger this — an "unknown type name"/
-        #    "undeclared" in a header decl (e.g. a proto that uses ``FILE *``) is
-        #    resolved by the normal typedef/struct rules below, not withdrawal.
         header_line_list = _build_source("", decls, structs).split("\n")
         withdrew = False
         for m in re.finditer(r"(?:^|\n)[^\n:]*:(\d+):\d+: error: ([^\n]+)", last_err):
@@ -1103,38 +984,27 @@ def compile_with_fixup(
             bad_line = header_line_list[ln0].strip()
             for nm, d in list(decls.items()):
                 if d and d.strip() == bad_line:
-                    decls[nm] = ""  # blank keeps it claimed so we don't re-add
+                    decls[nm] = ""
                     withdrew = True
                     added = True
                     break
         if withdrew:
-            continue  # recompile without the malformed decl before doing more
+            continue
 
-        # 1) Withdraw any injected decl that caused a conflict, and avoid re-adding.
-        #    Guard on truthiness so an already-blanked (or non-injected) name does
-        #    NOT keep re-firing `added` — otherwise a persistent conflict between
-        #    two decompiler-provided decls burns all _MAX_REPAIR_ITERS gcc runs.
         for name in _RE_CONFLICT.findall(last_err):
             if decls.get(name):
-                # Our decl clashed with a decompiler-provided one; drop ours.
-                decls[name] = ""  # blank keeps it "claimed" so we don't re-add
+                decls[name] = ""
                 added = True
-        # An injected prototype that doesn't fit the call site -> unprototyped.
         for name in _RE_BAD_ARGS.findall(last_err):
             if decls.get(name) and decls[name] != f"long {name}();":
                 decls[name] = f"long {name}();"
                 added = True
 
-        # 2) unknown type name -> typedef a width-matched concrete type (or a
-        #    special union/function/varargs typedef for known pseudo-types).
         for name in _RE_UNKNOWN_TYPE.findall(last_err):
             if name not in decls:
                 decls[name] = _typedef_decl(name, code)
                 added = True
 
-        # 3) implicit function declaration -> best available prototype.
-        #    A pseudo-TYPE name reported as a "function" is really a cast that
-        #    parses like a call — ``(bool (**)())v`` — and needs a typedef.
         for name in set(_RE_IMPLICIT_FUNC.findall(last_err)):
             if name == func_name:
                 continue
@@ -1146,8 +1016,6 @@ def compile_with_fixup(
                 decls[name] = decl
                 added = True
 
-        # 4) undeclared identifier -> typedef if it's used as a cast type or is
-        #    a known pseudo-type name; else a width-typed global definition.
         for name in _RE_UNDECLARED.findall(last_err):
             if name not in decls:
                 if name in _HELPER_MACROS:
@@ -1158,10 +1026,6 @@ def compile_with_fixup(
                     decls[name] = _global_decl(name, code)
                 added = True
 
-        # 4b) A parse error whose snippet shows one of OUR scalar globals in
-        #     cast position -> it was a type after all; flip to a typedef.
-        #     (Only names implicated by the failing line, so an unrelated parse
-        #     error can't misflip an ordinary parenthesized global.)
         for msg, snip in pairs:
             if not msg.startswith("expected"):
                 continue
@@ -1171,12 +1035,6 @@ def compile_with_fixup(
                     decls[name] = _typedef_decl(name, code)
                     added = True
 
-        # 5) Deref of an implicitly-declared (int-returning) call or of one of
-        #    our injected scalars -> pointer-returning / pointer / fn pointer.
-        #    Each deref diagnostic is routed ONCE: a decl upgrade when the
-        #    snippet names something we can retype, else a positional cast edit
-        #    (never both — a cast inserted on top of an upgraded decl re-breaks
-        #    the expression).
         deref_edits: list[tuple[int, int, object]] = []
         for m in _RE_DEREF_ERR.finditer(last_err):
             block_end = last_err.find("error:", m.end())
@@ -1194,9 +1052,6 @@ def compile_with_fixup(
                     handled = True
                     added = True
                 elif "(" in (cur or ""):
-                    # An earlier rule already gave this callee a (better)
-                    # prototype in THIS iteration — the deref resolves on the
-                    # next compile; a positional cast would re-break it.
                     handled = True
             if not handled:
                 for cm in re.finditer(r"\*\s*([A-Za-z_]\w*)\s*[^\w(]", snip):
@@ -1213,13 +1068,10 @@ def compile_with_fixup(
                         handled = True
                         added = True
                     elif "*" in d:
-                        handled = True  # already pointer-typed; resolves next pass
+                        handled = True
             if not handled:
-                # Untyped ``*(ptr + off)`` etc. -> positional word-width cast.
                 deref_edits.append((int(m.group(1)), int(m.group(2)), "deref"))
 
-        # 5b) void* locals/params that are subscripted or deref'd -> byte ptr
-        #     (preserves GNU void*-arithmetic offsets).
         if "invalid use of void expression" in last_err or "void value not ignored" in last_err:
             for msg, snip in pairs:
                 if "void" not in msg:
@@ -1231,13 +1083,8 @@ def compile_with_fixup(
                         code = new_code
                         added = True
 
-        # 6) Positional edits: brace assignments and calls through data values.
         for m in _RE_BRACE_ASSIGN.finditer(last_err):
             deref_edits.append((int(m.group(1)), int(m.group(2)), "brace"))
-        # Calls through a value the decompiler itself typed as data. NAMED form
-        # ("called object 'x' is not a function"): x has a non-function type in
-        # scope (a local/param/its own global), so injecting a decl can't help —
-        # cast the call sites instead (and withdraw any decl we injected).
         for name in set(_RE_NOT_A_FUNC.findall(last_err)):
             if decls.get(name):
                 decls[name] = ""
@@ -1247,18 +1094,14 @@ def compile_with_fixup(
             if n:
                 code = new_code
                 added = True
-        # ANONYMOUS form (expression callee: ``x->f(...)``, ``(*p)(...)``).
         for m in _RE_SCALAR_CALL.finditer(last_err):
             if re.search(rf"called object {_Q}", m.group(0)):
-                continue  # named form handled above
+                continue
             block_end = last_err.find("error:", m.end())
             block = last_err[m.end() : block_end if block_end != -1 else len(last_err)]
             sm = re.search(r"\d+ \|([^\n]*)", block)
             snip = sm.group(1) if sm else ""
             handled = False
-            # ``(*name)(...)`` — an indirect call through a data symbol: give
-            # OUR injected global a function-pointer type (matches the
-            # original's load-then-call codegen).
             for cm in re.finditer(r"\(\s*\*\s*([A-Za-z_]\w*)\s*\)\s*\(", snip):
                 name = cm.group(1)
                 d = decls.get(name)
@@ -1266,8 +1109,6 @@ def compile_with_fixup(
                     decls[name] = f"long (*{name})();"
                     handled = True
                     added = True
-            # ``(*(unsigned long *)NAME)(...)`` (often born from the *(void *)
-            # sanitize): load a function pointer from NAME, then call it.
             if not handled:
                 pat = re.compile(
                     r"\(\s*\*\s*\(\s*unsigned long\s*\*\s*\)\s*([A-Za-z_]\w*)\s*\)\s*\("
@@ -1286,8 +1127,6 @@ def compile_with_fixup(
                 code = new_code
                 added = True
 
-        # 7) Undefined struct types -> synthesize a definition and grow it from
-        #    subsequent has-no-member diagnostics.
         struct_names = set()
         for m in _RE_UNDEF_STRUCT.finditer(last_err):
             name = next((g for g in m.groups() if g), None)
@@ -1300,7 +1139,7 @@ def compile_with_fixup(
                 struct_names.add(dm.group(1))
         for name in struct_names:
             if re.search(rf"\bstruct\s+{re.escape(name)}\s*\{{", code):
-                continue  # decompiler defined it; never redefine
+                continue
             if name not in structs:
                 structs[name] = []
                 added = True
@@ -1310,11 +1149,8 @@ def compile_with_fixup(
                 structs[tag].append(f"long {member};")
                 added = True
 
-        # 7b) Member access on something we injected as a scalar -> grow it.
         for m in _RE_NO_MEMBER_ANON.finditer(last_err):
             member = m.group(1)
-            # SIMD member on a call result: ``_mm_*(x).m128i_i64`` — declare the
-            # intrinsic as returning the matching IDA SIMD union.
             simd = {"m128i": "__m128i", "m128": "__m128", "m128d": "__m128d", "m64": "__m64"}.get(
                 member.split("_")[0]
             )
@@ -1337,8 +1173,6 @@ def compile_with_fixup(
                 if not bm:
                     continue
                 var = bm.group(1)
-                # Base var is one of OUR injected scalar globals -> make IT a
-                # synthesized-struct global, accumulating members.
                 d = decls.get(var, "")
                 if d == f"long {var};":
                     decls[var] = f"struct {{ long {member}; }} {var};"
@@ -1352,8 +1186,6 @@ def compile_with_fixup(
                     decls[var] = d.replace("struct { ", f"struct {{ long {member}; ", 1)
                     added = True
                     continue
-                # Else: the var's TYPE is one of OUR scalar typedefs -> grow the
-                # typedef into a synthesized struct.
                 tm = re.search(rf"\b([A-Za-z_]\w*)\s*\**\s*{re.escape(var)}\s*[;,)\[=]", code)
                 if not tm:
                     continue
@@ -1370,8 +1202,6 @@ def compile_with_fixup(
                     )
                     added = True
 
-        # 8) Subscripted scalar -> our injected global was really data: make it
-        #    an array (definition keeps direct rip-relative codegen).
         if _RE_SUBSCRIPTED.search(last_err):
             for msg, snip in pairs:
                 if "subscripted value" not in msg:
@@ -1384,8 +1214,6 @@ def compile_with_fixup(
                         decls[name] = f"{base} {name}[1024];"
                         added = True
 
-        # 9) Array-typed variable assigned as a whole -> it was really a pointer
-        #    (arrays are not assignable; the decompiler meant a pointer).
         if _RE_ARRAY_ASSIGN.search(last_err):
             for msg, snip in pairs:
                 if "array type" not in msg:
@@ -1405,7 +1233,6 @@ def compile_with_fixup(
                     code = new_code
                     added = True
 
-        # 10) angr precedence bug: ``*(a0)->f`` means ``(*a0)->f``.
         for name in set(_RE_PTR_ARROW.findall(last_err)):
             esc = re.escape(name)
             pat = re.compile(rf"\*\(\s*{esc}\s*\)\s*->|\*{esc}\s*->")
@@ -1414,8 +1241,6 @@ def compile_with_fixup(
                 code = new_code
                 added = True
 
-        # 11) A typedef name also used as a function (``struct stat`` dropped its
-        #     keyword and shadows the libc call): rename the CALL sites only.
         for msg, snip in pairs:
             m = _RE_EXPECT_EXPR.search("error: " + msg)
             if not m:
@@ -1442,8 +1267,6 @@ def compile_with_fixup(
                 code = new_code
                 added = True
 
-        # 11b) Wrong member name with a gcc suggestion (angr's struct dedupe can
-        #      keep the variant that renamed a field): take the suggestion.
         for m in re.finditer(
             rf"has no member named {_Q}(\w+){_Q}; did you mean {_Q}(\w+){_Q}", last_err
         ):
@@ -1454,8 +1277,6 @@ def compile_with_fixup(
                 code = new_code
                 added = True
 
-        # 11c) Pointer/int mixed arithmetic (decompiler treats pointers as
-        #      integers): cast the offending simple-identifier operand.
         for msg, snip in pairs:
             bm = re.search(
                 rf"invalid operands to binary (\S+) \(have {_Q}([^'‘’]+?){_Q}"
@@ -1475,7 +1296,7 @@ def compile_with_fixup(
             ):
                 continue
             esc_op = re.escape(op)
-            if lb:  # cast the RHS identifier
+            if lb:
                 m2 = re.search(rf"{esc_op}\s*([A-Za-z_]\w*)\b(?!\s*[\[(])", snip)
                 if m2:
                     name = m2.group(1)
@@ -1486,7 +1307,7 @@ def compile_with_fixup(
                         code = new_code
                         added = True
                         continue
-            if la and not lb:  # int OP nothing matched above; cast the LHS
+            if la and not lb:
                 m2 = re.search(rf"([A-Za-z_]\w*)\s*{esc_op}", snip)
                 if m2:
                     name = m2.group(1)
@@ -1496,8 +1317,6 @@ def compile_with_fixup(
                         code = new_code
                         added = True
 
-        # 11d) A function-typedef of ours used in a VALUE cast (``(code)x``):
-        #      rewrite those cast sites to (long).
         if "cast specifies function type" in last_err:
             for name, d in list(decls.items()):
                 if d == f"typedef long {name}();":
@@ -1507,7 +1326,6 @@ def compile_with_fixup(
                         code = new_code
                         added = True
 
-        # 12) Read-only assignment -> strip const from that declaration.
         for name in _RE_RDONLY.findall(last_err):
             if not name:
                 continue
@@ -1519,7 +1337,6 @@ def compile_with_fixup(
                 code = new_code
                 added = True
 
-        # 13) ``void X;`` locals -> ``long X;``.
         for name in _RE_VOIDVAR.findall(last_err):
             new_code = re.sub(rf"\bvoid(\s+{re.escape(name)}\s*[;\[=])", r"long\1", code, count=1)
             if new_code != code:
@@ -1527,7 +1344,7 @@ def compile_with_fixup(
                 added = True
 
         if not added:
-            break  # nothing actionable left; give up
+            break
 
     return fail(
         _build_source(code, decls, structs),

--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -15,20 +15,9 @@ if TYPE_CHECKING:
     from decbench.models.decompilation import FunctionDecompilation
 
 
-# Exact GED is super-polynomial; a handful of huge optimized CFGs can dominate a
-# whole benchmark run. Above this node count we fall back to a cheap structural
-# distance so the run stays bounded. Tunable via DECBENCH_GED_MAX_NODES.
+# Exact GED is super-polynomial, so graphs above this node count fall back to a
+# cheap structural distance. Tunable via DECBENCH_GED_MAX_NODES.
 GED_MAX_NODES = int(os.environ.get("DECBENCH_GED_MAX_NODES") or "60")
-
-# A source CFG with this many nodes or fewer is NOT a usable structural graph.
-# In practice source_nodes == 1 means Joern only saw a prototype/declaration of
-# the function (or the wrong translation unit was matched), not its real body.
-# Scoring against such a graph inverts the metric: GED then rewards whichever
-# decompiler emitted the FEWEST nodes — a truncated one-block stub scores a
-# perfect 0 while a complete, correct decompilation is "penalized" by its real
-# size. Treat these like a missing source CFG (excluded from scoring) instead.
-# Tunable via DECBENCH_GED_MIN_SOURCE_NODES.
-GED_MIN_SOURCE_NODES = int(os.environ.get("DECBENCH_GED_MIN_SOURCE_NODES") or "1")
 
 
 @register_metric("ged")
@@ -51,10 +40,6 @@ class GEDMetric(Metric):
     requires_source_cfg = True
     requires_decompiled_cfg = True
 
-    # v2: exclude only EMPTY-prototype source CFGs (all-Nop single block), not
-    # every <=1-node source, so genuine straight-line functions are scored; the
-    # non-finite (degenerate/error) result is dropped from the denominator at the
-    # recording layer (metrics/base.py) instead of counting as a failure.
     cache_version = "2"
 
     def __init__(self, config: MetricConfig | None = None):
@@ -86,18 +71,10 @@ class GEDMetric(Metric):
                 metadata={"error": "Missing CFG"},
             )
 
-        # EMPTY-prototype source CFG (see is_degenerate_source_cfg): Joern only
-        # saw a declaration (an all-Nop single block) because the function's
-        # defining translation unit wasn't captured, so there is no structure to
-        # compare against. Return non-finite so the recording layer DROPS it from
-        # GED's denominator (unmeasurable for everyone, uniformly), rather than
-        # counting it as a per-decompiler failure. Genuine single-block functions
-        # (real straight-line bodies) are NOT degenerate and ARE scored — a
-        # correct 1-block decompilation earns GED 0. Checked BEFORE the cache so
-        # entries recorded under the old (rewarding) semantics are never served.
-        # NOTE: a truncated decompilation (e.g. angr's CFGFast emitting a
-        # prologue-only stub) can still score well against a genuinely tiny source
-        # function; detecting that needs decompiler-side signals (future work).
+        # A degenerate source CFG has no structure to compare against, so return
+        # non-finite and let the recording layer drop it from GED's denominator rather
+        # than count it as a per-decompiler failure. Checked BEFORE the cache so entries
+        # recorded under the old (rewarding) semantics are never served.
         from decbench.utils.cfg import is_degenerate_source_cfg
 
         s_nodes = source_cfg.number_of_nodes()
@@ -111,9 +88,6 @@ class GEDMetric(Metric):
                 },
             )
 
-        # GED is a pure function of the two CFG structures (node/edge sets) and
-        # the oversize threshold. Key on their canonical, sorted shapes so the
-        # super-polynomial computation is never repeated for identical graphs.
         key_inputs = [
             sorted(str(n) for n in source_cfg.nodes()),
             sorted((str(u), str(v)) for u, v in source_cfg.edges()),
@@ -144,12 +118,8 @@ class GEDMetric(Metric):
             "decompiled_size": decomp_size,
         }
 
-        # Cheap structural fallback for oversized graphs: exact GED is too slow
-        # and these are rarely a perfect match anyway. The size delta is a sound
-        # LOWER BOUND on the true edit distance — but a 0 here only means the
-        # two graphs have the same node and edge counts (necessary, not
-        # sufficient, for a true structural match). Consumers can tell the
-        # approximation apart via the "approximated" metadata flag.
+        # The size delta is a sound LOWER BOUND, so a 0 here only means equal node and
+        # edge counts. Consumers tell it apart via the "approximated" metadata flag.
         if s_nodes > GED_MAX_NODES or d_nodes > GED_MAX_NODES:
             approx = float(
                 abs(s_nodes - d_nodes)

--- a/decbench/metrics/registry.py
+++ b/decbench/metrics/registry.py
@@ -38,16 +38,6 @@ class MetricRegistry:
         return list(cls._metrics.keys())
 
     @classmethod
-    def get_all(
-        cls,
-        names: list[str] | None = None,
-        config: MetricConfig | None = None,
-    ) -> dict[str, Metric]:
-        if names is None:
-            names = cls.list_registered()
-        return {name: cls.get(name, config) for name in names if name in cls._metrics}
-
-    @classmethod
     def clear(cls) -> None:
         cls._metrics.clear()
 

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -27,15 +27,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Type normalization: map common decompiler-specific types to standard C types
 TYPE_MAP: dict[str, str] = {
-    # angr types
     "undefined8": "long long",
     "undefined4": "int",
     "undefined2": "short",
     "undefined1": "char",
     "undefined": "char",
-    # IDA types
     "__int64": "long long",
     "__int32": "int",
     "__int16": "short",
@@ -45,11 +42,8 @@ TYPE_MAP: dict[str, str] = {
     "_WORD": "short",
     "_BYTE": "char",
     "_BOOL": "bool",
-    # kuna types (SLEIGH core-type spellings: intN/uintN are sized in BYTES,
-    # matching the undefinedN convention above — int4 is a 4-byte int, int8 an
-    # 8-byte int). Without these kuna's recovered types never normalize to the
-    # DWARF base-type names and type_match is unfairly ~0, the same way angr's
-    # undefinedN / IDA's __intN are aliased here.
+    # kuna's SLEIGH spellings size intN/uintN in BYTES (int4 is 4 bytes), like the
+    # undefinedN convention above. Without these its type_match is unfairly ~0.
     "int1": "char",
     "int2": "short",
     "int4": "int",
@@ -58,7 +52,6 @@ TYPE_MAP: dict[str, str] = {
     "uint2": "short",
     "uint4": "int",
     "uint8": "long long",
-    # Ghidra types
     "uint": "int",
     "ulong": "long long",
     # LP64: plain "long" is 8 bytes, same as DWARF "long int"/"long long"
@@ -77,7 +70,6 @@ TYPE_MAP: dict[str, str] = {
     "ssize_t": "long long",
 }
 
-# Qualifiers to strip during normalization
 QUALIFIERS = ["unsigned", "signed", "const", "volatile", "register", "static", "extern"]
 
 
@@ -91,13 +83,11 @@ def normalize_type(type_str: str) -> set[str]:
 
     t = type_str.strip()
 
-    # Apply TYPE_MAP first
     if t in TYPE_MAP:
         t = TYPE_MAP[t]
 
     forms = {t}
 
-    # Strip qualifiers and generate normalized forms
     normalized = t
     for q in QUALIFIERS:
         normalized = normalized.replace(f"{q} ", "")
@@ -105,8 +95,6 @@ def normalize_type(type_str: str) -> set[str]:
     if normalized:
         forms.add(normalized)
 
-    # Standard normalizations (DWARF base-type names like "short int" /
-    # "long int" must converge with decompiler spellings like "short")
     for original, replacement in [
         ("long long int", "long long"),
         ("long int", "long long"),
@@ -119,39 +107,28 @@ def normalize_type(type_str: str) -> set[str]:
             if original in form:
                 forms.add(form.replace(original, replacement))
 
-    # Remove whitespace variations
     forms = {re.sub(r"\s+", " ", f).strip() for f in forms if f.strip()}
 
-    # Canonicalize pointer spacing ("char * *" / "char **" -> "char**")
     forms |= {re.sub(r"\s*\*", "*", f) for f in forms}
 
-    # Re-apply TYPE_MAP to derived forms (e.g. "unsigned long" -> "long" -> LP64
-    # "long long") after qualifier stripping.
     forms |= {TYPE_MAP[f] for f in forms if f in TYPE_MAP}
 
     return forms
 
 
-# --- Uncommitted (width-only) decompiler types --------------------------------
-# A decompiler often recovers a variable's SIZE but not a committed C type
-# (Ghidra ``undefined8``, IDA ``__int64``/``_QWORD``, kuna ``int8``). Crediting
-# such an uncommitted N-byte type against a ground-truth scalar of the same width
-# is fair ("it knew it was 8 bytes"); crediting it against a POINTER or an
-# aggregate is NOT — recovering a ``char *`` as a bare 8-byte scalar is a real
-# type miss (and ``struct *`` -> ``void *`` stays a miss too, handled by exact
-# name matching, not here).
+# Uncommitted types recover a variable's SIZE but not a committed C type. Matching
+# one against a same-width ground-truth SCALAR is fair; against a pointer or
+# aggregate it is a real miss, so those are excluded from _UNCOMMITTED_GT_SCALARS.
 _UNCOMMITTED_TYPES = re.compile(
     r"^\s*(?:"
-    r"undefined\d*"  # Ghidra: undefined, undefined1..8
-    r"|__u?int(?:8|16|32|64)"  # IDA: __int64 / __uint32 / ...
-    r"|_(?:BYTE|WORD|DWORD|QWORD)"  # IDA: _QWORD / _DWORD / ...
-    r"|u?int[1-8]"  # kuna: int4 / uint8 (sized in BYTES)
-    r"|byte|word|dword|qword"  # Ghidra: byte / word / dword / qword
+    r"undefined\d*"
+    r"|__u?int(?:8|16|32|64)"
+    r"|_(?:BYTE|WORD|DWORD|QWORD)"
+    r"|u?int[1-8]"
+    r"|byte|word|dword|qword"
     r"|uchar"
     r")\s*$"
 )
-# Byte width implied by an uncommitted spelling when ``VariableInfo.size`` is
-# absent (angr/ghidra usually populate ``size``, so this is a fallback).
 _UNCOMMITTED_WIDTH: dict[str, int] = {
     "undefined": 1,
     "undefined1": 1,
@@ -184,11 +161,8 @@ _UNCOMMITTED_WIDTH: dict[str, int] = {
     "__int64": 8,
     "__uint64": 8,
 }
-# Normalized ground-truth scalar names of each byte width. An uncommitted N-byte
-# decompiler var matches a GT var whose normalized type set intersects this.
-# Integer + bool only (a committed ``float``/``double`` is a type the decompiler
-# demonstrably failed to recover, so it stays a miss); pointers/aggregates never
-# appear here, so scalar<->pointer and struct*->void* correctly stay misses.
+# Integer + bool only: a committed float/double is a type the decompiler
+# demonstrably failed to recover, and pointers/aggregates must stay misses.
 _SIZE_SCALARS: dict[int, set[str]] = {
     1: {"char", "bool"},
     2: {"short"},
@@ -196,12 +170,8 @@ _SIZE_SCALARS: dict[int, set[str]] = {
     8: {"long long"},
 }
 
-# Ghidra/IDA encode a stack slot's frame offset in the variable NAME
-# (``local_28``, ``var_28``) but sometimes leave ``stack_offset`` unset. These
-# names are unambiguously frame-negative locals; the per-binary/-function
-# calibration absorbs the constant base difference vs DWARF, and its "needs >=2
-# aligned" guard means a wrongly-parsed offset simply fails to calibrate (no
-# harm). Deliberately excludes ``*Stack_*`` names (mixed sign conventions).
+# Ghidra/IDA encode a stack slot's frame offset in the NAME but sometimes leave
+# ``stack_offset`` unset. ``*Stack_*`` is excluded (mixed sign conventions).
 _NAME_OFFSET = re.compile(r"^(?:local|var)_([0-9a-fA-F]+)$")
 
 
@@ -287,8 +257,6 @@ def _parse_function_die(die: Any, dwarfinfo: Any) -> tuple[str | None, list[dict
             variables.extend(_parse_lexical_block(child, dwarfinfo))
         elif child.tag == "DW_TAG_formal_parameter":
             var = _parse_variable_die(child, dwarfinfo, is_arg=True, arg_index=arg_index)
-            # The positional index must reflect declaration order even when
-            # an argument is dropped (e.g. fully optimized out).
             arg_index += 1
             if var:
                 variables.append(var)
@@ -331,7 +299,6 @@ def _parse_variable_die(
     if not has_location:
         return None
 
-    # Follow abstract origin if present
     if "DW_AT_abstract_origin" in die.attributes:
         try:
             attr = die.attributes["DW_AT_abstract_origin"]
@@ -352,7 +319,6 @@ def _parse_variable_die(
     if not type_names:
         return None
 
-    # Normalize types
     all_forms: set[str] = set()
     for t in type_names:
         all_forms.update(normalize_type(t))
@@ -519,8 +485,6 @@ def _get_array_dims(die: Any) -> list[int | None]:
     return dims
 
 
-# Match common C local-variable declarations:
-#   type name;  |  type name = ...;  |  type *name;  |  type name[N];
 _DECL_PATTERN = re.compile(
     r"^\s*"
     r"((?:(?:unsigned|signed|const|volatile|static|struct|union|enum)\s+)*"
@@ -528,13 +492,13 @@ _DECL_PATTERN = re.compile(
     r"__int\d+|_DWORD|_QWORD|_WORD|_BYTE|_BOOL|"
     r"u?int\d+_t|size_t|ssize_t|"
     r"undefined\d?|ulong|uint|ushort|uchar|"
-    r"\w+_t)\s*\**)"  # type with possible pointer
+    r"\w+_t)\s*\**)"
     r")"
     r"\s+"
-    r"(\w+)"  # variable name
-    r"\s*(?:\[[^\]]*\])?"  # optional array
-    r"\s*(?:=[^;]*)?"  # optional initializer
-    r"\s*;",  # semicolon
+    r"(\w+)"
+    r"\s*(?:\[[^\]]*\])?"
+    r"\s*(?:=[^;]*)?"
+    r"\s*;",
     re.MULTILINE,
 )
 
@@ -618,17 +582,16 @@ def _parse_param(param: str) -> tuple[str, str] | None:
     p = param.strip()
     if not p or p == "void":
         return None
-    # function pointer:  ret (*name)(args)  /  ret (*name[N])(args)
     m = re.search(r"\(\s*\*+\s*(\w+)\s*(?:\[[^\]]*\])?\s*\)", p)
     if m:
         return m.group(1), (p[: m.start()] + "(*)" + p[m.end() :]).strip()
-    p = re.sub(r"\[[^\]]*\]\s*$", "", p).strip()  # drop a trailing array subscript
-    m = re.search(r"([A-Za-z_]\w*)\s*$", p)  # the last identifier is the name
+    p = re.sub(r"\[[^\]]*\]\s*$", "", p).strip()
+    m = re.search(r"([A-Za-z_]\w*)\s*$", p)
     if not m:
         return None
     name = m.group(1)
     type_ = p[: m.start()].strip()
-    if not type_:  # a lone identifier is a type without a parameter name
+    if not type_:
         return None
     return name, type_
 
@@ -653,7 +616,6 @@ def parse_c_variables(code: str, func_name: str) -> list[Any]:
         for i, raw in enumerate(_split_top_level_commas(params)):
             parsed = _parse_param(raw)
             if parsed is None:
-                # A non-void, un-nameable slot still occupies its ABI position.
                 token = raw.strip()
                 if token and token != "void":
                     out.append(VariableInfo(name="", type=token, arg_index=i, kind="arg"))
@@ -711,8 +673,6 @@ def _calibrate_shift(gt_offsets: list[int], decomp_offsets: list[int]) -> int | 
     best_k: int | None = None
     best_count = 0
     for k in _candidate_shifts(gt_offsets, decomp_offsets):
-        # Count UNIQUE ground-truth offsets matched so duplicate decompiled
-        # slots cannot inflate a spurious shift.
         count = len({d + k for d in decomp_offsets} & gt_set)
         if count > best_count:
             best_count = count
@@ -721,7 +681,6 @@ def _calibrate_shift(gt_offsets: list[int], decomp_offsets: list[int]) -> int | 
     if best_k is None or best_count == 0:
         return None
 
-    # Guard against spurious single-variable alignments at a nonzero shift.
     if best_k != 0 and len(decomp_offsets) >= 2 and best_count < 2:
         zero_count = len(set(decomp_offsets) & gt_set)
         return 0 if zero_count >= 1 else None
@@ -751,12 +710,8 @@ def _calibrate_shift_multi(
     if not pairs:
         return None
 
-    # Binary-wide calibration stays in the ±32 window: pooled across the binary
-    # it is robust for the decompilers whose offsets are already rbp/CFA-relative
-    # (a small constant), and keeping it narrow avoids a coincidental large shift
-    # winning the vote. IDA's per-function frame-bottom offsets are handled
-    # separately by the per-function override in _match_structured, so they do
-    # not need (and must not perturb) this binary-wide shift.
+    # The binary-wide shift stays in a ±32 window so a coincidental large shift
+    # cannot win the vote; IDA's frame-bottom offsets are handled per-function.
     candidates = sorted(range(-32, 33), key=lambda x: (abs(x), x))
 
     def matches(gt_offs: list[int], dec_offs: list[int], k: int) -> int:
@@ -773,8 +728,6 @@ def _calibrate_shift_multi(
     if best_k is not None:
         return best_k
 
-    # Fallback: no multi-variable signal anywhere; use plain unique counts,
-    # guarded against electing a shift from single-slot coincidences.
     for k in candidates:
         votes = sum(matches(g, d, k) for g, d in pairs)
         if votes > best_votes:
@@ -784,8 +737,6 @@ def _calibrate_shift_multi(
     if best_k is None or best_votes == 0:
         return None
     if best_k != 0:
-        # Prefer no shift whenever it aligns anything; otherwise require a
-        # nonzero shift to be supported by more than one coincidence.
         zero_votes = sum(matches(g, d, 0) for g, d in pairs)
         if zero_votes >= 1:
             return 0
@@ -812,15 +763,6 @@ class TypeMatchMetric(Metric):
     display_name = "Type Correctness"
     description = "Accuracy of variable type recovery vs DWARF ground truth"
 
-    # v2: per-function, adaptive (uncapped) stack-offset calibration so IDA's
-    # frame-bottom-relative offsets align with DWARF (the old binary-wide ±32
-    # shift silently failed for IDA, scoring most of its stack vars as misses).
-    # v3: uncommitted (width-only) types match a same-width GT scalar; recover
-    # local_/var_ name-encoded stack offsets; pointers/aggregates stay strict.
-    # v4: code-only decompilers (LLM backends) with no structured variables now
-    # get their C signature parsed into arguments (ABI position) + locals and run
-    # through the structured matcher — the old name-only regex fallback never
-    # credited arguments, zeroing functions whose only variables are their args.
     cache_version = "4"
 
     weight = 1.0
@@ -875,10 +817,6 @@ class TypeMatchMetric(Metric):
                 metadata={"error": "No ground truth types available"},
             )
 
-        # The type-match value is fully determined by the decompiled variables,
-        # the DWARF ground-truth variables, and the calibration shift. Cache on
-        # those (the decompiled code is included so the regex fallback path is
-        # also keyed correctly).
         key_inputs = [
             [
                 {
@@ -908,10 +846,6 @@ class TypeMatchMetric(Metric):
     ) -> MetricValue:
         gt_stack_vars = sum(1 for gv in ground_truth_vars if gv.get("rbp_offset"))
 
-        # Code-only decompilers (the LLM backends) expose no structured variables.
-        # Parse the emitted C into arguments (with ABI position) + locals so they
-        # get the same name-independent argument-position matching as everyone
-        # else, instead of the name-only regex fallback that never scored args.
         if not decompiled.variables and decompiled.decompiled_code:
             parsed = parse_c_variables(decompiled.decompiled_code, decompiled.name)
             if parsed:
@@ -980,8 +914,6 @@ class TypeMatchMetric(Metric):
         gt_offsets: list[int] = []
         for gv in ground_truth_vars:
             gt_offsets.extend(gv.get("rbp_offset", []))
-        # Effective offsets recover ``local_``/``var_`` name-encoded slots that
-        # some backends leave with ``stack_offset=None`` (see _effective_offset).
         var_offsets: list[int | None] = [_effective_offset(v) for v in decompiled.variables]
         decomp_offsets = [o for o in var_offsets if o is not None]
         gt_off_set = set(gt_offsets)
@@ -991,31 +923,17 @@ class TypeMatchMetric(Metric):
                 return 0
             return len({d + kk for d in decomp_offsets} & gt_off_set)
 
-        # Start from the binary-wide calibrated shift (robust for functions with
-        # few stack slots), then override with THIS function's own shift when it
-        # aligns strictly more of the function's slots. IDA's Hex-Rays offsets are
-        # frame-bottom relative, so the GT<->decompiler gap is a *per-function*
-        # constant (≈ frame size) that no single binary-wide shift can fit;
-        # per-function calibration recovers those matches. Decompilers whose
-        # offsets are already binary-consistent are unaffected — their
-        # per-function shift never aligns strictly more than the binary one.
+        # IDA's Hex-Rays offsets are frame-bottom relative, so the ground-truth gap is a
+        # per-function constant that no single binary-wide shift can fit. Overriding only
+        # when the per-function shift aligns strictly more leaves other backends unchanged.
         shift: int | None = calibration_shift if calibration_shift is not None else 0
         func_shift = _calibrate_shift(gt_offsets, decomp_offsets)
         if func_shift is not None and _aligned(shift) == 0 and _aligned(func_shift) > 0:
-            # Pure rescue: only when the binary-wide shift aligns NONE of this
-            # function's stack slots do we fall back to its own calibrated shift.
-            # This is the IDA case — its Hex-Rays offsets are frame-bottom
-            # relative, so the per-function GT gap is ≈ the frame size and no
-            # binary-wide ±32 shift fits. Decompilers whose offsets are already
-            # binary-consistent keep aligning >0 under the binary shift, so this
-            # never fires for them and their scores are byte-for-byte unchanged.
             shift = func_shift
 
         k = shift if shift is not None else 0
 
         var_types: list[set[str]] = [normalize_type(v.type) for v in decompiled.variables]
-        # Width of each decompiled var's uncommitted (undefinedN/__intN/...) type,
-        # else None. An uncommitted N-byte var matches a GT scalar of that width.
         var_unc: list[int | None] = [_uncommitted_size(v) for v in decompiled.variables]
         by_arg_index: dict[int, int] = {}
         by_off: dict[int, list[int]] = {}
@@ -1060,8 +978,6 @@ class TypeMatchMetric(Metric):
         decided: list[bool] = [False] * n
         pass_counts = {"arg": 0, "offset": 0, "name": 0}
 
-        # Pass 1: arguments by ABI position. Position is a reliable identity
-        # even with synthetic names (angr) and register args (-O2).
         for gi, gv in enumerate(ground_truth_vars):
             arg_index = gv.get("arg_index")
             if not gv.get("is_arg") or arg_index is None:
@@ -1074,8 +990,6 @@ class TypeMatchMetric(Metric):
             verdicts[gi] = _matches(set(gv.get("type", [])), di)
             pass_counts["arg"] += 1
 
-        # Pass 2: stack variables by calibrated offset (any-of across the
-        # DWARF loclist offsets).
         for gi, gv in enumerate(ground_truth_vars):
             if decided[gi]:
                 continue
@@ -1090,8 +1004,6 @@ class TypeMatchMetric(Metric):
                 verdicts[gi] = verdict
                 pass_counts["offset"] += 1
 
-        # Pass 3: names. Covers register-resident locals when the decompiler
-        # imported debug names, and stack slots promoted to args/registers.
         for gi, gv in enumerate(ground_truth_vars):
             if decided[gi]:
                 continue
@@ -1195,7 +1107,6 @@ class TypeMatchMetric(Metric):
         function_results: dict[str, MetricValue] = {}
         errors: list[str] = []
 
-        # Extract ground truth from the original binary
         binary_path = decompilation.binary_path
         cache_key = str(binary_path)
 
@@ -1211,10 +1122,6 @@ class TypeMatchMetric(Metric):
                 binary_path,
             )
 
-        # Calibrate the GT<->decompiler offset shift once per binary: the
-        # shift is an ABI/decompiler constant, and pooling offsets across all
-        # functions makes calibration robust for functions with few stack
-        # variables (where a lone slot could align to a spurious shift).
         binary_shift = self._calibrate_binary_shift(decompilation, gt_types)
 
         for func_name, func_decomp in decompilation.functions.items():
@@ -1233,7 +1140,6 @@ class TypeMatchMetric(Metric):
             except Exception as e:
                 errors.append(f"{func_name}: {str(e)}")
 
-        # Diagnostic: GT existed but nothing matched across all functions.
         if gt_types and (
             not function_results or all(v.value == 0.0 for v in function_results.values())
         ):

--- a/decbench/models/decompilation.py
+++ b/decbench/models/decompilation.py
@@ -48,27 +48,22 @@ class FunctionDecompilation(BaseModel):
     decompiled_code: str = Field(..., description="Decompiled C code")
     line_count: int = Field(default=0, description="Number of lines in decompilation")
 
-    # Line mappings for CFG reconstruction
     line_mappings: list[LineMapping] = Field(
         default_factory=list,
         description="Line to address mappings",
     )
 
-    # Structured variable info (stack vars + args) for type matching
     variables: list[VariableInfo] = Field(
         default_factory=list,
         description="Recovered stack variables and function arguments",
     )
 
-    # Pre-computed metadata (optional, computed during decompilation)
     metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional metadata (gotos, bools, func_calls, etc.)",
     )
 
-    # Structured cost capture (optional — both default None so artifacts written
-    # before these fields existed still load). Feeds the data page's cost section
-    # via decbench.scoring.cost, which prefers these over the trace/artifact scans.
+    # Both default None so artifacts written before these fields existed still load.
     time_seconds: float | None = Field(
         default=None,
         description="Wall time spent decompiling THIS function, when the backend "
@@ -83,14 +78,6 @@ class FunctionDecompilation(BaseModel):
         "decbench.scoring.cost.parse_session_tokens). None for non-LLM backends "
         "or when the session log was unavailable/unparseable.",
     )
-
-    @property
-    def has_gotos(self) -> bool:
-        return self.metadata.get("gotos", 0) > 0
-
-    @property
-    def goto_count(self) -> int:
-        return self.metadata.get("gotos", 0)
 
 
 class DecompilerMetadata(BaseModel):
@@ -125,25 +112,21 @@ class DecompilationResult(BaseModel):
     binary_path: Path = Field(..., description="Path to the source binary")
     binary_name: str = Field(..., description="Name of the binary")
 
-    # Decompiler information
     decompiler: DecompilerMetadata = Field(
         ...,
         description="Metadata about the decompiler",
     )
 
-    # Function-level results
     functions: dict[str, FunctionDecompilation] = Field(
         default_factory=dict,
         description="Decompilation results keyed by function name",
     )
 
-    # Combined output
     combined_source: str | None = Field(
         default=None,
         description="All functions combined into a single C file",
     )
 
-    # Output paths
     output_dir: Path | None = Field(
         default=None,
         description="Directory where output files are stored",
@@ -156,10 +139,6 @@ class DecompilationResult(BaseModel):
     @property
     def successful_count(self) -> int:
         return len(self.functions) - len(self.decompiler.failed_functions)
-
-    def get_function(self, name: str) -> FunctionDecompilation | None:
-        """Get decompilation for a specific function."""
-        return self.functions.get(name)
 
     def to_c_file(self, path: Path) -> None:
         """Write combined decompilation to a C file."""
@@ -183,10 +162,6 @@ class DecompilationResult(BaseModel):
             "failed_functions": self.decompiler.failed_functions,
         }
 
-        # Add per-function metadata. The structured cost fields ride along when
-        # set (they round-trip through toml.load; scoring/cost.py's structured
-        # scan reads them back), and are omitted when None so batch backends'
-        # artifacts are byte-identical to before the fields existed.
         for name, func in self.functions.items():
             entry: dict[str, Any] = {
                 "address": hex(func.address),

--- a/decbench/models/metrics.py
+++ b/decbench/models/metrics.py
@@ -50,12 +50,6 @@ class FunctionMetrics(BaseModel):
         description="Metric name to value mapping",
     )
 
-    def get_metric(self, name: str) -> MetricValue | None:
-        return self.metrics.get(name)
-
-    def set_metric(self, name: str, value: float, **metadata: Any) -> None:
-        self.metrics[name] = MetricValue(value=value, metadata=metadata)
-
 
 class MetricResult(BaseModel):
     """Results of a metric computation for one decompiler on one binary."""

--- a/decbench/models/project.py
+++ b/decbench/models/project.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import Annotated
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -99,11 +98,9 @@ class CompilationConfig(BaseModel):
 class ProjectConfig(BaseModel):
     """Configuration for a project to be compiled and evaluated."""
 
-    # Identity
     name: str = Field(..., description="Unique project identifier")
     version: str | None = Field(default=None, description="Version tag or commit")
 
-    # Source location
     source_remote: str | None = Field(
         default=None,
         description="Remote URL for source (git URL or tar URL)",
@@ -117,7 +114,6 @@ class ProjectConfig(BaseModel):
         description="Local path if remote_type is LOCAL",
     )
 
-    # Build configuration
     package_dir: str | None = Field(
         default=None,
         description="Directory name after extraction/clone",
@@ -127,26 +123,20 @@ class ProjectConfig(BaseModel):
         description="Subdirectory containing source files",
     )
 
-    # Custom fetch: when set, this shell command (run in a fresh source dir)
-    # is responsible for producing the source tree, instead of git/tar. Used by
-    # the malware targets to fetch + password-extract theZoo zips without
-    # cloning the whole repo.
     download_cmd: str | None = Field(
         default=None,
         description="Shell command that fetches/extracts the source into the "
         "current directory (overrides remote_type-based download)",
     )
 
-    # Danger flag: this target is REAL MALWARE. It is compiled (never executed)
-    # only for decompiler benchmarking, and ONLY inside a container — the
-    # pipeline refuses to build it on a bare host (see compile_project).
+    # Danger flag: compiled (never executed), and only inside a container — the
+    # pipeline refuses to build these on a bare host (see compile_project).
     is_malware: bool = Field(
         default=False,
         description="REAL malware source — compile-only, container-only, never "
         "execute. Guarded in compile_project.",
     )
 
-    # Build commands
     post_download_cmds: list[str] = Field(
         default=[],
         description="Commands to run after downloading source",
@@ -164,7 +154,6 @@ class ProjectConfig(BaseModel):
         description="Commands to run after make",
     )
 
-    # Options
     apply_patch: str | None = Field(
         default=None,
         description="Patch file to apply after download",
@@ -178,7 +167,6 @@ class ProjectConfig(BaseModel):
         description="Only compile these specific files",
     )
 
-    # Labels
     labels: list[str] = Field(
         default_factory=list,
         description="Labels applied to all binaries in this project "
@@ -206,7 +194,6 @@ class Project(BaseModel):
         description="Compilation configuration",
     )
 
-    # Runtime state (not serialized to config)
     compiled_binaries: dict[OptimizationLevel, list[Path]] = Field(
         default_factory=dict,
         exclude=True,
@@ -229,11 +216,8 @@ class Project(BaseModel):
 
         data = toml.load(path)
 
-        # Extract compilation config if present
         compilation_data = data.pop("compilation", {})
 
-        # Resolve a relative apply_patch against the TOML's directory so
-        # projects can ship patches next to their config.
         patch = data.get("apply_patch")
         if patch and not Path(patch).is_absolute():
             candidate = (Path(path).parent / patch).resolve()

--- a/decbench/pipeline/compile.py
+++ b/decbench/pipeline/compile.py
@@ -28,8 +28,6 @@ def download_source(project: Project, target_dir: Path) -> Path:
     config = project.config
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    # Custom fetch (e.g. malware: download + password-extract a theZoo zip
-    # without cloning the whole repo). Runs in a fresh per-project dir.
     if config.download_cmd:
         src = target_dir / (config.package_dir or config.name)
         src.mkdir(parents=True, exist_ok=True)
@@ -39,13 +37,11 @@ def download_source(project: Project, target_dir: Path) -> Path:
         return src
 
     if config.remote_type == RemoteType.LOCAL:
-        # Just use local path
         if config.local_path:
             return config.local_path
         raise ValueError("Local project requires local_path")
 
     elif config.remote_type == RemoteType.GIT:
-        # Git clone
         clone_dir = target_dir / (config.package_dir or config.name)
 
         cmd = ["git", "clone"]
@@ -57,21 +53,17 @@ def download_source(project: Project, target_dir: Path) -> Path:
         return clone_dir
 
     elif config.remote_type == RemoteType.TAR:
-        # Download and extract tarball
         import urllib.request
         from urllib.parse import urlparse
 
-        # Preserve the original file extension for correct archive detection
         url_path = urlparse(config.source_remote).path
         filename = Path(url_path).name or "source.tar.gz"
         tar_path = target_dir / filename
         urllib.request.urlretrieve(config.source_remote, tar_path)
 
-        # Extract
         shutil.unpack_archive(tar_path, target_dir)
         tar_path.unlink()
 
-        # Find extracted directory
         dirs = [d for d in target_dir.iterdir() if d.is_dir()]
         if len(dirs) == 1:
             return dirs[0]
@@ -101,10 +93,8 @@ def compile_project(
     config = project.config
     compilation = project.compilation
 
-    # SAFETY: malware targets are REAL malware. They are only ever COMPILED
-    # (never executed) for decompiler benchmarking, and only inside a container.
-    # Refuse to build them on a bare host unless explicitly overridden, so a
-    # stray `decbench run` can't drop malware binaries on someone's machine.
+    # SAFETY: malware targets are REAL malware — compiled (never executed) only
+    # inside a container. Refuse a bare-host build unless explicitly overridden.
     if config.is_malware:
         import os
 
@@ -119,31 +109,25 @@ def compile_project(
                 "DECBENCH_ALLOW_MALWARE=1 if you really know what you're doing."
             )
 
-    # Convert optimization to string
     if isinstance(optimization, OptimizationLevel):
         opt_str = optimization.value
     else:
         opt_str = optimization
 
-    # Create output directory
     opt_output_dir = output_dir / opt_str / config.name / "compiled"
     opt_output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get source directory
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
 
         if config.skip_compilation:
-            # Use pre-built binaries
             if config.local_path:
                 source_dir = config.local_path
             else:
                 raise ValueError("skip_compilation requires local_path")
         else:
-            # Download source
             source_dir = download_source(project, tmpdir)
 
-            # Apply patch if specified
             if config.apply_patch:
                 patch_path = Path(config.apply_patch)
                 if patch_path.exists():
@@ -153,7 +137,6 @@ def compile_project(
                         check=False,
                     )
 
-            # Run post-download commands
             for cmd in config.post_download_cmds:
                 subprocess.run(
                     cmd,
@@ -163,14 +146,12 @@ def compile_project(
                     check=False,
                 )
 
-        # Create compiler
         compiler = GCCCompiler(
             gcc_path=compilation.c_compiler,
             base_flags=compilation.base_flags + compilation.extra_flags,
             target_arch=compilation.target_arch,
         )
 
-        # Compile
         results = compiler.compile_project(
             project_dir=source_dir / config.source_dir if config.source_dir else source_dir,
             output_dir=opt_output_dir,
@@ -180,11 +161,8 @@ def compile_project(
             project_root=source_dir,
         )
 
-        # Also copy original C files. Recursive so nested source trees (CPS
-        # firmware, libacl, gnulib) keep their .c next to the binary, not just
-        # the top-level ones; dedup by basename, SHALLOWEST path first — plain
-        # sorted() would put arch/foo.c before foo.c and an unrelated nested
-        # duplicate would shadow the file that was actually compiled.
+        # Dedup by basename, SHALLOWEST path first: plain sorted() would put arch/foo.c
+        # before foo.c and let an unrelated nested duplicate shadow the compiled file.
         src_dir = source_dir / config.source_dir if config.source_dir else source_dir
         seen: set[str] = set()
         for c_file in sorted(src_dir.rglob("*.c"), key=lambda p: (len(p.parts), str(p))):
@@ -195,7 +173,6 @@ def compile_project(
             if not dest.exists():
                 shutil.copy2(c_file, dest)
 
-    # Update project state
     if optimization not in project.compiled_binaries:
         project.compiled_binaries[optimization] = []
 

--- a/decbench/pipeline/decompile.py
+++ b/decbench/pipeline/decompile.py
@@ -77,11 +77,9 @@ def decompile_project(
     Returns:
         Results keyed by binary name and decompiler name
     """
-    # Convert optimization level
     if isinstance(optimization, str):
         optimization = OptimizationLevel(optimization)
 
-    # Get compiled binaries
     if optimization not in project.compiled_binaries:
         raise ValueError(
             f"Project '{project.name}' not compiled at {optimization.value}"
@@ -89,14 +87,12 @@ def decompile_project(
 
     binaries = project.compiled_binaries[optimization]
 
-    # Get available decompilers
     if decompilers is None:
         decompilers = DecompilerRegistry.list_available()
 
     if not decompilers:
         raise ValueError("No decompilers available")
 
-    # Create output directory
     dec_output_dir = output_dir / optimization.value / project.name / "decompiled"
     dec_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -111,7 +107,7 @@ def decompile_project(
             executor_ctx = ProcessPoolExecutor(
                 max_workers=workers, max_tasks_per_child=1
             )
-        except TypeError:  # Python 3.10
+        except TypeError:
             executor_ctx = ProcessPoolExecutor(max_workers=workers)
 
         with executor_ctx as executor:
@@ -124,7 +120,7 @@ def decompile_project(
                         binary_path,
                         dec_name,
                         dec_output_dir,
-                        None,  # All functions
+                        None,
                         config,
                     )
                     futures[future] = (binary_path.stem, dec_name)
@@ -137,7 +133,6 @@ def decompile_project(
                         results[binary_name] = {}
                     results[binary_name][dec_name] = result
                 except Exception as e:
-                    # Create error result
                     from decbench.models.decompilation import (
                         DecompilationResult,
                         DecompilerMetadata,
@@ -146,7 +141,7 @@ def decompile_project(
                     if binary_name not in results:
                         results[binary_name] = {}
                     results[binary_name][dec_name] = DecompilationResult(
-                        binary_path=binaries[0],  # Approximate
+                        binary_path=binaries[0],
                         binary_name=binary_name,
                         decompiler=DecompilerMetadata(
                             decompiler_name=dec_name,
@@ -223,7 +218,6 @@ def decompile_projects(
                     workers=workers,
                 )
             except ValueError:
-                # Project not compiled at this level
                 results[project.name][opt] = {}
 
     return results

--- a/decbench/pipeline/evaluate.py
+++ b/decbench/pipeline/evaluate.py
@@ -33,7 +33,6 @@ def evaluate_decompilation(
 
     results: dict[str, MetricResult] = {}
 
-    # Extract CFGs from decompilation if needed
     decompiled_cfgs = None
     needs_decomp_cfg = any(MetricRegistry.get(m).requires_decompiled_cfg for m in metrics)
     if needs_decomp_cfg:
@@ -95,7 +94,6 @@ def evaluate_project(
 
     results: dict[str, dict[str, dict[str, MetricResult]]] = {}
 
-    # Get source CFGs for each binary
     source_cfgs_by_binary: dict[str, dict[str, DiGraph]] = {}
 
     logger.debug("preprocessed_sources keys: %s", list(project.preprocessed_sources.keys()))
@@ -104,9 +102,6 @@ def evaluate_project(
     elif optimization in project.preprocessed_sources:
         sources = project.preprocessed_sources[optimization]
         logger.debug("Found %d preprocessed sources for %s", len(sources), optimization)
-        # Source CFG extraction shells out to Joern (~seconds each); for projects
-        # with many binaries (e.g. coreutils) doing this serially dominates the
-        # run, so extract in parallel when there is more than one source.
         if parallel and len(sources) > 1:
             ex_workers = workers or cpu_count()
             with ProcessPoolExecutor(max_workers=ex_workers) as executor:
@@ -141,14 +136,10 @@ def evaluate_project(
     else:
         logger.warning("No preprocessed sources for %s/%s", project.name, optimization)
 
-    # Match each binary's decompiled functions against source CFGs TU-aware:
-    # prefer the binary's OWN translation unit (so per-program functions like
-    # main/usage/static helpers hit the RIGHT body, not an arbitrary same-named
-    # function from another binary of the project), and fall back to the cross-TU
-    # best-by-name only for functions the own TU doesn't define (statically-linked
-    # library code). This replaces the old name-keyed union whose last-writer-wins
-    # collisions scored, e.g., nologin's 5-node main against another binary's
-    # 56-node main. See decbench.utils.cfg.resolved_source_for_binary.
+    # TU-aware matching: prefer the binary's OWN translation unit so per-program
+    # functions hit the right body, falling back cross-TU only for functions it does
+    # not define. The old name-keyed union scored nologin's 5-node main against
+    # another binary's 56-node main.
     from decbench.utils.cfg import best_source_by_name, resolved_source_for_binary
 
     best_by_name = best_source_by_name(source_cfgs_by_binary)

--- a/decbench/pipeline/executor.py
+++ b/decbench/pipeline/executor.py
@@ -21,31 +21,26 @@ if TYPE_CHECKING:
 class PipelineConfig(BaseModel):
     """Configuration for the benchmark pipeline."""
 
-    # Output configuration
     output_dir: Path = Field(
         default=Path("results"),
         description="Directory for all output files",
     )
 
-    # Compilation settings
     optimization_levels: list[OptimizationLevel] = Field(
         default=[OptimizationLevel.O2],
         description="Optimization levels to compile at",
     )
 
-    # Decompiler settings
     decompilers: list[str] | None = Field(
         default=None,
         description="Decompilers to use (None for all available)",
     )
 
-    # Metric settings
     metrics: list[str] | None = Field(
         default=None,
         description="Metrics to compute (None for all)",
     )
 
-    # Parallelism
     parallel: bool = Field(
         default=True,
         description="Whether to run in parallel",
@@ -55,7 +50,6 @@ class PipelineConfig(BaseModel):
         description="Number of worker processes (None for CPU count)",
     )
 
-    # Pipeline steps
     skip_compile: bool = Field(
         default=False,
         description="Skip compilation step",
@@ -69,7 +63,6 @@ class PipelineConfig(BaseModel):
         description="Skip evaluation step",
     )
 
-    # Testing mode
     binary_limit: int | None = Field(
         default=None,
         description="Limit number of binaries to process (None for all)",
@@ -79,7 +72,6 @@ class PipelineConfig(BaseModel):
         description="Deterministically sample N binaries to process (None for all)",
     )
 
-    # Materialized-tree support (see decbench.pipeline.materialized)
     source_cfgs_root: Path | None = Field(
         default=None,
         description="Tree root holding published <opt>/<project>/source_cfgs/"
@@ -91,15 +83,12 @@ class PipelineConfig(BaseModel):
 class PipelineResults:
     """Results from a pipeline run."""
 
-    # Per-phase results
     compile_results: dict = field(default_factory=dict)
     decompile_results: dict = field(default_factory=dict)
     evaluate_results: dict = field(default_factory=dict)
 
-    # Final scoreboard
     scoreboard: Scoreboard | None = None
 
-    # Statistics
     total_binaries: int = 0
     total_functions: int = 0
     total_time_seconds: float = 0.0
@@ -139,7 +128,6 @@ class PipelineExecutor:
         output_dir = self.config.output_dir
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Step 1: Compile
         if not self.config.skip_compile:
             print(f"Compiling {len(projects)} projects...")
             results.compile_results = compile_projects(
@@ -153,7 +141,6 @@ class PipelineExecutor:
             print("Skipping compilation, discovering existing binaries...")
             self._discover_existing_binaries(projects, output_dir)
 
-        # Apply binary limit if set
         if self.config.binary_limit is not None:
             for project in projects:
                 for opt in self.config.optimization_levels:
@@ -166,7 +153,6 @@ class PipelineExecutor:
                                 f"for {project.name}/{opt.value}"
                             )
                     if opt in project.preprocessed_sources:
-                        # Keep only sources matching the limited binaries
                         limited_names = {b.stem for b in project.compiled_binaries.get(opt, [])}
                         project.preprocessed_sources[opt] = {
                             name: path
@@ -174,7 +160,6 @@ class PipelineExecutor:
                             if name in limited_names
                         }
 
-        # Apply binary sampling if set (deterministic random selection)
         if self.config.binary_sample is not None:
             import random
 
@@ -199,7 +184,6 @@ class PipelineExecutor:
                             if name in sampled_names
                         }
 
-        # Step 2: Decompile
         if not self.config.skip_decompile:
             print(f"Decompiling with {self.config.decompilers or 'all'} decompilers...")
             results.decompile_results = decompile_projects(
@@ -211,10 +195,6 @@ class PipelineExecutor:
                 self.config.workers,
             )
         else:
-            # A skipped decompile still needs DecompilationResult objects for
-            # the evaluate stage and the function-data universe — load them
-            # back from the stored <dec>_<stem>.c artifacts (materialized
-            # dataset trees and prior runs both keep them there).
             print("Skipping decompilation, loading stored decompiled artifacts...")
             from decbench.pipeline.materialized import discover_decompilations
 
@@ -232,7 +212,6 @@ class PipelineExecutor:
             )
             print(f"Loaded {n_loaded} stored decompilation artifact(s)")
 
-        # Step 3: Evaluate
         if not self.config.skip_evaluate:
             print(f"Evaluating with {self.config.metrics or 'all'} metrics...")
             results.evaluate_results = evaluate_projects(
@@ -246,11 +225,9 @@ class PipelineExecutor:
                 source_cfgs_root=self.config.source_cfgs_root,
             )
 
-        # Build per-function data FIRST — it carries the true function universe
-        # (every function any decompiler produced + explicit failures) and the
-        # measurability of each metric, which the scoreboard denominators derive
-        # from. Building it before the scoreboard makes scoreboard.toml and the
-        # HTML report share ONE source of truth (identical denominators).
+        # Built before the scoreboard: it carries the true function universe and each
+        # metric's measurability, which the scoreboard denominators derive from, so
+        # scoreboard.toml and the HTML report share one source of truth.
         from decbench.scoring.function_data_builder import build_function_data
 
         function_data = build_function_data(
@@ -259,15 +236,9 @@ class PipelineExecutor:
             results.decompile_results,
         )
 
-        # Step 4: Build scoreboard from the per-function universe (shared per-metric
-        # denominators; a decompile/metric failure is a not-perfect miss, not an
-        # exclusion). See scoring/scoreboard.py::build_scoreboard_from_function_data.
         print("Building scoreboard...")
         results.scoreboard = build_scoreboard_from_function_data(function_data)
 
-        # Attach the "hardest functions" table and any historical samples for
-        # the interactive report. Best-effort: never let report extras break a
-        # completed run.
         try:
             from decbench.scoring.report_extras import attach_extras
 
@@ -285,7 +256,6 @@ class PipelineExecutor:
         results.scoreboard.raw_data_path = function_data_path
         print(f"Function data saved to {function_data_path}")
 
-        # Compute statistics
         results.total_time_seconds = time.time() - start_time
 
         for project_results in results.decompile_results.values():
@@ -295,7 +265,6 @@ class PipelineExecutor:
                     for dec_result in binary_results.values():
                         results.total_functions += dec_result.function_count
 
-        # Save scoreboard
         scoreboard_path = output_dir / "scoreboard.toml"
         results.scoreboard.to_toml(scoreboard_path)
         print(f"Scoreboard saved to {scoreboard_path}")
@@ -332,9 +301,8 @@ class PipelineExecutor:
                     print(f"Warning: compiled directory not found: {compiled_dir}")
                     continue
 
-                # Discover ELF executables AND PE binaries (the malware targets
-                # are MinGW PE .exe/.dll; without the PE check they'd never be
-                # decompiled). cps ARM firmware is ELF, so it's covered already.
+                # The malware targets are MinGW PE, so the PE check is what gets them
+                # decompiled at all; cps ARM firmware is ELF and already covered.
                 from decbench.utils import binfmt
 
                 binaries: list[Path] = []
@@ -354,7 +322,6 @@ class PipelineExecutor:
                 else:
                     print(f"Warning: no ELF binaries found in {compiled_dir}")
 
-                # Discover preprocessed .i sources
                 i_files = {f.stem: f for f in sorted(compiled_dir.glob("*.i"))}
                 if i_files:
                     project.preprocessed_sources[opt] = i_files
@@ -384,15 +351,12 @@ class PipelineExecutor:
 
         results = PipelineResults()
 
-        # Get source CFGs if source provided
         source_cfgs = None
         if source_path:
             source_cfgs = extract_cfgs_from_source(source_path)
 
-        # Get decompilers
         decompilers = self.config.decompilers or DecompilerRegistry.list_available()
 
-        # Decompile with each decompiler
         output_dir = self.config.output_dir / "single_binary"
         output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -409,7 +373,6 @@ class PipelineExecutor:
                 )
                 results.decompile_results[binary_name][dec_name] = dec_result
 
-                # Evaluate
                 eval_result = evaluate_decompilation(
                     dec_result,
                     source_cfgs,

--- a/decbench/pipeline/materialized.py
+++ b/decbench/pipeline/materialized.py
@@ -112,7 +112,7 @@ def _split_artifact_name(
     Known decompiler names (when given) are matched as prefixes first, so a
     ``dec`` containing ``_`` still resolves; otherwise split on the first ``_``.
     """
-    base = filename[:-2]  # strip ".c"
+    base = filename[:-2]
     if decompilers:
         for dec in sorted(decompilers, key=len, reverse=True):
             if base.startswith(dec + "_"):

--- a/decbench/publish/cfg_export.py
+++ b/decbench/publish/cfg_export.py
@@ -38,8 +38,6 @@ logger = logging.getLogger(__name__)
 
 Logger = Callable[[str], None]
 
-# One function's serialized CFG: node ids (0..n-1), edges, readable labels, and
-# the ids of the entry / exit nodes (the only node attributes GED reads).
 CfgSerial = tuple[list[int], list[list[int]], dict[str, str], list[int], list[int]]
 
 

--- a/decbench/publish/layout.py
+++ b/decbench/publish/layout.py
@@ -45,27 +45,18 @@ from decbench.utils.results_tree import (
 
 logger = logging.getLogger(__name__)
 
-# Normative constants from the publishing contract.
 DATASET_NAME = "decbench-dataset"
 DATASET_REPO_ID = "noelo-lab/decbench-dataset"
-# `full` is a publisher-only config (the master everything slice); it is no
-# longer a scoring preset, so select_groups/copy_artifacts special-case it.
 DEFAULT_CONFIGS = ["sample-set", "large", "unoptimized", "optimized", "inlined", "full"]
 _FULL = "full"
-# `full` is not a scoring preset, so its description is the publisher's to own.
 _FULL_DESCRIPTION = "everything — all projects and opt levels (O0 + O2 + O2-noinline)"
-# Decompilers stripped from published datasets by default — the dataset mirror
-# of the site's `[decompilers] hidden`. Empty since 2026-07-23, when the last
-# excluded backend was fully removed from the benchmark; the strip mechanism
-# stays for future use.
+# The dataset mirror of the site's `[decompilers] hidden`. Empty since the last
+# excluded backend was removed; the strip mechanism stays for future use.
 EXCLUDED_DECOMPILERS: tuple[str, ...] = ()
 
 Logger = Callable[[str], None]
 
 
-# --------------------------------------------------------------------------- #
-# Manifest models (contract §3). Written as plain JSON via ``model_dump``.
-# --------------------------------------------------------------------------- #
 class ProjectSources(BaseModel):
     """The stripped translation units published for one project."""
 
@@ -108,9 +99,6 @@ class ConfigManifest(BaseModel):
     binaries: list[BinaryManifestEntry] = Field(default_factory=list)
 
 
-# --------------------------------------------------------------------------- #
-# Internal per-group record produced by the copy walk.
-# --------------------------------------------------------------------------- #
 class GroupRecord(BaseModel):
     """A processed ``(project, opt, binary-stem)`` group, on disk in the dest."""
 
@@ -136,9 +124,6 @@ class LayoutResult(BaseModel):
     unresolved: list[str] = Field(default_factory=list)
 
 
-# --------------------------------------------------------------------------- #
-# Small filesystem helpers (mirror decbench.dataset patterns).
-# --------------------------------------------------------------------------- #
 def _sha256_of(path: Path) -> str:
     """SHA-256 of a file's bytes (streamed)."""
     h = hashlib.sha256()
@@ -171,9 +156,6 @@ def _relpath(path: Path, dest: Path) -> str:
     return path.relative_to(dest).as_posix()
 
 
-# --------------------------------------------------------------------------- #
-# Group selection.
-# --------------------------------------------------------------------------- #
 def strip_decompilers(fd: FunctionData, exclude: Iterable[str]) -> list[str]:
     """Remove every trace of the ``exclude``d decompilers from ``fd``, in place.
 
@@ -241,8 +223,6 @@ def load_dataset(
     stripped = strip_decompilers(fd, exclude)
     if stripped:
         logger.info("stripped excluded decompiler(s) from dataset: %s", ", ".join(stripped))
-    # Pin the sample-set to the tree's frozen manifest when one exists; the
-    # seeded draw is only the bootstrap for manifest-less trees.
     assign_datasets(fd, seed=seed, sample_members=load_sample_manifest(results_dir))
     return fd
 
@@ -270,9 +250,6 @@ def select_groups(
     return selected
 
 
-# --------------------------------------------------------------------------- #
-# Sources: strip system headers, dedup by stripped content, one dir per project.
-# --------------------------------------------------------------------------- #
 def build_project_sources(
     root: Path,
     dest: Path,
@@ -325,9 +302,6 @@ def build_project_sources(
     return sorted(content_to_path.values()), written_bytes
 
 
-# --------------------------------------------------------------------------- #
-# Copy walk: binaries + decompiled results + sources.
-# --------------------------------------------------------------------------- #
 def copy_artifacts(
     root: Path,
     dest: Path,
@@ -366,7 +340,6 @@ def copy_artifacts(
             result.bytes["binaries"] += _copy_file(real, bin_dst)
         result.counts["binaries"] += 1
 
-        # Decompiled results -> results/<dec>/<opt>/<project>/<stem>.c (+ .toml).
         results_map: dict[str, str] = {}
         dec_dir = decompiled_dir(root, opt, project)
         for dec in fd.decompilers:
@@ -405,7 +378,6 @@ def copy_artifacts(
             )
         )
 
-    # Sources: once per project appearing in the processed index.
     for project in sorted({g.project for g in result.groups}):
         paths, nbytes = build_project_sources(root, dest, project, write=do_sources)
         result.project_sources[project] = paths
@@ -443,11 +415,8 @@ def attach_source_cfgs(
 # --------------------------------------------------------------------------- #
 # Config manifests + filtered scores (contract §3).
 # --------------------------------------------------------------------------- #
-# Publisher-side one-liners for the config tables in dataset.toml / manifests.
-# The scoring presets deliberately carry no text of their own any more (their
-# display copy lives in decbench/rendering/content/datasets.toml, which publish
-# must not depend on), so the published descriptions are owned here and kept in
-# sync with that file by hand.
+# Owned here because publish must not depend on rendering/content/datasets.toml;
+# kept in sync with that file by hand.
 _CONFIG_DESCRIPTIONS = {
     _FULL: _FULL_DESCRIPTION,
     "unoptimized": "unoptimized builds (O0) — surfaces simple structural differences",
@@ -606,9 +575,6 @@ def write_master_scores(
     log(f"[master] wrote results/function_results.json ({'filtered' if partial else 'full'})")
 
 
-# --------------------------------------------------------------------------- #
-# Top-level index (contract §4).
-# --------------------------------------------------------------------------- #
 def write_dataset_toml(
     dest: Path,
     fd: FunctionData,
@@ -655,15 +621,10 @@ def write_dataset_toml(
     log(f"[index] dataset.toml: {n_projects} projects, {n_binaries} binaries, {n_functions} funcs")
 
 
-# --------------------------------------------------------------------------- #
-# .gitattributes (contract §6).
-# --------------------------------------------------------------------------- #
 _GITATTRIBUTES_LINES = [
     "binaries/** filter=lfs diff=lfs merge=lfs -text",
     "results/**/*.c -filter -diff -merge text",
     "results/function_results.json filter=lfs diff=lfs merge=lfs -text",
-    # Per-config filtered scores are large for broad configs (e.g. 'unoptimized' =
-    # every O0 function, ~tens of MB) — LFS-track them too.
     "configs/**/function_results.json filter=lfs diff=lfs merge=lfs -text",
 ]
 
@@ -690,9 +651,6 @@ def extend_gitattributes(dest: Path, log: Logger = print) -> None:
     log(f"[gitattributes] appended {len(to_add)} rule(s)")
 
 
-# --------------------------------------------------------------------------- #
-# Manifest + index driver (called after the copy walk and optional CFG step).
-# --------------------------------------------------------------------------- #
 def write_manifests_and_index(
     root: Path,
     dest: Path,

--- a/decbench/rendering/aggregate.py
+++ b/decbench/rendering/aggregate.py
@@ -47,34 +47,15 @@ __all__ = [
     "union_leaders",
 ]
 
-#: Preset name for the synthetic all-functions combo emitted when a run carries no
-#: dataset presets at all. Reserved: no real preset may use it. The client falls back
-#: to this key when it has no preset to select (``app.js``'s ``FALLBACK_PRESET``), so
-#: a preset-less run renders every number with no dataset selector instead of an
-#: error banner. Kept in sync by ``docs/site.md`` and tests.
+# Reserved: no real preset may use this name. Mirrors app.js's FALLBACK_PRESET.
 ALL_PRESET = "__all__"
 
-#: The preset on which the sample-set-only decompilers (codex/claude-code — the LLM
-#: agents, cost-gated to the ~250-function sample-set slice) are actually shown.
-#: Mirrors ``app.js``'s ``SAMPLE_SET_PRESET``; the two must stay in sync. Used by the
-#: normalize gate: those decompilers join the "every decompiler decompiled it" test
-#: only where their rows render (see :func:`_active_combos`).
+# Mirrors app.js's SAMPLE_SET_PRESET; the two must stay in sync.
 SAMPLE_SET_PRESET = "sample-set"
 
-#: Floats are emitted EXACTLY as computed — deliberately unrounded. Rounding used to
-#: happen here (3dp) and was documented as "lossless"; it was not. The client
-#: re-renders some values at FEWER places than it stored (``toFixed(2)`` for Compare
-#: values, ``toFixed(1)`` for distance means), so pre-rounding to 3dp manufactures an
-#: exact 2dp/1dp half-boundary and the second rounding then breaks the tie the other
-#: way: 0.45454... renders "0.45", but stored as 0.455 it renders "0.46". That moved
-#: 13 Compare cells and 1 distance cell, in BOTH directions. The old proof only ever
-#: covered means and perfect flags, never the raw per-function values the Compare view
-#: prints. Rounding bought 0.087% of payload bytes (6.4 KB of 7.3 MB; 2.1 KB of 935 KB
-#: gzipped) — the payloads are dominated by embedded C source, not float digits — so
-#: the whole double-rounding hazard is simply deleted rather than re-proved. Do not
-#: reintroduce it: any rounding here is only safe at >= the most precise rendering the
-#: client does, and that is a coupling across the Python/JS boundary that no test in
-#: this repo can see.
+# Do NOT reintroduce rounding here. The client re-renders some values at fewer
+# places than they are stored, so pre-rounding manufactures half-boundaries that
+# the second rounding then breaks the other way. It saved 0.09% of payload bytes.
 
 
 def combo_key(preset: str, normalize: bool) -> str:
@@ -130,7 +111,7 @@ def _js_is_finite(value: float | None) -> bool:
     quirk costs nothing and "fixing" it would move published denominators.
     """
     if value is None:
-        return True  # isFinite(null) === true — Number(null) is 0.
+        return True
     return math.isfinite(value)
 
 
@@ -215,12 +196,8 @@ class _FunctionFacts:
 
     datasets: frozenset[str]
     all_decompiled: bool
-    #: ``all_decompiled`` with the sample-set-only decompilers ignored. Those backends
-    #: only ever attempt the sample-set slice, so requiring them everywhere would (and,
-    #: from 2026-07-22 until this field existed, DID) collapse every normalize=1 combo
-    #: to the sample-set intersection — optimized|1 went 7,850 -> 50 functions the day
-    #: codex landed. Both flags are selector-independent; :func:`_active_combos` picks
-    #: per preset.
+    # all_decompiled minus the sample-set-only decompilers: requiring them everywhere
+    # collapses every normalize=1 combo to the sample-set intersection.
     all_full_coverage_decompiled: bool
     err_scope: tuple[bool, ...]
     err_errored: tuple[bool, ...]
@@ -229,10 +206,6 @@ class _FunctionFacts:
     perfect: tuple[tuple[bool, ...], ...]
     union_perfect: tuple[bool, ...]
     distances: tuple[tuple[float | None, ...], ...]
-    # Per-decompiler recompilation status: True (byte_match built it), False (it
-    # did not compile), None (byte_match not measurable for this dec — ARM/PE
-    # abstained, or the dec never decompiled the function; excluded from the
-    # Compiles denominator). Independent of the metrics/perfect maps.
     compiles: tuple[bool | None, ...]
 
 
@@ -257,8 +230,6 @@ def _function_facts(
     all_full_coverage_decompiled = True
 
     for dec in decompilers:
-        # Errors: a function is in scope for `dec` if it attempted it (present in the
-        # decompiled map); errored if it produced nothing (failed / timed out).
         attempted = dec in func.decompiled
         err_scope.append(attempted)
         err_errored.append(attempted and not func.decompiled[dec])
@@ -271,13 +242,8 @@ def _function_facts(
         fperf = func.perfects.get(dec) or {}
         flags = tuple(bool(fperf.get(m)) for m in metrics)
         perfect.append(flags)
-        # Union: perfect on AT LEAST ONE measurable metric. Gating each flag on
-        # measurability keeps a stray perfect=True for an unmeasurable metric
-        # (which per_metric would never count) from leaking into the numerator.
         union_perfect.append(any(f and m for f, m in zip(flags, measurable, strict=True)))
 
-        # JS parity: `const dm = dd[d]; if (!dm) continue;` — a missing distances map
-        # yields no values, and so does an empty one (every lookup is undefined).
         dmap = func.distances.get(dec)
         if dmap is None:
             distances.append(tuple(None for _ in distance_metrics))
@@ -289,9 +255,6 @@ def _function_facts(
                 )
             )
 
-        # Compiles: only counts where byte_match was actually measured for this
-        # dec (it has a byte_match value). None otherwise → out of the Compiles
-        # denominator, matching the per-dec, non-shared basis of `compile_rates`.
         bm = (func.values.get(dec) or {}).get("byte_match")
         compiles.append(bool(func.compiles.get(dec)) if bm is not None else None)
 
@@ -333,8 +296,7 @@ def _distance_stats(values: list[float]) -> dict[str, Any] | None:
     if not values:
         return None
     ordered = sorted(values)
-    # Plain left-to-right summation, as in the JS `reduce`; math.fsum would be more
-    # accurate and therefore a different number.
+    # Left-to-right summation for JS `reduce` parity; math.fsum would differ.
     mean = sum(values) / len(values)
     return {
         "mean": mean,
@@ -381,14 +343,10 @@ class _ComboAccumulator:
             dec_perfect_counts = self._perfect[di]
             for mi in range(len(self._metrics)):
                 if not facts.measurable[mi]:
-                    continue  # Unmeasurable for everyone: excluded uniformly.
+                    continue
                 dec_total[mi] += 1
                 if dec_perfect[mi]:
                     dec_perfect_counts[mi] += 1
-            # Union (emitted under the legacy `overall` key): denominator is
-            # any-metric-measurable — the union dual of the old every-metric
-            # gate — so ARM/PE functions whose byte_match abstained still count
-            # through GED/type_match instead of leaving the column entirely.
             if facts.any_measurable:
                 self._overall_total[di] += 1
                 if facts.union_perfect[di]:
@@ -429,7 +387,6 @@ class _ComboAccumulator:
                 dec: [self._errored[di], self._scope[di]]
                 for di, dec in enumerate(self._decompilers)
             },
-            # Per-decompiler recompilation success: [# compiled, # byte_match-measured].
             "compile": {
                 dec: [self._compiled[di], self._compile_total[di]]
                 for di, dec in enumerate(self._decompilers)
@@ -542,7 +499,7 @@ def _cost_block(content: Content, function_data: FunctionData) -> dict[str, Any]
                 "n_binaries": entry.get("binaries"),
                 "basis": "batch",
             },
-            "dollars": None,  # a traditional decompiler has no per-token cost
+            "dollars": None,
         }
     for dec, entry in (info.get("llm") or {}).items():
         if dec not in visible:
@@ -586,12 +543,8 @@ def build_aggregates(function_data: FunctionData, scoreboard: Scoreboard) -> dic
 
     content = load_content()
     decompilers = function_data.decompilers
-    # Decompilers rendered ONLY on the sample-set view (codex/claude-code): run on
-    # the sample-set slice only, so on other presets they would be near-empty under
-    # the shared denominator. The client (app.js) keeps their rows off non-sample-set
-    # views; their data still ships. Match by exact id or base name, like `hidden`.
-    # Also fed to the normalize gate via _function_facts: off the sample-set preset
-    # these backends never gate the normalize=1 universe (see _active_combos).
+    # Shown only on the sample-set preset: elsewhere these backends would be
+    # near-empty under the shared denominator. Their data still ships.
     sample_set_only = [
         d for d in decompilers if is_hidden(d, content.site.sample_set_only_decompilers)
     ]
@@ -602,7 +555,6 @@ def build_aggregates(function_data: FunctionData, scoreboard: Scoreboard) -> dic
     preset_names = [preset.name for preset in presets]
     ged_present = "ged" in metrics
 
-    # No presets: one synthetic combo that every function is active under.
     match_all = not preset_names
     combo_names = [ALL_PRESET] if match_all else preset_names
 
@@ -631,21 +583,12 @@ def build_aggregates(function_data: FunctionData, scoreboard: Scoreboard) -> dic
         "projects_evaluated": scoreboard.projects_evaluated
         or sorted({group.project for group in function_data.groups}),
         "decompilers": decompilers,
-        # Decompilers the client shows only on the sample-set preset (see above).
         "sample_set_only": sample_set_only,
         "decompiler_versions": function_data.decompiler_versions,
-        # Official display names / links / prettified versions the client renders in
-        # place of raw ids. Keyed by the same (hidden-filtered) decompiler ids, so
-        # the registry can never reintroduce a hidden backend.
         "decompiler_registry": _decompiler_registry(
             content, decompilers, function_data.decompiler_versions
         ),
         "metrics": metrics,
-        # How to name and order those metrics on screen. `metrics` above is the run's
-        # raw order (whatever the metrics happened to be registered in); the site sorts
-        # and labels by this registry, which comes from content/metrics.toml. Without
-        # it the columns would read "byte_match | ged | type_match" instead of
-        # "Structure | Types | Recompile".
         "metric_registry": {
             spec.name: {
                 "display_name": spec.display_name,
@@ -656,18 +599,8 @@ def build_aggregates(function_data: FunctionData, scoreboard: Scoreboard) -> dic
             if spec.name in metrics
         },
         "presets": resolve_presets(function_data, content),
-        # Which view the site opens on, from views.toml's `default = true`. The
-        # skeleton already marks that section `active`, so this is the schema's
-        # record of the choice rather than the client's routing input (routing
-        # happens before this file lands).
         "default_view": content.default_view,
-        # Corpus-wide, selector-independent: `binaries` here counts BUILDS (one per
-        # binary x opt level), the same population each combo's `binaries` is a
-        # subset of. It can exceed every combo's count — a group whose function list
-        # is empty is never active anywhere.
         "totals": {"functions": total_functions, "binaries": len(function_data.groups)},
-        # GLOBAL, not per-combo: decompile time and estimated LLM $ do not vary by
-        # preset/normalize, so the data page's cost table ships once up here.
         "cost": _cost_block(content, function_data),
         "combos": {
             combo_key(name, normalize): accumulator.result()
@@ -698,10 +631,6 @@ def _decompiler_registry(
             entry["display_name"] = spec.display_name
             if spec.url:
                 entry["url"] = spec.url
-            # `license` (open/closed-source) and `logo` (a shipped .dlogo-<id>
-            # background) are presentation-only; the client renders the license as a
-            # muted tag in the stacked name cell and shows a logo when SHOW_LOGOS is
-            # on. Emit each only when set, so the payload stays minimal.
             if spec.license:
                 entry["license"] = spec.license
             if spec.logo:
@@ -761,8 +690,6 @@ def resolve_presets(
             "name": preset.name,
             "label": spec.label if spec else (preset.label or preset.name),
             "description": spec.description if spec else preset.description,
-            # The leaderboard's per-dataset explainer (registry-only: data written
-            # before the field existed has none to fall back on).
             "long_description": spec.long_description if spec else "",
         }
         if preset.name == default_name:
@@ -904,8 +831,6 @@ def build_dataset_page(function_data: FunctionData) -> dict[str, Any]:
     loc_by_project = info.get("loc_by_project") or {}
 
     stats = _project_stats(function_data)
-    # Emit each project's presets in the selector's canonical order (not set order),
-    # so the payload is deterministic and rebuilds byte-identically.
     preset_order = [p.name for p in function_data.dataset_presets]
     projects = [
         _ProjectRow(
@@ -923,12 +848,10 @@ def build_dataset_page(function_data: FunctionData) -> dict[str, Any]:
         for cat in content.categories
     ]
 
-    # `unique_binaries` sums each project's distinct binary names — binaries are
-    # unique within a project, not across the corpus (many projects ship a `main`).
     summary = {
         "projects": len(projects),
         "unique_binaries": sum(p.binaries for p in projects),
-        "builds": len(function_data.groups),  # binary x opt-level instances
+        "builds": len(function_data.groups),
         "functions": sum(p.functions for p in projects),
         "total_loc": info.get("total_loc") or 0,
     }
@@ -958,8 +881,6 @@ def build_dataset_page(function_data: FunctionData) -> dict[str, Any]:
     return {
         "summary": summary,
         "categories": categories,
-        # Table order: biggest project first (stable, so equal-LOC projects keep
-        # their name order). Sorted AFTER the totals above are summed.
         "projects": [p.as_dict() for p in sorted(projects, key=lambda p: -p.loc)],
         "joern": {
             "source": {"lost": source_lost, "total": source_total},

--- a/decbench/rendering/assets/app.css
+++ b/decbench/rendering/assets/app.css
@@ -33,57 +33,38 @@
 }
 
 /* ---- Theme ----
-   Dark is the default look. Two theme surfaces share ONE token set: this :root
-   block IS the dark palette; the :root[data-theme="light"] block below re-inks
-   every token for a light ground. The choice is an explicit user opt-in — the
-   FOUC-free head script (html.py) stamps data-theme on <html> from
-   localStorage['decbench-theme'] (or a ?theme= debug param) before first paint;
-   there is NO OS-preference detection. Anything hard-coded outside these two
-   blocks is a theme leak, so keep palette values here (or derived from --line-rgb
-   / the tint tokens). app.js reads the chart tokens via getComputedStyle, so the
-   whole palette — chart chrome included — lives in this one file. */
+   This :root block IS the dark palette; :root[data-theme="light"] below re-inks
+   every token for a light ground. The head script (html.py) stamps data-theme on
+   <html> before first paint, so there is no FOUC. ---- */
 :root {
     --bg: #000;
     --code-bg: #141414;
     --code-border: #545454;
     --text: #DBDBDB;
     --text-muted: #8a8a8a;
-    /* One ink channel drives every dashed rule, inverting hover and low-alpha
-       wash: --border-color and the rgba(var(--line-rgb), a) borders below all
-       follow it, so a single override in the light block re-inks them all. */
     --line-rgb: 219, 219, 219;
     --border-color: rgba(var(--line-rgb), 0.9);
     --border-dim: rgba(var(--line-rgb), 0.4);
     --green: #6ab04c;
     --amber: #d4a72c;
     --red: #c0504d;
-    /* License tags: dimmer than the --green/--amber score palette so they never
-       read as a bar (see .lic-open-source / .lic-closed-source). */
     --lic-open: #7f9e63;
     --lic-closed: #b39a54;
-    /* Diff-row washes (.dl-match/.dl-norm/.dl-diff, .cat-hl) + the red-tinted
-       "inserted node" panel in the about-page GED SVG. */
     --tint-green: rgba(106, 176, 76, 0.10);
     --tint-green-hl: rgba(106, 176, 76, 0.16);
     --tint-amber: rgba(212, 167, 44, 0.10);
     --tint-red: rgba(192, 80, 77, 0.14);
     --dl-diff-fg: #e2938f;
     --panel-red-tint: #1a0f0f;
-    /* Inset chrome under a code panel: a heavy black inset reads as depth on the
-       dark ground; on paper it becomes barely-there (a dark vignette would look
-       like grime), see the light override. */
     --pre-shadow: rgba(0, 0, 0, 0.8);
     --chart-grid: #333;
     --chart-axis: #666;
     --sidebar-w: 230px;
 }
 
-/* Light theme — terminal-on-paper. The SAME design system re-inked for a light
-   ground, NOT a naive invert: every token above is redeclared (except the ones
-   that derive from --line-rgb / the tint channel, which re-ink for free). The
-   --blue / --viz-* tokens are declared in the second :root block further down;
-   their light values live here too (this selector's higher specificity wins) so
-   ALL light overrides sit in one place. */
+/* Light theme — terminal-on-paper: every token above redeclared, not inverted.
+   Higher specificity, so it also owns the light values of the --blue / --viz-*
+   tokens declared in the second :root block below. */
 :root[data-theme="light"] {
     --bg: #f7f6f3;
     --code-bg: #ececea;
@@ -163,10 +144,8 @@ a { color: var(--text); text-decoration: none; }
 .side-foot { color: var(--text-muted); font-size: 0.78em; margin-top: auto; }
 
 /* ---- Theme toggle (sidebar foot) ----
-   A terminal-style button (.ds-btn) that flips the light/dark theme. Its LABEL is
-   driven purely by data-theme in CSS, so it reads correctly at first paint with no
-   JS flash: "[ light mode ]" while dark is active (a click switches TO light) and
-   "[ dark mode ]" once light is active. app.js wires only the click. */
+   The button LABEL is driven purely by data-theme in CSS, so it reads correctly
+   at first paint with no JS flash; app.js wires only the click. ---- */
 .theme-toggle { display: inline-block; margin-bottom: 0.55rem; }
 .theme-toggle .th-to-dark { display: none; }
 :root[data-theme="light"] .theme-toggle .th-to-light { display: none; }
@@ -192,13 +171,7 @@ h2.view-title:before { content: "## "; color: var(--text-muted); }
 h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
 h3.sub:before { content: "> "; color: var(--text-muted); }
 
-/* ---- Prose lists ----
-   Markdown bodies (the changelog's dated entries, any bulleted prose) render to
-   plain <ul>/<ol>. The browser default — ~40px indent and disc bullets — floats
-   the markers left of the terminal content column and clashes with the `## `/`> `
-   heading prefixes. Scope compact, muted, dash-marked lists to the content area so
-   a bullet reads like a terminal `- ` line and items sit under their date heading.
-   .view ul/ol/li here only ever match markdown output — no scaffold uses lists. */
+/* ---- Prose lists ---- */
 .view ul, .view ol {
     margin: 0.45rem 0 1.1rem;
     padding-left: 1.4em;
@@ -216,8 +189,6 @@ h3.sub:before { content: "> "; color: var(--text-muted); }
     color: var(--text-muted);
 }
 .view ol { list-style: decimal; }
-/* Nested lists share the gutter, don't compound the shrink, and lose the trailing
-   block margin so a sub-list hugs its parent item. */
 .view li > ul, .view li > ol { margin: 0.3rem 0 0; font-size: 1em; }
 
 /* ---- Tables ---- */
@@ -238,32 +209,21 @@ tr:last-child td { border-bottom: none; }
 .lb-rank { color: var(--text-muted); width: 2.6em; }
 .lb-name { font-weight: 700; font-size: 1.02em; }
 .lb-name .ver { color: var(--text-muted); font-weight: 400; font-size: 0.85em; }
-/* Linked decompiler names keep the terminal look: same color, underline on hover. */
 .lb-name a { color: inherit; text-decoration: none; }
 .lb-name a:hover { text-decoration: underline; }
 
-/* ---- Leaderboard stacked name cell (name / version / license) --------------
-   Only the leaderboard uses the stacked block (.lb-name-stacked); the metrics and
-   distance tables keep the compact inline `name <span.ver>` form above. The cell is
-   taller than one line, so the leaderboard top-aligns its cells (below) and the name
-   line — the thing the row is about — sits level with the rank and the metric bars. */
+/* ---- Leaderboard stacked name cell (name / version / license) ---- */
 .lb-name-stacked { vertical-align: top; }
 .lb-stack { display: flex; flex-direction: column; gap: 0.03rem; line-height: 1.25; }
-/* nowrap: "Binary Ninja" must not fold into a taller two-line row. */
 .lb-name-stacked .lb-nm { font-weight: 700; display: flex; align-items: center; white-space: nowrap; }
 .lb-name-stacked .ver,
 .lb-name-stacked .lic {
     font-weight: 400; font-size: 0.72em; letter-spacing: 0.02em; white-space: nowrap;
 }
 .lb-name-stacked .ver { color: var(--text-muted); }
-/* License: a subtle lowercase tag, not a loud badge — a tinted line that keeps the
-   terminal look. open-source reads muted green, closed-source muted amber (both
-   dimmer than the --green/--amber score palette so they never compete with a bar). */
 .lb-name-stacked .lic { text-transform: lowercase; }
 .lic-open-source { color: var(--lic-open); }
 .lic-closed-source { color: var(--lic-closed); }
-/* Taller name rows: top-align the whole leaderboard row and nudge the single-line
-   cells down so they line up with the NAME (first) line of the stacked block. */
 #leaderboard-table td { vertical-align: top; }
 #leaderboard-table td.lb-rank,
 #leaderboard-table td.metric-cell { padding-top: 0.5rem; }
@@ -275,9 +235,6 @@ td.metric-cell { white-space: nowrap; }
 .pct-mid { color: var(--amber); }
 .pct-low { color: var(--red); }
 .binrow:hover td { background: rgba(var(--line-rgb), 0.06); }
-/* Sample-set-only backends on the distance page: below a labeled dashed break,
-   muted — their numbers cover only this dataset's overlap with the sample-set
-   slice (see the .subset-note under each table). */
 .subset-break td {
     border-bottom: none; color: var(--text-muted); font-size: 0.78em;
     letter-spacing: 0.08em; text-align: center; padding: 0.6rem 0 0.25rem;
@@ -372,31 +329,23 @@ footer { color: var(--text-muted); font-size: 0.82em; margin-top: 1.5rem; }
     .layout { flex-direction: column; }
     .sidebar { width: 100%; min-width: 0; height: auto; position: static;
                border-right: none; border-bottom: dashed 1px var(--border-color); }
-    /* The layout is align-items:flex-start, so a column-direction .main is NOT
-       stretched — without an explicit width it grows to its widest content and
-       the whole page scrolls sideways. Pin it to the column's full width so wide
-       content (tables/SVGs/selects) overflows INSIDE .main, not the viewport. */
+    /* .main is in an align-items:flex-start column, so without an explicit width it
+       grows to its widest content and the whole page scrolls sideways. */
     .main { padding: 1.2rem 1rem 3rem; width: 100%; }
     .nav { flex-direction: row; flex-wrap: wrap; }
     .side-foot { margin-top: 0.5rem; }
 }
 
 /* ==========================================================================
-   Metric-visualization + syntax-highlight additions.
-
-   Appended after the base rules above (see viz/NOTES.md). Everything here is
-   NEW and namespaced tok- / viz- / dl- so it cannot collide with the rules
-   above; a couple of view-page helpers (.src-*) are tacked on at the very end.
+   Metric-visualization + syntax-highlight additions. Namespaced tok- / viz- /
+   dl- so they cannot collide with the base rules above.
    ========================================================================== */
 
-/* Dark values for the syntax/viz palette. Their LIGHT overrides live in the
-   :root[data-theme="light"] block near the top of this file (kept together with
-   the rest of the light palette; that selector's higher specificity wins). */
 :root {
-  --blue: #4a90d9;          /* chart blue — also numbers/immediates            */
-  --viz-type: #57b9ab;      /* types: a calm teal, distinct from kw/str        */
-  --viz-pp: #b083c9;        /* preprocessor / directives                       */
-  --viz-call: #d7cf94;      /* function calls: soft gold                       */
+  --blue: #4a90d9;
+  --viz-type: #57b9ab;
+  --viz-pp: #b083c9;
+  --viz-call: #d7cf94;
 }
 
 /* ---- Syntax token colours (dark terminal) ------------------------------- */
@@ -408,9 +357,9 @@ footer { color: var(--text-muted); font-size: 0.82em; margin-top: 1.5rem; }
 .tok-imm  { color: var(--blue); }
 .tok-pp   { color: var(--viz-pp); }
 .tok-call { color: var(--viz-call); }
-.tok-mn   { color: var(--amber); }            /* asm mnemonic                 */
-.tok-reg  { color: var(--text); }             /* asm register: default text   */
-.tok-lbl  { color: var(--green); }            /* asm label / address          */
+.tok-mn   { color: var(--amber); }
+.tok-reg  { color: var(--text); }
+.tok-lbl  { color: var(--green); }
 
 /* ---- Code panels inside a visualization --------------------------------- */
 /* Strip base.css pre chrome: the .viz-panel provides the frame instead.     */
@@ -466,7 +415,6 @@ pre.viz-code code {
 .viz-panel-h.is-dec   { color: var(--text); }
 .viz-panel svg { flex: 1; min-height: 0; }
 
-/* graph caption (under a CFG etc.) */
 .viz-cap {
   color: var(--text-muted);
   font-size: 0.76em;
@@ -577,7 +525,7 @@ pre.viz-code code {
 .dl-diff  { background: var(--tint-red); }
 .dl-diff  .dl-mk { color: var(--red); }
 .dl-diff  code { color: var(--dl-diff-fg); }
-.dl-op { color: var(--amber); }               /* normalized operand  ____     */
+.dl-op { color: var(--amber); }
 
 /* ---- Narrow layout ------------------------------------------------------- */
 @media (max-width: 700px) {
@@ -601,15 +549,9 @@ pre.viz-code code {
 
 
 /* ==========================================================================
-   Decompiler logos  (the SHOW_LOGOS experiment — gated in app.js)
-
-   Each .dlogo-<id> carries its logo as a self-contained data: URI (no network,
-   CSP-safe, no external host). Logos are grayscale + dimmed at rest so a column
-   of colored favicons doesn't turn the strict mono table into a sticker sheet;
-   hovering a row reveals the logo's true colour. Only the leaderboard's stacked
-   name line prepends a .dlogo span, and only when SHOW_LOGOS is on AND the
-   registry marks the id with a logo — flip SHOW_LOGOS off in app.js and this
-   whole block simply goes unused.
+   Decompiler logos (the SHOW_LOGOS experiment — gated in app.js). Each
+   .dlogo-<id> carries its logo as a self-contained data: URI: no network, no
+   external host, CSP-safe.
    ========================================================================== */
 .dlogo {
   display: inline-block;
@@ -620,75 +562,41 @@ pre.viz-code code {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  /* Uniform, terminal-friendly at rest; full colour on row hover (below). */
   filter: grayscale(1) brightness(1.5) contrast(0.95);
   opacity: 0.72;
   transition: filter 0.12s ease, opacity 0.12s ease;
 }
 .binrow:hover .dlogo { filter: none; opacity: 1; }
 
-/* Light theme: several marks (r2dec/dewolf/kuna) are RECOLOURED to light #DBDBDB
-   art for the dark ground — on paper they would vanish. Darken every logo to a
-   grey silhouette instead, and KEEP that filter on row hover (a light-art logo
-   has no useful full-colour form on a light page), so the column stays legible.
-   The colour-favicon marks (angr/ghidra/ida/binja) also darken to a clean grey,
-   matching the terminal-on-paper look rather than turning the table into stickers. */
 :root[data-theme="light"] .dlogo { filter: grayscale(1) brightness(0.4) contrast(1.1); opacity: 0.9; }
 :root[data-theme="light"] .binrow:hover .dlogo { filter: grayscale(1) brightness(0.4) contrast(1.1); opacity: 1; }
 
-/* angr — github.com/angr avatar (angr.io) */
 .dlogo-angr { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAM0klEQVR42sWZe4xc1XnAf+ecO/fenZl9za7tXXtfxmtj/ACMcIrdmAoF0qBWSSjgmkJBBByR0jRSRGjVBKVRqRIBStQmqhTaqGpDSiFpIKEY4vLGwWBjMLaxDV4vXnu93vU+vDuzM3Of5+sfs2tsbAgkbXOlo7nn3plzf/f7vvO9RvEbHuqUcfKCBpHaVOTd8/+3Q8+MD/0SSqE1KPXrCeAjgdn3XGsFrwDNLTCnGXK2k8x0B8XyJMWxScbGJihXw3d/pvVHk6r6KF+aXfMcaPk4fPriuXOuW9ax4LK21lYnm/PxAkv66YVEly8gGJtg4sQg/Qf379+9+61Htu6oPrBzL/sr1RqsUh8OUn0UqZ0PXVe77tevXLfmc73LF5N1FVRKpKVSIqlN7Ng0mZsuwVl/Eaoca+3kHCu+rpQrDB7exgvP/3jnzzcduuOZl3gmCBGtwdrfAHAWrg70jfClW9at/fbSy34HN5228ZGDkQ1ih2xe61y9pi4LgUFdkUdd6iGVEIhAxDq6JTHeCmul4Pf1beKRR3/ws/v/bfpPDw9R+lWQ6lfBLYD6v2pqfGz95/7k9xoKTpQc2KXFcR3T3omubwBtQARJLUwnqEubUWvrkUoAhIhUkbSEBCWMbbJO/e9G5dj1N//i7uJ939u9ettO3v4gSPNBcCtg/r2dHX3X3PmFpX5pIEiH+j2zZJl2Fi1GNWQho0ASSCNQFsIQ1dOA7m6A2IKakYDSKONCWlZ2aoeTJU2WrNzonbd45C+GjvY/3TfAYa3PbpPm/eDmQ/7ezo7+K7/6xUbZ/2JkbeI5q1aDAjs6jh09AaUq+A6qzqDiEMII3VNAdRcgThEEKxaxFlSKUoJWPul0vzaVQeleenvc2XF44649h/712HEmzwZpztC3UvhK6b9tanzm6r/8Qq/sfyHC9VznvBWQVFASozKC9kGSEDs4ikQxurkOKmXUwrnorlYkTvBzBrdO47ogaYJNU5RN0HhIMKxUsU86z73VNjfuuOHFl8e/O10hfa+vPANQgJtRX/7in910i18eCGyl6DnLV6LiaZSxKFdQvkJnNTS5mFYPOT5Zg/RBdc5FdbfjasvL20fY9ORR+g9V6GjPkMsKaVSDVGSQyhFtkiDpXvZHDaXS5tatO9LHz6bRkycCLIMFG9dcfF9jmxckRw74zrnLICqBimdGhFIhIgG+DhEdo3vzKB0iYRlRioyb5V/+fR8/fLiPppYsA4MRd91zlJFxwXgGQQEW7TZjx19yczYOrrt2w21rLpKVIjVnfgagzKh3ve9/a+nvr7Pxm9u1bmsHlYKN3oXTMZgYx0vom5jEd0OUjlGtBlEhrms4OjTNvrfG+eZda1h/zULu+MpiVl/QyONPl3B9jUWD0ogSlJNFH93kLOm63H7mysJ3HUdhrTpdxbPSWwiFr6675EcLegtpfGhfxunqRhlBmQRMCsZiTYKfg+f7xrnrFR+IWNWWgAg2qKK6evB7e7h09RyyWUVQqpIGESvOzbCoS6ElRScJKklQaYK2CqaPaie/NM7Pm7Noy0s7fnB8jOLshtGnOsNLlbrqnAuW2ujg/kTV+bX9nAaIjUAiFCFaRaADHt5VpKWtk289O8Ht//EWoYQoImwak8lofN+QJCnGmUlpEBryBrGnbFMREAsqg4y9Yhd1XWLXXpzZcIYNpjOT1S0t1+dzGZ1OjDoqk4EkQpKo5ufSCLERWsWEUcDB4RIH9u8hLo3xj/89yM9fO4bvptg0wdqUJE0AQUQQJYhYktSeYlAyIxhBGw9dOujUm4y+6MLeDY6pOW6lwJnduQXwzu2cv0bCaauS2EE8JApQRoO2NWMwAqmgUiGolNh7ZBxfJyiVkiYRWBdIMDpB6xRIEVLEpoi2CBaxae3ptnadNAUU2lYcmT5mF/cuX9Va2JcdHqVyGmALNLfPa/VtaTIC7ZJYqFbAZBAsNbsWErHUeYbzWoQXd04QuFCXsXysMwt47Hn2SXZufgRjpQYnAtSctdEWz8yo1VqUWJQVkiThyjXzaI7Hk3lzutx5c2gdHuUwzADO5HVzstksUg0tAlhBgipkagvJrGZcwZYst69t5RevjzIwEXLnFQtYUshRHZmifeVn+f6WIbY+9yzZXANWBK011WrAhStXcMeXbqOhsYEwjIijAJXJseO/7uPo0NM0rSjbfLaVpkbmAIcV4MwaYxPkPGOwQQRWQQoSW6iGYGtZMUqjUETWsrKljqduX8aR8YhLFuQIyhaihFzjfDKNmlDnyGQasDZFa02kNTrXQqFzOQ0NjQRBQBhUUZkchc4LKB56AtIqnu+RrSM/Gzmc0wKJtbXMJBEkFVQMGIuomagvFlKNyghBBAt9j94Oj2rV1rKZUCBOQGI0Fi0piEULKCwKiyQhSVQhiQLSuAoCxs0SRfa0gDsLdRJwCqbDagi+A7FAJIgCHI12DQoNqdRUnwBKCLA16VrAaggEJQqldM2DcPpAKbRxappQ+t1PEVACxieKQ6oB07Ob3Zn1SqMwOl0qMzdXryWyEIP2DTIVEI9UEUcw9R6mqQ6dd1FeBi2CIEhikUQhESira+bAe9ISEbRSmFNTFql5uqhygqaMQmWadKlYZHKKsdnbJwHHYGJo5HiwqGOeayOxOlV6/NVDjISaYE4brutiBspkpo/hq4A6X/CaPTINPk7eR3s+TIWo2GIyDsYYjDEzFZ2emTtofXo9KAjVEwM05V203+qM9L1kj48yelLFs4AnINo3PPLCOlZ90jh1SXHfoN7TuZjhW2+kvm0+nV09lCenkBNTuKPj2LcPwDvv4I0MYYbG0EGJ9MQkbVfEBFGV8fEJ4lRmNomhVJ6mXCljzLsJlNKGqDpNOLqbtlXzE+XPcw70v7lzdILKbKBxZgNyCmwvFh+4fjr4pGf8ZLwcO1MbbyTf3kaL59NZKFCuq4OODrINDVRtSrVcJV+XJS2WSCtlpsbGsT09XLptG4VMBt/zsWLRShNGIQt7urEitQRABCfjM3L4ddzqARq7r0rKUaR3vnHgoThBtAI7CzgrxS3w2L7+g/bC9nZnuq0NKTTjhCFOQzPZfB5tDI5xaMjliaOIQBTNzQVsoYBFKJamQSzXb/jjGTs8/UiShJGRERzHQcRivDxHXn+URXNS1IJ1uu/IK3rr9vjBU5NTzSll5WGY3D44+LSk1ombGhOZsRelFGmS1IKj1ogISisyjoNWYJTCATzH4GhDpVIhTdMzRqVSOQnneFkmju5jau9DnP+xdUliCs5Tz/3k5TcP1CLIbBHlvPctQ5i0cXR62q01SRzXWh4iiOPg1GUxp/RlEgSTJFiJT26QMwqgmU0zq97tP/0bVswPcM/bkOw99Iz/2OOjfx7Hp9fLZwAiYqy16CCsxcvUorXGei51TU2oJCUaHiba+ybh3n0kb71NMjSELRZJikXqN24kd9tttSfos3RwJCXb3M6Wh++mbmQzq2/ZGFXw/Z/854MPbHlV7VAK7CmV05mA1mKNwT86hA4CkvY2lOcR7d1L8MuthM89j31jF3p8nIwIjjH4rovyfSgWyRSLJ6V0+rIpCmhsbWfHk//Ekafu4roNn7J0fIZNT/x18Z8fnP58OpNinepCnfcWTOUwnIhdN8pXqnbeN77p2O5uq94Z0FOHBnDjmLpcDq+hAdPZiZqRkLW1cJjGMdrzanFKajngLKjWhmwux9MP/h39m77G+vWfsO6qO6Otr9zr3/P3u1YdG6V6tgL+DMAX4vh7n+3ru3XB6tXkBgdR+/u0ztYhvb0Rk5OuUopUa5JqFSVy8mVFa9JqFTdNUCKg1Ew4q90/1r+L5x74CnJ4M9fddG2SXXEzW7d/27/7vif+4LU97H2/7sJJQDsDuQXe+NrAwMdvmJq6f15LyxKbcbSOY91VKLj1ra02HBhIZHLSVcagjAGlajmfMSRxhDYuWilskjI1eoTDe7fQt+0him8/zoXLu+zKO78TJdkF/s+e/Lq95x+2r375dV79oNbH+/ZmXFB58KT2FuZTcP3NHR3f7+npQcdxEg8PJ8nkpCNxrBVo0QpTiTlyeQfH1jTB1DgSjtDgxXbRkuV26dprE6f9fP/AwC/58U/vf/7+H05eM3CUsV+reXS2RiW1mnn+VUp94xPd3bd2tbeTAdJymbhcTiSOkmSygnd1J97Vi2lw8tS3nePoub0Ojk//4Gs8++yPjj36RP+XNz/PQ1H8G7bf1Fnms2sthMJa+MOLs9kbepuaLmvN5x3fczGViKbPryF7/YWUhscZnRziQP++sd279zz+0iul+19/k22lMsn/agPzw7SAW2ot4LnNkLM9+NFCdHGMiePjDI6f4MR0tQZ1sgVsz0jGfrtN9Fmw//Mm+m/jb4j/AfRLg8hxhcQYAAAAAElFTkSuQmCC); }
-/* Ghidra — NationalSecurityAgency/ghidra dragon logo (ghidra-sre.org), text cropped */
 .dlogo-ghidra { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAIZklEQVR42u2Wa4xdVRXH/2s/zjn3MTN3Ou/3QKctUpGGhkILlAYQAR8UChqlAgIWgkiICFFTRFAa0YhCY1QgxJIIYhosAqXFCBhqebdDH9S2tDPTKTOdV+feO/d5zt57+WGmOpiKJH4z80t2ch47e6+91l7/tYAZZphhhhlm+F+g6S+CCMQMCwBEWDW7eXlBcGF5deV3srlo8KVc/vef9P3T7+sb/JHU5NK5sjm2AH/EBgTAATizubp1eXVq5TBTfT+Fr0tjD/Zly0PbR7IDJWPssfl8PAMFAW7qzx3z2q5ZXB2/cCG8ryRLFmFoQRawSiCwjFfI7mtLKP+re/tP3zuRG/k4nrhxTvNl91bXPH3IEqhCoC20cCGjO6GxLwrf+euR8fv+cnjk2UwYmelG0jHPOWacNqui7uauxls/Y7zVVXmDccHGhs6ASDCzkwJgJVTMQSkmvEk8OOjZF+7c13/TWDmMiACednwBAEJgSaqia0NLy/6JUhQ6TyIRWuSNc5BCSE2iQkt1JO7hRYq6H9zTt6w3nc8cM1Iee5iXSiQemN3y7KV5uTJTDku5kI0rMIJA+olKIWOBUFyGivJsjEccCqCFObmIvNP2Sep9t1jYTo4xPSJCEB7obH/izqrUwza0JSlJHwQLLaVqUlI5gowcmzByRMWwuACipbkqeeaWfOGPUWTLDEAKAKQl/a6z4+9nGnHqoDUFFEin2rRXtyImJ84SfT1d7qXhOdwdLNBBS42uj3qtMMyWJVHWmPLiROKyhamKU15IZ9c7ZkgiOAaSntZ3NNT9IWXZgEhpBqLWuPjl0cy6TGTeS2o1v1kqZcAsiDwOne1yoqNI+GBrLve2BE2GeHVX2y3f0Mm1RRuVuEiqYamvDpztNv1k49DNf34j2zc8HDkAqKnRtOK86k98r71uQ2KjnZONrFGKlHYcRsrzvjD4wcnvjqf3AEBHIlb1/dq6NZ9LxG8+zA5Vhl19QottjX7/ss3d7WBGbcwPvjyr+ovfqqxa5zl2ZQAKMCkpva8PDy15avToa1Tned6THe07T1WyK5O3Yf0CP3jj3OihK+49cFsmY4+bnHPnxrynzmnf2Poqzp+AM4JIADAHwelPH+hpurAyOf+R5qYdAQP3TGTXzFGyfZUXX7kZ0dZvHh64uD9XzBIIbioVllRXzV3X2LgnsOwigvABlyW4C3v7UvLi6uqzV1VW3J41phjzpJ/+vNh50f3vXzY+blkr+tClJwK0JIyMRnbzWO6JFaemlicG0RApOMHM7VJVDmt5ZH7MX9zh+0vvyWXvfnR44AeHS+Zv19XXfPvB8fHbXh7LdCsiWDAIgCZCX7E0Voqrns/GEitK1kWGiOuE8LKCesRZsdjlEZxzRXbV87V46J3RG8bGjNOSEBn+kIHMQGQZShJ6D5XNNe8dPkd2ilCE7FiQmnDW3FdZ+avIU4vO6+lNbUoP/ZjLzO/ny2P9ksN9Ydgt6F8SwgAsGALAhnxm/WA9nGehiCDKzO7sWHCtOC3wv8TMQguRHK9yhee2ZbqJAOv4P2qasQwlCG/szWfvSo8sqU0pz0YuJIKyhsOrdLBs8WzVSTFjGvx4as28jsepIebtyBb6HQNu2qkdT4r4aDYqDdS4A74UApNzRJPSnxJ7wvJTighaEQYKZlt/fxgxf1jPjmukYygiPLxtbPsThYm7arUKjEUYKajGJqvurqnfUkhrOVwqph8dGLp15Zv7O9LlMPpPVYcdgysRkQLAEDwZ/kDEiWLMABGhPGaK1vLHrpOWJ8Nz+/7BNbvK4fZkAKVPMC4nnek6opOrGxvXOjB2ZXKjb41mDn1UKUwGUjZWqM7IMIgmRX7CuSExakyPALky2DXm1cKmGi1pKiH+G4xJMZ6w1t0+PnSxamMhNBsMSy8dmtL1yeSNV7bWXQIAvhTHXUNKAgM4fW7FvE6t4sWCLUHAKSL0htEWsb1YepkAYQTn6nJy1tIg3sUABOhjedE4Rk1Si0JLmPl1fuy65JAXRBMoCS2CQikq/ay+9vmlHdUnl60DAChJkGJyaEkwliEgxOoVTevMzshBCcUMJ4nweqm4XmzKTrz9gTHDPsHLR87dpFJrPSIYnrxjxwuJmPpOBLTMisnZTYl43Gp9//bx3z7Wm7ur3ldBZF3JSRHIrA0fb2/cfdWihvOhBYxlWDc5IstIelo/9t2uR5Zk5MKjuyOnYqQ0Q4ywC/+UyWySBedcJOitKyorbxixNnOi583v9Lz8xlxuq+VJrRLT2h4+FloitKUS6pTWVE3gCXkkHRYHRiPzSjH/6pKKxBlztXdS3rkQkjyZdmZ5ffLaZUtT5zV0BlHNLF/MaY03XH5OzSU/v671mXOP6nMH1xeNjpOKrCvUK+U/MJ6+fmM68zZJIjgAv2lt+eHVlZWr+6MoWytl5ZZ84ZE1o6N3vlYopKd7sNpTNGdWMjm7tqIuiGmvtT7RtGPw6N7n3x0YcG5SQho9rZ/t7NgxW6iTxp0NlSDPljmsigsvdqKGaxSgOEGVGRO7Q2R6rNFJUpFzpXqpgpfD0otX9h66KLKO/xlERYSfNjbeck2qam3GOZcQQjhm7CyVNuzj8it9sLsGHQ/UVQQ1Qcz3daBVQSC36eDQtt0D6aKd0iUx1Zx2Bn7sybaWrXOlXpBldpIgrINxZWcmO+LJIiB94UmfhHMwKSHUlrC88er+w5ceneoL5bF7ZQFsyuXeHHb2mTOC4AIGEiHgTvC9+R2BvoA0JspE4wXHOQZcb6546Ln9R3a9PzoR8r9ltiTCuDFmcz6/blEyvqhZqhMjhpUEJTUp6ZOSvlDSF0pIIscwHpF4upj/xar+ga9lImPFR3TpM8wwwwwzzPB/xD8AGjpDGFrm2d0AAAAASUVORK5CYII=); }
-/* Hex-Rays/IDA — hex-rays.com favicon */
 .dlogo-ida { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAK5UlEQVR42o1Ya6xUVxX+1tr7nJkzM/deLgVuETD31ogFUtOG0KYJplpSqyQKwWhCjKmVFEu0PqLV1safPhLbH2ol2sT+alAwvlDAFkxarj/6kD+VtsSCQdL23hau3BfzOI+1/HH2PrMZoDpkmLnnnNn72996fWsR3uWVJEmt0WiMtZrNm+u12k1s7SgzLyOiEVUVVYWIgJkhIgAAVYW/7i5A4b8qZ1n2TxF5J03T13q93qvdbncqTdPetTDQ1S42Go366lWr7h0ZGbm/Vqt90G8oqhUIqEIcGA/Cg/PvCqAH7X8fXE/T9OTCwsIPZ2dnf5NlWfo/AY6Nja2dmJg4FkfRmkIERVG0VcSCiD0LAKAifuOSK3c9ZBKDwPrs5v5vIooJQK/Xe/nCzMynFhYWTl8BkIigqli9evXmiYmJSagiL4ouEVlVtSjNyQoIVFnKT6gIq6oAYHGfFTARUSJWEXEAWUVE/bPumojkIpIycwMAzp8/f/vs7OzzVzC4dHR0bMOGDdOFSEolW4wSlD+1AOizV7Ll6fKbsqqKOqAhi6ELoA/UMyv+TUQ8PT09sbi4+Ab8hlEU8cT4+CF/UgDWsSFuEyGivumcD7nTsbvCCJ5xzAqIoICEv1H39msO7Gmvu+66g9ZargCuWrXqk0mjsTHP81RVS1P0wQJEDMdGGJXV/RIMPHtEBCrvsZagyt+XYIE+MH8QoDwEq0gaRdEtQ0NDWwCAoyji4eHhe4JNoZ49H22lJUsf9Iv7zfwBABAzE5EMHEIqUB6MswoCE3ufBBFEBEmSfMkYwzZJkuGkXt+a53nORHFlwj47Pi2I80lvdg78h5kIWZ4jyzKOokjIH/TydRgD7uCYFvEsAxaqeRRFW6IoanEURaPGmFhFcu2DqfxIAycPgHu/E1UFM6PdaaPRaOCuuz6KWq0GKQNJBvKYVKYO1gbA1Dc5RCQ1xrSMMaO2FscrtdyJoSrk0oCPZO37RmUmzzKVvimLi4tYt369PPLIdzkvchw//lxp8n50VsxpGGgueNx9gfNfLdMbImvfw2zMiIgA/VzVz1mevRIcB5uxYeZupyMAcM/n78WPf/I4b9x4C9rtNthHc9/Elb+FryAQyzzr1vfRzcassMaYpQHtCBZj73d+AagyiIRUMT8/zzeuX8/37/kyNm/ejDTtodNJYdn6wPBmE+9z6nKp908qrwFB6qo+S5CRZealrqYyBtNH8KmqYozhbrfLIoIdn/4Mdu26DytWrEC7fQnMDBsZqArSLGMmFue5DJd+wkpTpRWXBbyVSBXiDsFEy2xIvw6YwSfV0mTKC/PzWL3mvbjn3i/g7o99HIDi0qVLiKLIuadidOkoxsbGcPr0aW42GmBjRAfzZb9K9ctjwLQPUhBZs2TJktsajcbWoJSpwyYKqDGG0jSVPC/orrs/hm9++2Fs3LgJaa8HBRBZC2MYxjCYCLVaHSuvvx71JMH01DTm5mYpimMvyQgAOUbVsUmODHLV0xca7vV6hy3cg9ovZ+xzFhHJwsK8rFy5infd90V85M4tICK02+0SGDOICERl2WJmFEWOoeFh7Nz5Wdxxx4fxh9//TiYnJ1lE0Gw2URQFNHAfrbJ5P2BCK5rh4eFbm83mVgeUvWlLCpU2bbpNH3zoO7Tx1luR9rpQUVhrwUwwzGAmsDFgYlhj0Ov18NZbU1AVjI+PY/v27TQxMS5TU1P65ptvEhOJjSJ2ck2IiAITk+cVAKdperivTspoEmd79Ho9jI9P4MGHH+F169ajvXgJqgAbAxCBmADHGoPABDB7NgFmgzzL0Wl3sHPnTt63bx/v2bMH9Xqd52Zn4RI8V4rIlzxXNisGl4yM3JYkyVYFhIiMV8rGWvnPzAy9+OLzSJIE4ze8D7U4hkgBNuzYYximkkVmWGvR6XQxPf02ImuRNBIkSQIAGBkZwebNm7FlyxZMT0/L2bNntdfrkTGGgpgk5245EZk0TQ+bkZGRTUm9vlWKIgdggv6BiAgXzp/Hc88+i7enpvD+tWuxYmwMcGraWgM2HmgJsNvrYnp6GlEcIUkSJPU6ms0GrLUQESxfvhzbt2+nNWvW0L/OnMHF2VkEUk7U2ZuIuNfrHWFxmxGRL0MSSvW4VpM4juTIkUP4xtcewP59T4GZ0Wq1nFs4XUdUyV9VgNw/T04/iArkeY4dO3Zg/4EDWLdunXQ6HRCRXCFStK9IygaoRMuiCnKSqCgKVlVOkgRTU1Pyg+9/T77+1Qdw8h8vo9lqwUa29KdSA0JFXREoAZPzS994GWNgrcXRo0exe/dunDp1imu1mhRFwVUGCRzTVlJcRIjZaljFfSrwizPzyMgIJieP45WTJ7Ft+3bcv2cPVixfhjTNSpnnEgcxuWxQ6jsigjEG586dw2OPPYaDBw9Kp9NBI0k43EcDgUxUlhYabAUdo1XfG17L8xxDQ0Nod9p48slfYvfu+zA5+TfEcQQQUOZZgLi/YbPZxOLiIvbu3Svbtm3DgQMHQEDpJqVLiRex6gSu21OtEpFPkhKWnEDziZPtqsoESJ7nzEQYGhqSl158gX/06KPSaA3x+hs/UPmcFoqk0UBST3Dw4J/wxBO/wIkTJziOY7SaTYgqF0UhwT4VSUGnaa0UxaWw0SanAWmwD768HXDIhWtxDZG13G538O9zb8BaA2MYzVYTp19/Hft//SscPXYMRVH4wJK89DcvQkIxDCLioG9esCIyEzYvAwW8EgyXNTauNBoizvIcjSTBzTdtABuL1069hrn5eTx95AgOHzkiMzMXuNFoIIoiKYqir5p8KxqIFN9BBsLlgvWy3aUaOM3X70WcPHeUc3BU9iYhJgwND+HkK6/imaefwaHDf8a5s2climO0Wi1cBqy/eai0Ra8iaEWkbdM0PecekMr/Bk6kXlj2/ROqKkzEhQistXLs2F/5Z3v34sTfXwIzo15GJ4o8r8qXa/grmU+ug9PQlRx4R8gcNZvN5WtWr35HRFIQ2UHR6rt97Tfd1TTBt4hOpcjc3BzX63UfmVXiH9g8/LzaPVHVlJnjmZmZVZxl2UIvTV8HEGtf6nMwHfCM+j6ZpTS/H1VgYWEB7XabkySphkpy5eBIAgD9tf2cJ7gPoJ5l2Zk8z2c5y7JumqZ/BJEURZG6MZvPSxxs5r+LTzned9kJh6IowmdF++kpDLwqO/i/vT50BSRnZuR5vr8oii5r2QA9LiLsU0tQiy+TQtVGZccXdmJVQg/aUg4Y4WDEgYE1w1lOlXra7fbPVRUGANI0navVaqZWq90pRdFWIPYFNciRVE3DtD9Ccv8RObOHaUhLScQiAgIoUErVmiIiVMoZUtUOM9c7nc63FhcX/wKgBAgA3W73eL1e/1AUx2sLNxscGPAQ9VtTv6BWzbaTaEHD5Z8RfzD/PQwWp6hFVXvGmCTLskMXL178iufABDlHu93u/jiOb4ii6BaUZmsroC6K1QNwQC8fWDrJPhDtGphXEc4NgVxVcwAZgMgYY9M0fWp2dvZzRVFk1xwBMzONjo7uarVaPzXW1l3+g4h0rzkZcIl9sNK4AMlRjjIGk3HdC1URudDpdB6am5t7UgceoneZ8C9rNBpb4zj+hLX2dmvMKiKCBEPIACkGZi7X/O7n2HmenymK4oU8z59pt9u/zbJs8f+e8l/WtBjDxpi6YU5AFBljhoPbETMPOYCVj7oDEIBCRC6GAEVkXlUzEWkXRdELm6arvf4LuwP/7Nx4g4cAAAAASUVORK5CYII=); }
-/* Binary Ninja — Vector35/binaryninja-api docs logo (binary.ninja) */
 .dlogo-binja { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAMK0lEQVR42rWZfWzVVZrHP+ec3+93Xwr0DdrLBaQtUxiZdQYs0gGUsQF2dk1mHDNRgytdwFGJFFhcZtSNjOKajSRqUGQh2xVF0Y2yuzExixmXBdNuWqkDNI6KiKWUESi0pZe+3Jffyzn7x72tlWF5cfAk54+b8/b9nec8z/N9vldwBU0IgZSSIAgAiEajzJ07t6impqbqpptuWlBcXDxPCFHpum4xgOM4PVrrI+fOnWvev3//f+/bt+9gU1NTbzqdBkAphTEGrfXlz77cBKXUMLDrr78+tHz58r+cMWPGqq6urkUfffQRBw8e5NixY/T29jI4OAhAXl4ehYWFVFRUMHPmTKqrq4nFYrs//PDDF1999dV9R44ccS/c+6qbEAKlFAATJ0606uvraxsbG/vXrl1r4vG4AQyQATwgyP0e2YPcWAYwsVjMrFmzxjQ2Np7ftm3b30ycOFENgRRCXD24oUX33Xff1NbW1i8efvhhY9u2AVKAh5AGRBaMEEYoZSK2bSKObaSSBpEbQ5jsXDwgpZQya9asMR9//PGntbW1Uy4877ImFkJgjAGgvr6+tqKiYseyZcs4ceJEWoETCCkxmmjIZnb+KH5ckMe0sEOppcgTAgQkteasrzmSdmnpS7I/MUB/2gUhURgdGONOmDAh/Morr9DW1nbPypUr/01r/Y2zLwpw6Cts2+add9556sSJE+tXrFiRBhzbsqTn+8TyIiyJF/HzglGU2QoLg68NgYGA7OYKgRJgCUEgBB1+wH8lBnnt9Dm+6k9iWxae72vA3bx5c7isrOyJO++886lMJgPwDZDiQk/VWrN79+5/bG1tffyxxx5L2paKer4GKbhvcikrSwuIS8GgH5AxJgtJCMSIzYYeIbmDQkKQpxRdxrD1bIJtHWcwgcGxFK7vJzds2BCtqqp68vbbb98AoLUeBjkM0LIsfN/n5ZdfXuZ53vYVK1YkQ7YdzXgehZEQz0+dwG2jwvR5WWAqB+pKmgECY3CAfNtiT8pl7ZGvOJtME3IcMq6bfPHFF6OO49y7YsWKN0Z6txjp7kuXLv3e8uXLj86fPz/p2HbU9TxioyLsmH4dP1SSbj/Augpg/x/QIqX4QhtqP+vgxEAKx7ZxPS+5d+/e6Pbt2yt27tzZPoRJSCkxxhCPx9UHH3zQVlNTM+HUyZNSIOSokMXbN5TzAyXoDTS2+LbQvtl8Y8iXkjYDd35ynJ5UBiGEP3bcOBobGzvmz58/9cyZM1oIgRp6dy+88MKy999/v/a9995zbcuyfaPZPH0yPwnb9FxDcABSCJLGMEkJpubn8c7ZBEpK2dff70opS+6+++62d99992MpZdZalZWV9q5duxKzZ892dBBIPwjk4utK2DRpLF2uj3UNwV14kyWOxT+c6uVf209jKaURQu/fvz991113FbW1tXkS4MEHH/yrt956K+q6rm+MkUVhh4fHF9Hv+ajvCByAEoKE61MXKyCWF0EbI33f9994441R999//0IAmUv8v9mxYwdCCCvQmsXxYiYpSSoXjvR31MnlwVIBtfFicsHaev3115k/f/6vw+Ew1rx584rPnDlz86lTp7QQ0nIsxR1Fo0kFAVEpkd/dBeY8W5AOND8rzGOLY5P0Aqurq0ufPHmyZs6cOYXWggULZu/fvx8hhG8wzo/y86h0LPo8n7Oej74g9VzLJnKhp8hSlIcdqgryaDh7HiGE39TU5CxcuHCWVVVVdevGjRsxxkiA2flR8oB2IfnF58dJZrzhja79G4TAwKYp41kWDTF7TJSGswmMQR44cID169cvtMaNGzf3yy+/BJAA34+E0NrkvCwbWAHkt6FFl2iB72MAbcAIQaAN0yIhEAKMkceOHaO4uHiuZdt2ZSKRyAJUirhj4ZsssxjKrwLQ35ZYXioe5iwjcyEn5lgIpTC+LxOJBFLKSsvzvOJkMpkLoBBVAo34k8S/bt064vE4WhvESM/J2T4IAqSSCCEIfD9LdoXIjg9vZrLjgWbjxmfo6e4efjpaQNgPsHSABwwODpJOp4utS5HDkRZduXIlZWVl1+z26uv/he7u7kt7uDFI27Z7IpFI9hYMpDRIzJ84RSKRIJPJkE6ncV13uKdSKbTW1NfXM2vWLKZPn84jjzxCMpkklUqRyWSG52YymeE9RnI+Y0AayFiKQMrhuiYcDvdYruseLSwsLD1//rwmCGRnxkM5EVSgkcYMPVr6BwYIhUIX/dIDBw7wwAMPDP8+fPgwsdh41q79u4vOT6VS9Pb2DpspEnaQwFkvQAcaQBcUFEit9VGru7u7qaKi4ubjx49rQH6RdjFjIhQoyVjHZsD1QQhWr1rFE088SUVFOZZlAYJUKsXhzw+zYcOGLNlFgNbYtmL9b9cT6ICb581j9OgxCJElot3d3bz00kt0d3cjZfbNxkIWBjiaygyRXF1eXi7PnTvXZLW0tOypqqr6zb59+7Qx0NKXJFmST6GAuYWjaO9P4khBa2srd9zxi+GvFheh5jMLRlERDfEfp3oIvAF+vW7diDpnKDJn19hS4mnN9QWjqXQsBnNng0AI9I033khLS8seuWfPnt/PmTMHY4wlpOBgYoAOXxNozYpYIcXRMK42KCmxlUIJUMYgc6zazpWmRkqerBjPsxXjiY2KogFbKSwpsnMxKGOwc/t4OltG/P3kcYwxho4goCUxMFQ4WXPmzGHPnj2/l83Nzb3xeHxfaWmpxBg/7fm82zuAJRVxATunX0f12Hy0EHhBkCuOct0YPK0pGx3ln6dfx48cReB6vPr9idw0Nh9vqKDi6zWe1nhaUzEmjy3TJ7Mg4qCF4Hfnk/RnPDDaHzt2rJw0adK+5ubmXgHwzDPP/HV3d/fuZ599Ni2lDI+LOPzuhnLCQUBISrSUfOp6HB1M0z/CrCEEkyMON4QdCoD+QIOAiBAEUvJJxqUt5TKg9XBUCAFlkRA3hB3yBQz4Adqy+Okf2jmVzKC1Tq9evTocj8dve/TRR98TAFOmTLHffvvtc9XV1WGMkX4QyF+Vx/ineDGdGQ9bCCJS4EjByIrEYPCNIa0Nnsnm1iF6JowhKiX2JdaktCEWsni6M8HmtlNYSmkDuqmpKX3PPfcUtbW1eUopRU9Pj541a9ZXZWVlv2xubs7YyrIOnR/gh4Wj+YFjMWiyZkppQ0rr4Z7WWbnA5LLQSIcRQuBedI3BAzxjKLIkH7oBjx75I0pI/CDIPPTQQw7wq9dee+2QUurroqm0tFQ2NDR8ccstt0zu7urCGGONjYT497+YTJkQ9Gl9zai/bwyjpeS0gF9+0sGpwTRSCL+ouJjGxsaOW2+9dbhoklprpJR0dnbqp556atGbb75pBVq7lmVxNplmyWcn6DBQqCSeMX827fKMoUBJOgX87edfcXIghWNZBFq7O3futJ5++ulFnZ2deqiYk0OJXinFzp07248ePXrvpk2boq7nJUOOQ8dAirs/66DZDSixLaTJviFzVaw5S90whhLb4pCnueuTExxJDBB2HDKel3zuueei7e3t946sibMyygVa4O7du/+wcuVKKisrF/3P3r1Jx7LsRNrlP7vOEzg2M0dFKZICfxiouKjKOMz1MFhCkG9JXKnY1tPH2iN/pCedwbEsMp6XfPzxx6MzZsx4csmSJZuHbu6S4lEoFGLXrl2/PXbs2IY1a9akAcdSSvpBwPfy81g+vpif5keJKYkwBk9nweoRPM8SAlsKEIIzWrOnL8XLp3r4PDEwpGRowH3++efDlZWVlxePLpTfpJRs2bJlcXl5+ZvLli3j9OnTaSWEE4DEGMZFw8wrHM2PR0eYGnEYaykiKstE0oGmOwg4mnJp6U/xv739dA6mQQgU6MAYNxaLhbdv305HR8cl5bfLCpi1tbVTWltbP121apWRUo4QMMXXAqZSJhpyTFE0bIqiIRMNOQalcuNiSMz0gJQQwtTV1ZnW1tYrEjCvVAJWW7duXdzQ0HC+rq7OlJSUXLUEXFJSYurq6kxDQ8P5rVu3Lr5SCfiqRPRp06Y5S5curamurl598uTJ21paWjh06BDt7cfo7U2QTqUACEciFBYWUF6eFdFnz55NPB7f3dLSctUi+hXd6xBvG9osHA4zd+7cwpqamhurq6sXjRkzZo4QYpoxpjh3+z3GmCN9fX1/9t8Q/wdWxFg+TPRL5wAAAABJRU5ErkJggg==); }
-/* r2dec — radare2 (github.com/radareorg) mark, recoloured to light for the dark UI */
 .dlogo-r2dec { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAF0UlEQVR42u2WX0wURxzHfzOzC/f/EGjZtVgCpparpE0kEMWYRpsIUWo8eOAaUZuLSBqaXKItmNinmvjWpEZIavvkQxNNNJQGEtI+QcWmGiCnctylKijo0RPwDnb3jtudnT54eznxwJKm6ct9k8le5mb299nf/Ob3+wHklFNOOeWUU07/p5DxA2MMCCFgjKUHQggwxsAYe7E4438ASD9fawShDa03eBhjLzYbL1i94F9/PUJACNnQHozxS7bTZBUVFbwgCFZVVenY2NgypRScTieqqqpyqqqqAwDjOI6Ew2F5cXFRs9lsZH5+XltZWckKhjEGSikAAJSWlnI8z6OpqSnVOIW1HKLrOgAAVFZW5sdiMQ1KS0u5S5cufT46OjoUCATuTkxM+Pv7+3vq6uoKtmzZwk1PTz+9d+/e+MTEhD8QCNwdHx///cqVK193dHTUlpWVcZlHuNpjoigSn8+30+/33/L5fDsB4BWPYoxfmnO5XKbz5883BQKBu42NjZs5r9e7v6Gh4av5+fmQoigLGGNeFMWqxsbGfQ8ePPgzEokECCE8ADBKabKgoKAiFotFenp6bmUaIoQApRQopSCKImlpaaltamrqLCkpeY/neWs8Ho9nizHDYy6Xy3T06NEDDQ0Np61Wa7GmaYlkMqlxoiiWLy8vhxljDGNMAEAHALh8+fLA2bNnT9ntdlFRlGcIIYIx5nRdVzNjhTGWBispKcFHjhzZ5Xa7uwRBqJJlOfL8+fOHhYWF7+DUGa4Gq6yszD9+/PjH9fX1p2022xuSJIVjsdgjq9VaghBCXCKRWOZ53ipJUgRjTDiOMwOAPjc3l7xz587I7t27P5MkKUxS54AQwuiFQNM0AAAQBIG0trbWHTp06JQoih9IkhSJRqPTGGNCCMk39mCMQVVVA8zk8/k+ra2t/cRut7+VAntMCOEJIXmGp7lr1679XFdX11pcXPwupTRpMpkc3d3dLbFYjEWj0ViW9IA0TVMppSAIAvF4PLXNzc1dgiC8L8tyJhifWk8RQjiZTKq6rkN1dbXN7XbvP3jw4JcWi6VQluVIBhi/+vJwIyMj0ebm5gNut7va4XA4/X7/xMDAwJNUwKNMOIQQ1nV9xel0vunz+XZ5vd4LJpOpQJblv6LR6EOM8StGEEKYUroiCIJ47ty5imPHjn2vKMq8oijPlpaWnqwFlgZECMHs7Kx28eLFP4xJnudBVVVg2TMrZozRUCg0NTo6enXHjh0tFoulUJKkZ4wxihDKlkCJoihyMBgMbd++/UeXy1VvMpk2KYqyoOs6TcV+9rxoVAxCSHqslfEZYzrGmF9aWlocHByc83q933R0dOwfHh7+wWKxFNlsNlHXdWpcJGMPIYSTZVm6fv36I4/Hc+rMmTP1wWDwV4fD8bbZbN5EKVV1XadZAY0YM26ikVzXESOEECN/jYyMRE+ePPntiRMn9gwNDfWYzeZNdrtdZIzpBmjqwzAhBDRNg76+vlmPx/NFZ2fn3snJyUGn07kmKF6vRCGEMGNMX6++GjX85s2b0fb29u729vYPh4eHvzOZTI6URzUDlFKafreqqtDX1zfj8Xi6urq69k1OTg46HI7SFGiSpjyVFVBVVaCUQjwej2OMOcaYboyUIc3wtq7rwBhLg964cSPa1tZ2oa2tbW/Ko4U2m21zZthkgmqaBr29vY89Hk9XZ2fnR8Fg8Ben01lmNpsLGGNAsnll69at/OHDh101NTV7ysvLayilKiEkH2PMIYSQ2Wy28Dx/PxwOz0uSxDLrq1FTZ2ZmEv39/bf8fv9VURTZzMzM/du3bz/N7I6Mp1GFQqHQUm9v769TU1M/lZeXbx4bG/sNrQZkjEFRURHetm2bXZKkZCKRoBhjZFwmxhgQQpDD4cgLBoPLsViMZWsADBBjvqioCC8sLOjrBbcBCgCQl5cHFosF/ecN50bbttUNB1prUbYeMUva2VDTupGG9Z/YzymnnHLKKafX628VzRN1ScxpEgAAAABJRU5ErkJggg==); }
-/* dewolf — fkie-cad/dewolf assets/logo-dark.svg, rasterised */
 .dlogo-dewolf { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAOAklEQVR42rVYe1AU55Y//ZgXM4zD8BIQ0MXIc1AkZRAFRMUHuMjNloZil1VLS1ajMboxariBBI1CwNqoN+aaorRKLd+57r0+ghYRRFG46O5FRAjKApFhHMEZZqYZenq6++wfoakJvhLv7qnqqunq6e87/fvO+Z3fOQS8wgiCAESE6OhoRW5u7pzi4uIr0jMfHx9ixowZfjNnzpwWExPzTnh4+FRvb+9gAACHw9H3008/tbS2tt5ubGxsbmpqGhgYGBCldymKAlEUARHhdUa86iFFUSAIAqxZsybm22+/bc3Ly/sHq9XKrFu3bn1qauoHPj4++sHBQWdvb2+T2WxuGxoasoiiCBqNRhcYGBgZGhr6jk6n09hsNnttbe2+o0ePfnvhwoVet9sNAAAkSYIoivDGRhA/+19VVbVfFEV0Op3Isiy2tbXVfvHFF1mpqak6X19f8mXv6/V6IiUlRbdz587Mtra2G4iI3d3d/7VmzZoYkiRHQXgjx2QyGQAATJ48WW61Wq0Oh8PNcRx2d3c3BwQEPOcUSZK/uF5k6enp+qqqqgpExMbGxlOJiYlq6V0JjN9su3btykJEdDqdaLVahwYHB8179uzJpmkaZDLZSxcnCAIIggCKop5DKTMzM7Czs7MBEbGgoCD+Nzvp5eUFaWlpPjRNw+LFiwOXLVsWlpycrI2NjVUGBwdTer2ekBb8tRdJkkDT9Kiz3t7exJEjR9YhIu7evTvrVzkpIbJu3bqpiIgxMTEK+H8wTyc++eSTVETEL7/88ncvikna80bKrosXL7a6XK5oi8Xi9vf3Jz2zTaKGX0MRL3OOYRiR4zggCAJ2795dx/P8rLKysnqz2Txz7969DRJ7jNKMxHfJyclaRITbt2/bT5w4sW3evHmrWZYVSJKkCIIg/x7UEFHked6l0WhUBw8efL+4uPgKTf+MD8/z8NVXX+Vu2rTp5Ny5c31ramosEiiEZ4w0Nzdft9lsxlmzZuUZDAbVlStX2srLy3Pr6upaZDIZJYoivgliFEWRbrdbrKio+Lqrq+uvH3/88cH+/n5ROgVp//r6+jMBAQGTp06dmsgwDD53StOnT1fHxMQopfvW1tb69PR0/f9V7P3www9/3LZt22wAAAk9KTkAAAwGgwoRsaSkZPEv4lGhUIC3tzcxtop0dHTcyc/Pn+K5yG9FT6fTEWFhYfTGjRsTWJbFxMREtYTY2P0AAL7++usVDMMMBQUFUSNrEFBaWro0Ly/vS4PBEGW325EkSeB5Hj777LOMjRs3Hl+5cuW069evP/FMDpIkQaPRkP7+/orx48drgoKC9MHBweNDQkLCx48fP8nX13eiXq+fqNFofOVyuRoRXTt27Fh67NixDinmxxI9IkJoaCjd2dnpLikpmbdz585rBADA/Pnz/dLS0mYUFRVdRsRRGiAIAoqKiuZv3LjxKMMwzxCRJEmSRkRREAROoVCMQ0SR47ghhmHMAwMDXWazudNsNnf39vZ29/b2mk0m06DZbHb29PS4hoeH4UXOeTopiiJ89913xQaD4R/j4uLehoiICNnL4swD9n+tqan5Y2pqqk96ero+Ly8vwmKxODIzMwMDAgJIlUr1q478dXWXpmkgCAKWLl0ajIg4e/ZsHZ2fnz+nuLj4akhICN3X1yd4cp5HQacfPnz433V1dVYAgICAgEGGYUzNzc0DT58+FaVyRlHUc5XAkzcR8RfJAQAgiuLofoIgACLCjRs3TDabzb5o0aJkOikpKfPOnTt/7uvrEwiC+IX8QcRRwlQqlSoJAa1WS5EkSavVavrndYXRDf5OrgSCIMBiseCDBw+upKSkLKcNBsPvampqDkiIvWwTRETpmSiKQFEUPTQ0xL/99tvqOXPmxLlcLp6iKPIVx0tJX4KIIIqiQFEU8f3339//8ccfXVJsSj48ePDgWk5Ozhd0YGBgeE9PT7tnjZSKtqR8iRHzCGaCZVlbaGio14kTJ+omTZo07XXoDA0NiWq1mhyLllKpTCstLa2jKAp4nh/1oaen50dfX189SVEUOBwO29i4EAQBXC4XiKIIbrebI0nS00FgWZbZunXrlvDw8GlWq9Vpt9s5m83G2mw2Vvo9PDwMAAAcx0Fpaen8p0+fPhUEAURRBJ7nQRRF3uVyuV70QXa73TEqFjy5DQAgJSVFt379+lVut5vfv3//Ea1Wq3O73W4pCTiOQ71ePzkrK+szp9PJKxQKrzEfKMrlctJoNP7twIEDBXa7nenr63um0+kCbt26deTcuXMHFQqFvKSk5AeZTEa/yEFxJBlIRASlUqn0POLMzMzUuXPnbp4zZ8766upqY15e3n6SJClBEIDneZDJZIRKpfLieV4EAPJFwoAkSbG8vHxlYmJiSlZW1vLh4WF3T0/Pre3bt3+4ePHiZUaj8UlFRcU/6XQ6n5doUjUAAG21WgeDg4PDx/6hurp6v1ar9a+trf1TS0vL/5w9e/bRqVOn5I8ePWpbunTpFoVC4cVxnEi+oAbSNE0zDMM6HI6h3NzcCoqioLGxsbq5uflKV1cXU11dfT44ODggJydn/alTpypeREsTJkwIZxiGIzs6Oq5ERUWlSLEn1T8vLy+tSqXSWiwW+9WrV/tzcnImURRFxsfHz+7q6mp4lR4UBIFXq9Vymqapy5cvlzU2Np7t6OjojoyMnB0XF6cvKCgoXbRo0Qq73W6lxrC35ENsbGzaw4cPq8n6+vpzMTExWVqtlpAE60hgu3ie51iWdQEA1NTUWJYtW1aWnZ29vaWlpV6hUIAgCNwr+Iz88MMPvzp+/Pg3dXV1J/Pz81fHxsZmbNiwYfPnn3+++vTp03+YMGFCLM/z/Ng+XKVSwcSJE2c0NDScJhYuXOhfVVX1dN68eb41NTUWRISysrKcqVOnplMURev1+uCWlpZrcrnca0R1sxkZGf/u6+sb+rIjlpxUq9WjgpSmaWAYRlSr1aTEdwAAH3300cy9e/c20DQNHr5CYGAgSZIkQd68eXPgyZMnPbm5ucukYzOZTMb09PT1CQkJy41GYxvLsk6WZe12u70/NDQ0LiAgIJRlWV7KNinjBEHgeJ7neJ7naJqG+/fvX7979+6fWZYVHQ4Hj4jgdDp5o9HYceHChT39/f2dCoVCPrZXWbBggb9Wq6VNJtPPlWHfvn3/PDg4+MzHx4cgCAI0Gg0RFxenjI6Ofq5p2rJlS5LUhnIchyzLotvtRofDIeCIiaKILMsK586d+31ERITs3r171TzPo8vlQpvNZlu7dm1cYWFhSnNz8/dFRUVzpYaNIAjw8vICm802fOTIkQ2jtSEqKkqBiLhjx460sV0XQRBA0/TodfPmzWMMwwy1trZef/DgQX1PT09bS0vLNUEQ8Pz58yVbt25Nvnz5cgXHcYiIuGHDhumXLl0qR0S02+2OrVu3JhsMBtU333zzLyaT6VFhYeGcsQo7KSnJe9KkSTIAAJqiKGhvb3cdO3Zsy/bt2//z8OHDvv39/aJU5jyvkJAQKiYmJvvZs2fGEydOFD1+/LgvLCwsRKfT+Vmt1u7jx49XFhQUvH/o0KF93t7e+uTk5HylUqkQRVEYQYn28/PzN5lMLoVC4S2TyZRSeIzwMZAkCQ0NDY7RqiXVxMLCwgMURdH79+/fOrbFlBCdNm2av4+Pj9bHxyfk4cOH3a2trX2XLl36q16vD7xz507V8uXL8zMyMj7Ozs5+98aNG38aEbcgJZhCoVAuWrTo/SVLlry1atWqg76+viGCIAiSQDh69Ojva2trv1MoFKPSjRRFEUiShMePH/MffPDBO8uXLy8tKCgwSJk3xsEoQRA4b29vL0EQcObMmZGIiEFBQRHBwcER9fX1V+x2u7mhoaF2woQJk0VR5DmO47q6uv7mcDie8jwvsizrUCqVCpfLxQqCwBEEQUiAXLt27S8nT54s4zhuVD8+p3YrKysLEBGzsrLGe04bAAAuX75cMSK78OLFi+W3bt06ceHChTKz2fwEEbG4uDhjxYoVU3bt2rVEEH7OmZaWlmurVq2Kktbt7u5uPX/+fImUUNu3b08JCgqiJEp6TqaN7QmqqqruJiQkeBUXF5+/e/fuofb2dkZyPjU1NUwmk4kkSfokJCQsCA0NNdA0rTabza1ms7kzPj4+IzIyMjYxMXGJ0Wi8bzQa22iaViQlJS1WqVTeLpeLmzhxYsKUKVPSmpqazrW3t199/Pjxw5MnT9612+3Xmpqa+miafvnMUDpKLy8vuHjxYhki4rp16+I9USZJEhITE9WbNm2avmrVqiitVktI2pEgCJDL5aONuPR/iqIgPj5eVVxcPK+6uvoPVVVV/7F58+Z3Vq5cGRUQEEDu2LFj9pQpU+RjGeSlnRUAgFwuh0OHDq1GRDx9+vS2kJAQ6k1kvDQvTElJ0dlsNofVarU9e/bMhojY0NBw9o0HmJKtXr06hmEYh9PpdBUWFqaNHV5KY7UXXWOr4KeffjoPEdFisQwJgoA5OTkh0uDgNw8wPbv/sLAw+vDhwwWIiAzDuCsrK/8tIyPDf9y4ca9dddy4cURGRoZfZWVlQX9/f78oiiiKIt67d69apVKNzg/faIjuOUgHAIiOjlasXbs2+7333tsTFBQUMTAwMHD//v2/tLe33+zt7e1yOp3DgiAIGo1GHRYWFhEZGTkrLi4u28/Pz89kMnUeP378o5qamttnzpzpKCkpWVxeXn7Lc/03NinQPSewCxcu9K+oqHj39u3bpywWiw3HmNVqdTQ0NJypqKh4d8GCBX6ezf2KFSsi33rrLfnr0AMA+F+FfGKwjUIoRgAAAABJRU5ErkJggg==); }
-/* Kuna — maintainer-supplied mark (kuna.png), black art recoloured to --text for the dark UI */
 .dlogo-kuna { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAJx0lEQVR42u1YXWwc1RX+zr0zO7O72bWd2IYE52/J2k5jwBAhQSOVBCoioYrfriuEWrUSghdUKKrUP1TbpK2ESlshykORUKWqVcsuAlVtA6WQNQ1tiRIoRHESz27sxHFCEstr73pnZ2dn5p4+eBdWKE5sSAsPvdK+zN45853v3HPOdw/wGV90KY0xM33EJhMRf6oeptNpmc1mtTq484Ku/y8X23OhpX0SYKlUShFR0HhWKBRaSqXSSmY2iMiNx+MFIioC8JsAy+Z3LjnAOgui8ZGJiYkbhBB3BkHwhdnZ2U1KqVYAGhF5hUKhOD4+PiGlfAvAn/ft27eHiAJmFkSkLvkZbDacz+dv1nX9+wBuiUQiKJfL8DyPhRDEzCAiSCmh6zpCoRA8z4Pv+++5rvuj7u7uF5hZZDIZGhgYCC4Jg+l0WhJRkM1mV2zYsOFJXdcfFEKgXC6XXdeVRMREBKWUSUSklIJSCp7ncaVSUcwsIpHINS0tLZl8Pv8zIvr2R53+2Aym02k5MDAQHDx4MNHS0vJiOBy+plgslpg5REQEQACgRhLUM1fUf80RCIgI8XhcOo7zarVafay3t3c/M9Ni2U5LDeuhQ4c2RaPR1zRNW1+pVBwhhGBmCUCGw2EyDAMAoJSCEAK2baNWqwVCCFH/DjMzACgi8k3TNIQQXqVSuT+ZTP5mseTRlpAQmJiYaAXwF13X19u2XRJCRJiZotGoZGa4rjtaq9X+rpQ6DKAEoIWIvtfR0bF6ZmYGzKwAkKZpZBiGlFJKx3GwevVqvVKpfAXAb0ZGRmjZDDa8Ghsbez4ejw/Mz8/bAEwiong8LmzbfouZfzI5Ofnyjh07/OZ333nnnY729vZnlFK3h0Ihw/d91Gq1OWY+CmBGShnXNG3W9/0fJhKJ9xY7i3QxcPl8/q5YLPZisVicJyKTiEQkEpGu6z6xf//+HzSy8PTp05t93+/1PG8VEXlCiHwQBIcAmEKINcwcikQixy+//PKzl6LVETNjdHRUD4VC74XD4U3ValUxs4zH43J+fv7xZDI5CADj4+NfE0I8YhjGtS0tLRBCwPd92LaNcrk8J6XMKqV+lUgk/lp3XMtkMjw6OspDQ0NUb4fLy+JsNqvt2LHDtyzrnnA4/EKlUikRUSQWi2nlcvlvyWTy1r1797Z1dXX9fs2aNTtPnjxZUUr9i4iOK6WEEGI9EV3b2traxswIggDVanV/tVp9tLe3983ldJPzJsn09HQj5b+haRqISCci6bquz8yPZLNZbd26da+HQqErp6am7q9Wqy/19fUVmm2cOHFiTbFYvFcI8R0hRIcQ4vpIJPJGLpf7JhE90yBh2SFu1KTJycmVjuPkpJRRZkYsFjOKxeKrPT09O8fGxp6LRCI3zczMfL6/v/8cAEDQh9YUA3UXLcu60jCMNBFd57qu39raqs3MzDza29v7i6UwKRZ7VqvV+k3TbFNKBfUSASHE7yzL6hJC3D41NbWtv7//nPXUbgMEWHr7lSe441tTqvPHk7T63n923RCGpqG7u/vYGdu+NQiCfCgUEqVSqRaLxX5+7NixLxJRkE6n5XIZ1IjIHxsbe6itre3pubm5CgBzxYoVolgs9kop72Jmv6en50nrqd1G98O3uWPisq+boF8ajCjXyXSAg0IF96zlcxNEFBw5cmT7ihUr9lSrVd8wDN113fFisXjV1q1bnabusyQGUX9hteu6ICIlhBCO44CIakS00vO89ODgoOh+5DY3r6/eaoB+XWOOzkJ5RSh/llXNZFxdEfTScSKdmcXmzZtHKpXKP6LRqO44jtva2pqIxWL3ERGPjIzI5YS4ATCs6zqYWTAzlFIgojgzH5+enj49NDxMYEAp9aDJgA/2CNABaASEZqG8OESfkpfdQppUzExSyj/pug4hREP5fBUAtm/frpYNkJmrCzoAzMzKNE0wczsRHdk+MqIySNX3IeEBTE22PlAKDOUx9wDcCGE+CAIwM9u2DQD9R48ebScitZjavhCDp33fR72IBqZpQkq5WdO0f4+mUloKmQUDjDPaAibVfLAVQEwQAJ1qcrqZKV/TtJgQYu2FavL5AHId4OG6+jCJCL7vIwiCOzZu3Dh3+PDhD0uDoN8KWigyvCDtAwZqUZBWgjoXVsaraV/JevlaJ6VsRIU0TQOAOABkMpklA1QAUK1W37Vtu6hpmg5A2ratTNPcns/n+1KplMqk02BAJIMzr8yxeqKFhNYKocUg5EqIEIBZSXTvekzOfm5oSBIRK6VuCoIPfBPMDCGEv6w6SEScTqdlX19fgYhGwuEwL8g8xYZhaEqpnxIRJxIJAWYeBEQPn/tuhWhnDfysD/WCA95lM67bFJzdw4OD2pahIW9sbOwKTdN2lstlRURSCCFc1w0AnAOAVCq19OtpXYjCsqwvvf/++2xZlp/L5diyLP/s2bOcz+cfa+xLp9OSFznLBx54QM9ms1rd1vNnzpxhy7KcXC7n5XK5wLKs45ZlGc3ac0m9mIiCwcFBkUwmXx4bG3s3Fov127YdEJEslUpBNBrdNT4+TkS0CwB4cFBYhZWGXiqQF1/JeqlAGzbAp+FhD88+i1wutysWiw3Mz8+7WChFgWEY0nXdPclk0r1Qy1uKHrw5Eom8btu2D0Cr39iC+r3iZaXUcCKR2Hc+GydOnNjCzI+bpnl3uVx26zVVMrMTiUSijuPc2N3d/VbjzvOxFfXRo0ef7uzsfGh6etoTQuiNC1AsFpOO4wDAm0qpvUqpY0KIAEAXEW0jolvC4bBeKpVcIpJEpCmlnEgkEnYc56Xu7u67LwRuKQAJgHj77bdFS0vLK21tbTcXCoUaEYUaIAHIaDSKUCiEelkCEcHzPJTL5YCZPSIKEZFg5rKUMiyEKGmadnVXV9ephe20/E7S1MDV1q1bfd/37yyVSntWrVoVYuaAmVWdFa5UKsHc3JxXKpXcYrFYnZ2drZTLZafex416pyhrmhaWUqpKpZJau3btVCaTueiEQV4so4eHhwFApFIpd9u2bX9ob2/vjEaj10spqVarBU2drdEXNQA6EWkAFDN7APxwOLxCSlm0bfvuLVu2vMbMsq+vL1i2YL1QuBuSaHx8/A4hxK5wOHyVUgqO48D3fa6DZSJq7PdN0wxpmgbXdXeXy+WH+/r68p9Y8i8WbmamTCYjEonEHw8cOLC7s7Pzy8x8HzPfaJrmylBoYdDAzKjVavB9v6iUeqNarT63cePGV5pHKP/VAeZHGTh16lS753ndSqkrAEQAVIjopJTSWrduXaERgaGhIRoeHlb4XyxmpnpNExeb6zQ606c2Am6EvqOjg5pvhvUB56c7Av7/+qyv/wCH+35xzg0c6AAAAABJRU5ErkJggg==); }
-/* Codex — github.com/openai avatar (openai.com), black blossom recoloured to light art for the dark UI */
 .dlogo-codex { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAM1ElEQVR42u1Ye1BT57b/9s4OCRKeIkp4SSGiYQ60ASrVVuotaBrEV7EO6DlqHW91Ot5Wqh3lWupwJ1R6QGdkWhlbnUJBenvo8IrSYDtGXsFiA44CQgDz4JGyEzYJSYDAzrr/uLmRgu2x58/z/ZWZb2V9v/Xa67cWQv8+f+5gf1gQwxAAIIQQCgwMZCUmJoaIRKKNQqEwxc/PL2JgYODHnp4e5Z07d9o6Ozstc3NziCAIhBBCNE0jAEA4jiMcx5HT6UROp/NfaAX2/3YcPnw4XqVS9ZpMJpiamoLR0VHQarVAURRYrVbQarVQXV19TSQSeT1LJ47jT+l9bg8yStzc3FB+fv4HBw8evDg5OYl++umn/J9//rlOpVJ1T0xMTEdHRweLRKL1EonkfHBwcBBJkta8vLwNPB6Pt379+m1+fn7h/f39jQ8fPrzb3t7e+/DhQztCCLFYLETT9PN7j7H0s88+O2a1WkGlUg1u3bqVv5R8aGgou7W19d7AwMAsRVHgcDjAYrEARVFgt9thZmYGHj9+DIWFhf8ZHh7uxrzxXIfFYiGEEJJIJCEURUFzc3NTTEyMB6OUIAjk5uY2L5+YmOhTXFx8SqvVwsjICJSXl188ffp02v79+/+yd+/ete+///7mwsLCo7/88ovObrdDe3t7V2pqathzgcQwDLHZbITjOPr222+/pCgKNm3atAIhhNhs9jx4hBCKjIzkXLhw4ahOp4OpqSlobGxsycjIEC6lOyIiglNSUiIlSRKGh4dh06ZN/v8USFdBoVDoPjY2RldUVFxmsVhPASMIAr333nuvdnV1Gex2O6jV6qkTJ078h4+PD8bcLzSY+T+LxUKXLl06QVEU1NfX1/J4PAzDsN8vHEaBl5cXtnfv3jVff/31ebPZDEePHn2FuScIAqWlpa2urq6+ZrVaQaPRQGFh4bG4uLj5ymWz2QghhPz9/fHNmzf7cziceaMY4B4eHlhtbe11q9UKhw4dErm+/0zPxcfHe9fX11dZLBYYGRkBg8EAu3fvjmDkXn311eXj4+NgMBigrKzs7/Hx8d4LgSGEUHp6uqClpUVpMBigurr6mw0bNvgxdwzglJQUPkmStFwur3d3d0dLepEBt23btrC+vj6KoihoaGj4sa6u7h9msxl27tz5AiMrFouDSJKcuXXrVgPjDTc3t3nFQqHQvbi4+NTY2BiMjY1BX18fUBQFAwMDtFQqzeDz+QQTdg8PD6y5ublDr9dDREQE55m5GBMT46FWqyfHx8fh6tWr57y9vbGcnJw9DocDtm/fvpqR27JlS6DZbIbKysprTHdACCF3d3f08ccf73r06NGk1WqF7u5uMisra4tIJPKUSqV/0+v1YLfbQalUKtPT0wWMQaWlpRd+/fVXOjEx0XfJMHt5eWEymax6YmICioqKPuRyuQghhPLz8w9PT08vBMg3m81QU1NzHSGEuFwuOnz4cLxcLq8dHh4GjUZD5+fnHwoICHjqpfj4eK9Lly59YDQagSRJqKqqurZjx47w0tLSC0ajEV577TX/JQG+8cYbqwwGA7S0tLR5enpiTAjy8vIOLAbQYrHA999/fy0pKWmFTCb7ZmJiAkiSBK1WC0NDQ1BRUXHhpZde8lwsNyUSSUhra2sbk+M9PT1TfX19dFRUFBfDsKdCjLskfhKPx3NWV1fnTk5OAofDmScHi+QrNj09jSIiIiRlZWVjSUlJ+7u6utqPHTsWlZWVJdDpdB1paWkn6urqLAUFBe8GBQURs7Oz81V88+ZN/bZt2zacO3cuhaIovZeXFxcA5nAcx5Z6E929e7dHq9WCUCh0Z75ZCKFFPSgWi4NGRkbg8ePH0NjY2JSZmSlcvnz5vLG+vr74vn37hCqVqt9oNIJKperLyclJ9/HxwReGMCQkhCguLj5NkiQ0NjY2hYaGshetYo1GA52dnQbmIaY6GYA7d+58gfnj1q1b+SaTCRQKRZMrsIUf8qCgIOL27dt39Ho9kCQJCoWiIT09XbAw7BwOB12/fv3SzMwM5OXlvfNUtJgfT/gaZ2GJA4ATAJx2u30aAOYBsNlsZDQa1SaTyUkQBMIwDNE0jWiaRhiGIYIg0PDw8BxFUUMIIefg4OCj6OjolCtXrvSVlpbmCQQCzuzsLCIIAs3MzKDs7OyTarVa+/bbb38eGxvr8RuA/f39P61YscJHIBD4uCYqh8Ph0TSNi8Xi3atWrWLRNI1mZ2fpJx7jMMBccwcA5oGyWCzk6emJS6XSN0+ePPmiWq3ukEgkZ+RyuWHPnj1r5ubmkJubG9JoNI6amprcwMBAbnJy8sbfAJTJZFJPT0+0Y8eO3a6PKRSKGwaDYfzAgQNF9fX16uPHjyf5+Ph4Op1OhOM49qzeyYDHMAzZbLapkpKS+2KxOP6LL77IXLlypU9SUtJ2V9m6uroqs9mMUlNT//s3ABUKRbvRaERpaWnnIiMjOQ6HA7HZbCSTyXRpaWnBP/zwQ2FwcHB4bm6uIjs7+0eLxeKkaRqeAH2qPTEReELtZ56EnMVisRBFUc7m5uY7OI477Xb7JEIIOZ1OBABoYGDAbDQax1evXr3pNwC7urqsDQ0N58LCwoLy8/O/8PLywmZnZxGbzUY9PT1T+/btO3nkyJEXlEplBZ/PD8NxHPf19V0dEhLCZkLMFAkT4oiICI6/v7+A+cQw3ly2bBkXwzAcX5DwTwyaWzIqfn5+uFwuv2E0GqGuru76mjVruAtZDo7j6J133hF1dHT0kiQJDx480J09e3aHv7///GP+/v54bm7uXrVabevv74fR0VEQi8VBzP327dtXT09PQ0FBwTGm4DAMQzExMR46nQ6am5tVS5IFgUDA6e3tnRoaGoLu7u5fz549u9P108MAXblyJUsqlf51aGgIbDYb3Lt3r+vgwYMvZmZmRre1tXVYrVZ49OjRVGdn58jY2NgzATLM5tSpUxKr1Up/8skne5ecPaKiorhqtZru6emx6fV6sNlscPv27YbU1NRQV6LKnISEBO/y8vJ8vV4PWq0WxsfHgaIo+O677y4JhUL3ysrKaxaLBbZs2cJfDCATTm9vb6y1tbVtZGRkvic/lYPM3BsQEMDz8fHBVSrVV++++25YbW3t50KhMKW0tFR75cqVnI0bN/rNzc3NAyRJ0j46OjoIAIggCNTS0vK/x48f/0tGRsZ/dXd3T7HZbO5S7YvFYhEAgJYtW4akUumHMTEx66uqqs4olUrjkkz65Zdf9jEYDHRpaekF5u6tt94SKJVKpc1mg9HRUbh48eLxhIQE79OnT2/XaDRgt9vh/v37uqysrGSmOzBerqysvDYxMUGnpKQEunrQ4XDAp59+esjX1xf/8ssvz1EUBT09PSaBQMB5JpsODw930+l00NTUpGIYLkIIBQQEsHJycnb19vZSFosFNBoNmM1m0Ov1UFBQcDgsLIztOu0xFO7WrVsNFEWBRCIJZt7atWvXCxMTEyCXy+sVCkXb5OQkdHd3G1JSUvhLElaGanO5XFRbW/sdSZK0RCIJZdgyc6Kjo5cVFRW9/+DBA7K8vPzC5s2bVzJ3jByO4+jNN98Mkslk/yBJEjQaDR0XF+fFGLtr164Ig8EwP06UlJRIY2Njeb872TFhzsjIEFqtVpDL5TIPDw9sYQUjhJArSXDleomJib4VFRWfkyQJFEVBVVVV8SuvvOLnGvYjR468bDaboaSk5H9ef/31FYtNk0u2JhzHEY/Hw2pqar6lKAqKioo+dB0V2Ww2cs0zRmlAQAArOzs7dXBwkLZarXDv3r2+zMxMIXPP9GWG4o+NjdHMd9ZVzx/eJiQmJvrqdDowmUxw9erVc5GRkYsmL0EQ6NChQy/evXv3/vT0NAwODkJeXt7+0NBQtqtOxqgNGzYspygKKioqLjOs559eHjF9NDk5OTA3N7cuJiYmbmBgYKypqem8TqfrMxgMQwRBsPl8fmhCQkL6+vXrM6xWq+PGjRsflpWVfdPe3m5mcpJZtTmdThQbG8u7fPlyfUhISPyePXv4bW1t1HMvjxiX8/l84uLFi8e0Wi3Y7XaYnp4Gs9kMNpsNHA4HmEwm6O/vn1EqlT9HRUVxl9InFouDOzo6NFNTU3DmzJmdvzuk/5H1m6t169atc4+Li4tcu3ZtTGhoaNz4+PhgZ2dnC47j+EcffaRYtWoVb3R01CGTyd7r6OhQqtXqIT8/P55QKFwrEom2paSkfMDlctFXX3117OzZs8Wzs7PzLOZPLy9/b1+ybt069/Pnzx9Qq9U2q9UKk5OTMDIyAiaTCex2O1AUBTdv3vw+NTU1ZLGl6L9kBcwM6ACAnE7nfMUz1IoBmpycHL9mzRpRUFBQ/MTEhGZwcFDV0dHRrlAohm02GzDA/rTn/n3+4Pk/Qzen6kK0xQwAAAAASUVORK5CYII=); }
-/* Claude Code — github.com/anthropics avatar (anthropic.com), logomark recoloured to light art for the dark UI */
 .dlogo-claude-code { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAGJUlEQVR42u2XXWwTVxbH7z0zcz3jrxk7X42oCVGy6cqEDWAQIqjZECvIJnKLtPuwbVe7LeKhWq2IKtQ+tm+LeIEKNS9VpZIKpIoSqVohKwoiEojmwaAGR21ThUg4IhAZLDuxxzOTmbn37guu+gEkLoXtQ87Tna87P517/uf+L0Ib8XSBa4O2tjbp9wS2sLDgIIQQ/N4zuAG4Afj/DvGpWgDGP7nmnD/y2Y/vPzdAjDGilHLGGMIYI4wxAgBcA3Jdl2OMEecciaKInzsgpRR5vV6REAI1IMMwXIwxkiQJq6pKGGMcAJCu6y6llP88488EEGOMXNflmqZ5RkZGLodCoRcZY8iyrNLRo0dfXlhYqDQ0NJDTp0+Ph8PhdlmW4dy5c8MjIyNjqqqKlFL+TEUCANgwDNbX17cjGo3uURRlk8/n29TZ2dk9MDDwMqWUP3jwYHV6evrz1tbWTbIstyYSiffD4bDkOE7dWawbkDHGZVmGRCJx1DRN5rquQSm1dF1ng4ODx4LBoIgxxul0eqxcLtvVatXesmVLd29v7x8Nw6C1On0mgLXsbdu2raW7u/svhmEgWZa9hBDZNE3W1dX15x07drRxzvns7GxhZmbmgs/nEymlKJFIvC2KIq5X0fBrlJtKpV6TZRkIIWhubm58fn5+wuPxAACgVCp1RBAEbNs2u3jx4klJkqBarbq7d+9+MxqNNtabRagHbnV1lUUiEW9fX9+7lUrF9fv9cP78+ffHxsY+CAQCUKlU7L179/67o6NDBQA8NTX1bS6X+0YURfD5fHIymXy13jqEepbXNE22f//+PU1NTc0IIcjn84VMJvNdJpP55v79+8sIIVBV1RuPx+OMMV4sFu3r169/4vP5QNd11t/ff6ylpcVj2zZbLyTU0fe4z+eDAwcOvGNZFvP7/ZDJZD4uFApWPp+3bty48UkwGBSr1SqLx+PHNE2TGGNocnLyv47jINd17Ugk0rVv375tpmmy9S4z1CEOun379k3RaHTIsiyXc47S6fSn5XKZVSoVeuHChY8cx2Grq6tuR0fHnl27dnUghFA2m12cnZ0dVxRFdl0XJZPJfxFCMGPst8sgxhgxxlAikfgbIQQBAJRKpWVN07SDBw/+IZlMdqmqGiwUCnclSRIxxiiZTB6WJAnruk4nJiZOyrKMdF23e3p63ohGo42maa5LLGtafowxchyHNzU1yaOjo3OBQKDVtm2Xc84URSG1WuKcI8uybIwxAABQSo3Dhw+33bp1a3nz5s3+M2fO3CKEhFVVFUdHR4+cOHHiU03THruzrNvy18TR39+/u6WlpdWyLJsQIgaDQSIIAgIABABIEAQUCASIJEmi4zhuKBTyx+Pxfs45WlxcrF67du10IBAQH4rlvebmZs96FC3UBpqmCY96oeZGhoeHP2xsbHyJc86Xl5fvZLPZL5aWlmYWFxdv3r179+a9e/du3r59O+PxeIJ+vz9MKUXhcLh9YmLiM9M0qeM4i4lEYtiyrNXm5uaW+fn5L2dmZu4piiI8qnmvrKywNc0CAGBd193e3t62rVu3Dum6boVCIfnUqVN/P3v27FfBYFCoFTsAoHK5TA8dOvSn48eP31xZWTE6Ozv3xGKx9suXL89NT0/fyWazX3Z3d79i2zYbGhp6J51O/5Mxxp9KJJxzlEql3pJlGWRZlpeWlu5cuXLla1VVBUmSgBCCCSFYkiTQNE2cmpr6PpfLzSiK4hUEAQ0MDPwVAHC1WqXj4+MnFUUBy7JYLBZ7vaen54W1dhZYa+dob28P7Ny58x+FQmFZEARjcnLyRD6ftyRJAsYY55wjzjlijHFRFHGpVHIuXbr0HwAwSqVSORaLvRmJRHyCIOCrV69+ncvlvuecGwghfXBwMLVWu3miihljyOv1CuFwWKGUcgBAxWLRsiyLAsAjrTznHBFCoLGxUWGMIQDAxWLRtCyLcs5RQ0ODR5Zl8aHJZYVCwXySitdsM4wx5LouwxjjmmAAYM2yqCmUc85FUQQA+KFl1bJWc99PAhTX0WaQx+OBxx2OHlceHo+n9uMfLBbn/BdAa821Lsv/a05lj/vmmfrBjYP7BuAG4AbgRjz/+B9CoyRKNwvZjAAAAABJRU5ErkJggg==); }
 
 
 /* ==========================================================================
-   Mobile: stack the wide results tables into per-row cards  (<= 700px)
-
-   On desktop the leaderboard / metrics / distance / compiles tables are wide
-   grids — one decompiler per row, ASCII-bar cells across. On a phone that runs
-   hundreds of px off the right edge, so below this breakpoint each row becomes
-   a self-contained dashed CARD:
-
-     - thead is hidden (column-sort is a header-click, so sorting is unavailable
-       on phones — accepted; rows keep their current sort order);
-     - the rank (leaderboard) + decompiler name form the card's header line;
-     - every other cell becomes a "label ....... value" row, the label taken from
-       the <td data-label> app.js stamps with the column's header text.
-
-   Only these four #ids are affected — the desktop rendering above and the 820px
-   sidebar-collapse block are untouched. The About page's two plain tables get a
-   lighter horizontal-scroll treatment further down. */
+   Mobile (<= 700px): stack the wide results tables into per-row cards.
+   ========================================================================== */
 @media (max-width: 700px) {
-  /* table / tbody / rows / cells all go block-level for the four bar tables. */
   #leaderboard-table, #leaderboard-table > tbody,
   #metrics-perfect-table, #metrics-perfect-table > tbody,
   #distance-table, #distance-table > tbody,
   #compile-table, #compile-table > tbody { display: block; width: 100%; }
 
-  /* Hide the header row (labels move onto each cell via data-label). Visually
-     hidden rather than display:none so the markup/contract is unchanged. */
   #leaderboard-table > thead, #metrics-perfect-table > thead,
   #distance-table > thead, #compile-table > thead {
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
     overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
   }
 
-  /* Each data row -> a dashed card. */
   #leaderboard-table > tbody > tr, #metrics-perfect-table > tbody > tr,
   #distance-table > tbody > tr, #compile-table > tbody > tr {
     display: block;
@@ -696,7 +604,6 @@ pre.viz-code code {
     margin: 0.7rem 0;
     padding: 0.45rem 0.7rem 0.55rem;
   }
-  /* Kill the desktop last-row border rule; the card border owns the frame now. */
   #leaderboard-table > tbody > tr:last-child > td,
   #metrics-perfect-table > tbody > tr:last-child > td,
   #distance-table > tbody > tr:last-child > td,
@@ -721,10 +628,8 @@ pre.viz-code code {
     column-gap: 0.45rem; row-gap: 0.05rem;
     padding: 0.3rem 0; white-space: normal;
     border-top: dashed 1px rgba(var(--line-rgb), 0.16);
-    border-bottom: none; border-left: none;   /* neutralize col-overall's left rule */
+    border-bottom: none; border-left: none;
   }
-  /* The label column: a fixed-width muted stub so every value (and its ASCII
-     bar) starts at the same x down the card. */
   #leaderboard-table td[data-label]::before, #metrics-perfect-table td[data-label]::before,
   #distance-table td[data-label]::before, #compile-table td[data-label]::before {
     content: attr(data-label);
@@ -732,31 +637,21 @@ pre.viz-code code {
     color: var(--text-muted); font-size: 0.82em; letter-spacing: 0.01em;
     white-space: nowrap;
   }
-  /* Distance labels are longer ("Recompile dist") — widen their stub to keep the
-     numbers aligned. */
   #distance-table td[data-label]::before { min-width: 8.9em; }
 
-  /* Nothing inside a card may force the page wider than the phone: counts wrap
-     under their bar, long tokens break, and any residual pixel is clipped at the
-     body rather than shifting the whole layout sideways. */
   #leaderboard-table td[data-label] .cell-count, #metrics-perfect-table td[data-label] .cell-count,
   #distance-table td[data-label] .cell-count, #compile-table td[data-label] .cell-count {
     white-space: normal; overflow-wrap: anywhere;
   }
   html, body { overflow-x: hidden; }
 
-  /* The counts hug the right edge (so the column reads as "label  bar %  count"),
-     and drop to their own line rather than overflow on a very narrow card. */
   #leaderboard-table td[data-label] .cell-count,
   #metrics-perfect-table td[data-label] .cell-count,
   #distance-table td[data-label] .cell-count,
   #compile-table td[data-label] .cell-count { margin-left: auto; white-space: nowrap; }
-  /* Keep the ASCII bar unbroken. */
   #leaderboard-table td[data-label] .bar-ascii, #metrics-perfect-table td[data-label] .bar-ascii,
   #compile-table td[data-label] .bar-ascii { white-space: pre; }
 
-  /* (The desktop leaderboard's top-align padding shims — lines ~240 — are
-     overridden by the td[data-label] and td.lb-rank padding rules above.) */
 
   /* ---- About page: two plain tables -> horizontal scroll, no page overflow -- */
   #dataset-projects, #joern-output-table {
@@ -764,40 +659,26 @@ pre.viz-code code {
     -webkit-overflow-scrolling: touch;
   }
 
-  /* ---- About page: metric-viz SVGs.  Their inline style is max-width:100% only
-     (no `width`), and a percentage max-width is ignored while the browser sizes
-     the flex column by min-content — so the 360/720-unit viewBoxes propagate a
-     ~500px min-content up and widen the whole page. Pin an explicit width:100%
-     (mobile only; desktop keeps its natural sizing) to kill that. ------------- */
+  /* ---- About page: metric-viz SVGs. A percentage max-width is ignored while the
+     browser sizes the flex column by min-content, so the viewBox propagates a
+     ~500px min-content up and widens the page; pin width:100% to kill that. ---- */
   .metric-viz svg { width: 100%; height: auto; }
-  /* Legend entries are white-space:nowrap; one ("≈ matches after normalizing a
-     link-time-dependent operand") is wider than a phone — let them wrap. */
   .viz-legend .pass { white-space: normal; }
 
   /* ---- View page: the form controls. The function <select> is as wide as its
-     longest option ("proj/opt/bin :: fn"), which drags the layout off-screen;
-     let the controls shrink (min-width:0) and give the two wide ones their own
-     full-width row. ----------------------------------------------------------- */
+     longest option, so let the controls shrink and give the wide ones a row. ---- */
   .controls { gap: 0.5rem 0.6rem; }
   .controls select, .controls input[type=text] { min-width: 0; max-width: 100%; }
   #view-select { flex: 1 1 100%; }
   #view-filter { flex: 1 1 12rem; }
 
-  /* ---- View page: stack source / decompiler code panels (inline style forces
-     2 cols; !important is the minimal way to override it on a phone). ---------- */
+  /* ---- View page: stack the code panels. !important is the minimal way to
+     override the inline 2-column style on a phone. ---- */
   .cmp-grid { grid-template-columns: 1fr !important; }
 }
 
 /* ==========================================================================
    Tablet / small-laptop band: horizontal-scroll the wide results tables.
-
-   Between the stacked-card phone layout (<=700px, above) and the width where
-   the ~1230px-wide desktop tables actually fit their column (roughly a >=1500px
-   viewport, sidebar included), the tables are wider than .main and — because
-   .main is width:100% with visible overflow — they push the whole PAGE sideways.
-   Let each scroll INSIDE its own box instead (display:block + overflow-x:auto),
-   so the body never scrolls horizontally at any width. Bounded to <=1499px so the
-   >=1500px desktop keeps its untouched display:table rendering (pixel-identical).
    ========================================================================== */
 @media (min-width: 701px) and (max-width: 1499px) {
   #leaderboard-table, #distance-table, #compile-table,

--- a/decbench/rendering/assets/app.js
+++ b/decbench/rendering/assets/app.js
@@ -28,22 +28,15 @@
 /* ============================================================================
  * Self-contained syntax highlighter — no third-party code, no CDN.
  *
- * An IIFE that exposes three globals on `window` (this file is a classic
- * script, so they are reachable as bare names below):
+ * An IIFE exposing three globals on `window` (this is a classic script, so they
+ * are reachable as bare names below):
  *   hlC(code)                    -> HTML string  (C / decompiler pseudo-C)
  *   hlAsm(text)                  -> HTML string  (x86-64 Intel + basic ARM)
  *   applyStaticHighlights(root)  -> highlight every <pre data-lang="c|asm">
- *                                   under `root` by reading its textContent.
  *
- * Token span classes (styled in app.css): tok-kw tok-type tok-str tok-num
- * tok-com tok-pp tok-call tok-mn tok-reg tok-imm tok-lbl.
- *
- * The tokenizers escape every token's text and clamp unterminated strings /
- * comments to EOL/EOF, so output is always well-formed even on adversarial
- * input (< > & " '). init() drives applyStaticHighlights(document) (there is no
- * DOMContentLoaded auto-init here — see the source viz/hl.js), so the about
- * page's server-rendered <pre data-lang> blocks are highlighted in both the
- * split and inline delivery modes.
+ * Token span classes are styled in app.css (tok-kw, tok-type, ...). The
+ * tokenizers escape every token and clamp unterminated strings/comments to
+ * EOL/EOF, so the output is well-formed on adversarial input.
  * ==========================================================================*/
 (function (global) {
   "use strict";
@@ -58,7 +51,6 @@
     return '<span class="' + cls + '">' + esc(text) + "</span>";
   }
 
-  // ---- C keyword / type vocabularies -------------------------------------
   var C_KEYWORDS = new Set([
     "if", "else", "for", "while", "do", "switch", "case", "default", "break",
     "continue", "return", "goto", "sizeof", "typedef", "struct", "union",
@@ -69,13 +61,11 @@
     "__volatile__", "__extension__", "true", "false", "NULL"
   ]);
   var C_TYPES = new Set([
-    // real C types
     "void", "char", "short", "int", "long", "float", "double", "bool",
     "size_t", "ssize_t", "ptrdiff_t", "wchar_t", "va_list", "FILE", "off_t",
     "int8_t", "int16_t", "int32_t", "int64_t",
     "uint8_t", "uint16_t", "uint32_t", "uint64_t",
     "intptr_t", "uintptr_t",
-    // decompiler pseudo-types (Ghidra / IDA / angr / binja flavours)
     "undefined", "undefined1", "undefined2", "undefined4", "undefined8",
     "uint", "ulong", "ushort", "uchar", "byte", "word", "dword", "qword",
     "code", "__int8", "__int16", "__int32", "__int64", "__uint64",
@@ -96,19 +86,15 @@
   }
   function isSpaceNoNL(c) { return c === " " || c === "\t" || c === "\r"; }
 
-  // -------------------------------------------------------------------------
-  //  C / pseudo-C
-  // -------------------------------------------------------------------------
   function hlC(code) {
     code = String(code == null ? "" : code);
     var out = "", plain = "", i = 0, n = code.length;
-    var atLineStart = true;            // only whitespace seen since last '\n'
+    var atLineStart = true;
     function flush() { if (plain) { out += esc(plain); plain = ""; } }
 
     while (i < n) {
       var c = code[i];
 
-      // preprocessor line: '#' as the first non-space token on a line
       if (c === "#" && atLineStart) {
         flush();
         var j = i;
@@ -119,21 +105,18 @@
         out += span("tok-pp", code.slice(i, j));
         i = j; atLineStart = true; continue;
       }
-      // line comment
       if (c === "/" && code[i + 1] === "/") {
         flush();
         var k = code.indexOf("\n", i); if (k < 0) k = n;
         out += span("tok-com", code.slice(i, k));
         i = k; continue;
       }
-      // block comment
       if (c === "/" && code[i + 1] === "*") {
         flush();
         var e = code.indexOf("*/", i + 2); e = (e < 0) ? n : e + 2;
         out += span("tok-com", code.slice(i, e));
         i = e; atLineStart = false; continue;
       }
-      // string / char literal
       if (c === '"' || c === "'") {
         flush();
         var q = c, p = i + 1;
@@ -142,11 +125,10 @@
           if (code[p] === q || code[p] === "\n") break;
           p++;
         }
-        if (code[p] === q) p++;        // include closing quote when present
+        if (code[p] === q) p++;
         out += span("tok-str", code.slice(i, p));
         i = p; atLineStart = false; continue;
       }
-      // number (hex / decimal / float, with suffixes)
       if (isDigit(c) || (c === "." && isDigit(code[i + 1]))) {
         flush();
         var s = i;
@@ -164,7 +146,6 @@
         out += span("tok-num", code.slice(s, i));
         atLineStart = false; continue;
       }
-      // identifier / keyword / type / call
       if (isIdentStart(c)) {
         flush();
         var a = i; i++;
@@ -179,7 +160,6 @@
         }
         atLineStart = false; continue;
       }
-      // plain char (operators, punctuation, whitespace)
       if (c === "\n") { plain += c; atLineStart = true; i++; continue; }
       if (!isSpaceNoNL(c)) atLineStart = false;
       plain += c; i++;
@@ -188,28 +168,25 @@
     return out;
   }
 
-  // -------------------------------------------------------------------------
-  //  Assembly (x86-64 Intel-syntax + basic ARM)
-  // -------------------------------------------------------------------------
   var X86_REGS = new Set([
     "rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rbp", "rsp", "rip",
     "eax", "ebx", "ecx", "edx", "esi", "edi", "ebp", "esp",
     "ax", "bx", "cx", "dx", "si", "di", "bp", "sp",
     "al", "bl", "cl", "dl", "ah", "bh", "ch", "dh",
     "sil", "dil", "bpl", "spl",
-    "lr", "pc", "fp", "ip", "sb", "sl", "xzr", "wzr"   // ARM aliases
+    "lr", "pc", "fp", "ip", "sb", "sl", "xzr", "wzr"
   ]);
   function isReg(w) {
     var r = w.toLowerCase();
     if (X86_REGS.has(r)) return true;
-    if (/^r\d{1,2}[dwb]?$/.test(r)) return true;         // r0..r15, r8d/r9w/..
-    if (/^[xw]([0-9]|[12][0-9]|3[01])$/.test(r)) return true; // ARM x0..x31/w0..
-    if (/^(xmm|ymm|zmm)\d{1,2}$/.test(r)) return true;   // SIMD
-    if (/^[dsq]([0-9]|[12][0-9]|3[01])$/.test(r)) return true; // ARM d/s/q regs
+    if (/^r\d{1,2}[dwb]?$/.test(r)) return true;
+    if (/^[xw]([0-9]|[12][0-9]|3[01])$/.test(r)) return true;
+    if (/^(xmm|ymm|zmm)\d{1,2}$/.test(r)) return true;
+    if (/^[dsq]([0-9]|[12][0-9]|3[01])$/.test(r)) return true;
     return false;
   }
 
-  function readNumTail(line, s) {          // s points just past the # / $ prefix
+  function readNumTail(line, s) {
     var n = line.length;
     if (line[s] === "+" || line[s] === "-") s++;
     if (line[s] === "0" && (line[s + 1] === "x" || line[s + 1] === "X")) {
@@ -222,11 +199,9 @@
 
   function hlAsmLine(line) {
     var n = line.length, i = 0, out = "";
-    // leading whitespace
     var ws = 0; while (ws < n && (line[ws] === " " || line[ws] === "\t")) ws++;
     if (ws) { out += esc(line.slice(0, ws)); i = ws; }
 
-    // leading label:  name:  /  .Lxx:  /  hexaddr:
     var lm = /^([.\w$@]+):/.exec(line.slice(i));
     if (lm) {
       out += span("tok-lbl", lm[0]);
@@ -239,28 +214,24 @@
     var mnemSeen = false;
     while (i < n) {
       var c = line[i];
-      // comments
       if (c === ";" || c === "@") { out += span("tok-com", line.slice(i)); break; }
       if (c === "/" && line[i + 1] === "/") { out += span("tok-com", line.slice(i)); break; }
       if (c === "#") {
         var d = line[i + 1];
-        if (d === "-" || d === "+" || (d >= "0" && d <= "9")) {   // #imm
+        if (d === "-" || d === "+" || (d >= "0" && d <= "9")) {
           var s = readNumTail(line, i + 1);
           out += span("tok-imm", line.slice(i, s)); i = s; continue;
         }
-        out += span("tok-com", line.slice(i)); break;            // '# comment'
+        out += span("tok-com", line.slice(i)); break;
       }
-      // whitespace
       if (c === " " || c === "\t") {
         var a = i; while (i < n && (line[i] === " " || line[i] === "\t")) i++;
         out += esc(line.slice(a, i)); continue;
       }
-      // AT&T immediate  $imm
       if (c === "$") {
         var s2 = readNumTail(line, i + 1);
         out += span("tok-imm", line.slice(i, s2)); i = s2; continue;
       }
-      // bare number / hex
       if (isDigit(c)) {
         var s3 = i;
         if (c === "0" && (line[i + 1] === "x" || line[i + 1] === "X")) {
@@ -270,7 +241,6 @@
         }
         out += span("tok-imm", line.slice(s3, i)); continue;
       }
-      // word: mnemonic / directive / register / symbol
       if ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c === ".") {
         var wstart = i; i++;
         while (i < n && /[\w.$]/.test(line[i])) i++;
@@ -285,7 +255,6 @@
         }
         continue;
       }
-      // any other char (brackets, commas, +, -, *, :, !, etc.)
       out += esc(c); i++;
     }
     return out;
@@ -296,16 +265,13 @@
     return text.split("\n").map(hlAsmLine).join("\n");
   }
 
-  // -------------------------------------------------------------------------
-  //  Static application to <pre data-lang="c|asm"> blocks
-  // -------------------------------------------------------------------------
   function applyStaticHighlights(root) {
     root = root || (typeof document !== "undefined" ? document : null);
     if (!root) return;
     var pres = root.querySelectorAll("pre[data-lang]");
     for (var i = 0; i < pres.length; i++) {
       var pre = pres[i];
-      if (pre.getAttribute("data-hl") === "1") continue;   // idempotent
+      if (pre.getAttribute("data-hl") === "1") continue;
       var lang = (pre.getAttribute("data-lang") || "").toLowerCase();
       var target = pre.querySelector("code") || pre;
       var text = target.textContent;
@@ -320,24 +286,17 @@
 })(typeof window !== "undefined" ? window
   : (typeof globalThis !== "undefined" ? globalThis : this));
 
-// The inline payload, or null in split mode. Set before this script runs.
 const INLINE = (typeof window !== "undefined" && window.__DECBENCH_INLINE__) || null;
 
-// Split-mode routing root: the relative hop from THIS page to the site root,
-// stamped by the renderer (html.py::linked_assets) before this script — "" on the
-// root index, "../" on a `<view>/index.html` subpage. It is a string only in split
-// mode; null in the single-file/inline report, which keeps pure hash routing.
 const ROOT = (typeof window !== "undefined" && typeof window.__DECBENCH_ROOT__ === "string")
     ? window.__DECBENCH_ROOT__ : null;
 
-// Query params from the URL the page FIRST loaded with, read once before any
-// replaceState rewrites location: dataset/norm, and on the view page tier/dec/
-// metric/fn. Unknown values are ignored where they are applied, never here.
 const INIT_PARAMS = (function () {
     try { return new URLSearchParams(location.search); } catch (e) { return new URLSearchParams(); }
 })();
 
-// The directory of the SITE ROOT (e.g. "/decbench/"), resolved once from the page
+// Cached deliberately: pushState later moves location without moving the root,
+// so recomputing from a post-navigation URL would lie.
 // that first loaded plus the stamped hop. Cached deliberately: pushState later moves
 // location without moving the root, so recomputing from a post-navigation URL lies.
 let _basePath = null;
@@ -348,7 +307,7 @@ function basePath() {
     }
     return _basePath;
 }
-// Resolve NOW, before any pushState moves location: a later first call would
+// Resolve NOW, before any pushState moves location.
 // compute the root from wherever the user has since navigated.
 if (ROOT !== null) basePath();
 
@@ -361,9 +320,6 @@ const state = {
     normalize: false
 };
 
-// ---- Data loading ----
-// One promise per payload, cached: a view is never fetched twice, and a failure
-// stays failed rather than re-storming the network on every navigation.
 const _payloads = {};
 function loadData(name) {
     if (_payloads[name]) return _payloads[name];
@@ -374,6 +330,7 @@ function loadData(name) {
             : Promise.reject(new Error("inline payload '" + name + "' is missing"));
     } else {
         // Anchored to the site root, not the document: a relative "data/..." would
+// re-resolve after pushState, and the first cached rejection would then stick.
         // re-resolve against whatever path pushState/replaceState moved us to, and
         // the first cached rejection would stick for the whole session.
         const prefix = ROOT !== null ? basePath() : "";
@@ -386,9 +343,6 @@ function loadData(name) {
     return p;
 }
 
-// ---- Metric presentation (from the registry in aggregates.json) ----
-// Names and column order used to be hardcoded here AND in html.py; both now read
-// decbench/rendering/content/metrics.toml, which ships into aggregates.json.
 let _metricSpecs = null;
 function metricSpecs() {
     if (_metricSpecs) return _metricSpecs;
@@ -404,8 +358,6 @@ function metricSpecs() {
 function metricList() { return (AGG && AGG.metrics) || []; }
 function metricShort(m) { const s = metricSpecs()[m]; return (s && s.short_name) || m; }
 function metricName(m) { const s = metricSpecs()[m]; return (s && s.display_name) || m; }
-// Registry order (structure -> types -> recompile); unregistered metrics keep
-// their given order and are appended. Mirrors Content.ordered_metrics().
 function orderedMetrics() {
     const specs = metricSpecs(), ms = metricList();
     const known = ms.filter(m => m in specs).sort((a, b) => specs[a].order - specs[b].order);
@@ -414,6 +366,8 @@ function orderedMetrics() {
 }
 
 // ---- Decompiler presentation (from the registry in aggregates.json) ----
+// SHOW_LOGOS is the single switch for the leaderboard logos; flip it to false to
+// disable them everywhere with no other edit.
 // Official names / links / prettified versions replace raw ids on screen. Tolerant
 // the same way metricSpecs is: a missing registry (older payload) or an unknown id
 // (r2dec/dewolf data landing before its entry) falls back to the raw id, unlinked.
@@ -430,8 +384,6 @@ function decRegistry() { return (AGG && AGG.decompiler_registry) || {}; }
 function decRegEntry(id) {
     const reg = decRegistry();
     if (reg[id]) return reg[id];
-    // Base-name fallback: a versioned id ("ghidra@12.1") resolves to its base
-    // ("ghidra") entry when the registry has no exact match for it.
     const base = baseName(id);
     if (reg[base]) return reg[base];
     for (const k in reg) if (baseName(k) === base) return reg[k];
@@ -445,21 +397,10 @@ function decVersion(id) {
     if (e && e.version) return e.version;
     return (AGG && AGG.decompiler_versions && AGG.decompiler_versions[id]) || null;
 }
-// Tooltip: pretty name + pretty version (was the raw id + raw version).
 function decTip(id) {
     const v = decVersion(id);
     return v ? (decName(id) + " — version " + v) : decName(id);
 }
-// A decompiler as a table cell: linked when the registry carries a url (opens in a
-// new tab; styled to keep the terminal look — see .lb-name a).
-//
-// Two forms, one source of truth (name/url/version/logo):
-//   compact (default)  `[logo] name <span.ver>vX</span>` on one line — the metrics
-//                      table, the distance table and the compile table.
-//   stacked ({stacked:true})  a two-line block for the LEADERBOARD: logo-prefixed
-//                      name, then the version on its own line.
-// The version keeps the same rule in both: a "v" prefix only in front of a digit
-// ("v9.2" reads right, "vr2 6.0.8" does not).
 function decNameHtml(id, options) {
     options = options || {};
     const name = escapeHtml(decName(id)), url = decUrl(id), v = decVersion(id);
@@ -479,7 +420,10 @@ function decNameHtml(id, options) {
     return html + '</span>';
 }
 
-// ---- Combo lookup (replaces the old client-side recompute) ----
+// ---- Combo lookup ----
+// A run with no dataset presets has none to select, so the builder emits one
+// synthetic all-functions combo under this reserved name (aggregate.py's
+// ALL_PRESET). Without the fallback every view here shows an error banner.
 // A run with no dataset presets has no preset to select, so state.dataset stays null.
 // The builder emits one synthetic all-functions combo under this reserved name for
 // exactly that case (aggregate.py's ALL_PRESET); selecting it renders the full corpus
@@ -493,12 +437,12 @@ function currentCombo() {
 }
 function totalFunctions() { return (AGG && AGG.totals && AGG.totals.functions) || 0; }
 
-// Aggregates ship [numerator, denominator] pairs rather than percentages: the UI
-// shows the raw counts next to the bar, so the pair is what it needs.
 function pairOf(map, key) { const c = map && map[key]; return c || [0, 0]; }
 function metricCell(result, d, m) { return pairOf((result.per_metric || {})[d], m); }
 
-// Decompilers to render as rows for the CURRENT preset. Backends in
+// Decompilers to render as rows for the CURRENT preset. AGG.sample_set_only
+// backends ran on the sample-set slice only, so they render there and, on the
+// data page, below a partial-coverage break (splitDecs) — never elsewhere.
 // AGG.sample_set_only (the LLM/coding-agent ones — codex/claude-code) ran on the
 // sample-set slice only, so their rows are shown ONLY when the sample-set preset is
 // selected; on every other view they are omitted (their data still ships, it is
@@ -514,11 +458,6 @@ function visibleDecs() {
     if (preset === SAMPLE_SET_PRESET) return all;
     return all.filter(d => sso.indexOf(d) < 0);
 }
-// The same rows split into {main, subset} for the data page's tables: off the
-// sample-set preset the sample-set-only backends are NOT hidden there (unlike the
-// leaderboard) — they render below a dashed break, muted, because their numbers
-// cover only the part of the selected dataset that overlaps the sample-set slice.
-// On the sample-set preset itself they are first-class rows (subset is empty).
 function splitDecs() {
     const all = ((AGG && AGG.decompilers) || []).slice();
     const sso = (AGG && AGG.sample_set_only) || [];
@@ -529,9 +468,6 @@ function splitDecs() {
         subset: all.filter(d => sso.indexOf(d) >= 0),
     };
 }
-// The dashed break labeling the sample-set-only rows, and the note shown with it
-// (the note's text lives in content/data.md; it ships hidden and is revealed
-// only when subset rows are actually rendered).
 function subsetBreakRow(colspan) {
     return '<tr class="subset-break"><td colspan="' + colspan +
         '">&mdash; sample-set only &mdash;</td></tr>';
@@ -542,13 +478,8 @@ function toggleSubsetNote(id, on) {
 }
 function overallCell(result, d) { return pairOf(result.overall, d); }
 function errorCell(result, d) { return pairOf(result.errors, d); }
-// Compiles: share of a decompiler's byte_match-measured functions whose output
-// actually recompiled (the compilability-fixup pass built it). Denominator is
-// per-decompiler (functions where byte_match was measurable), so ARM/PE
-// abstentions never enter it — see aggregate.py `compile`.
 function compileCell(result, d) { return pairOf(result.compile, d); }
 
-// ---- Formatting ----
 function pctClass(p) { return p >= 50 ? "high" : (p >= 20 ? "mid" : "low"); }
 function asciiBar(pct, width) {
     width = width || 12;
@@ -563,15 +494,12 @@ function escapeHtml(s) {
 }
 function pct(cell) { return cell && cell[1] > 0 ? (cell[0] / cell[1]) * 100 : 0; }
 
-// Read a theme color from CSS (app.css :root owns the palette).
 function cssVar(name, fallback) {
     const v = getComputedStyle(document.documentElement).getPropertyValue(name);
     return (v && v.trim()) || fallback;
 }
 
-// ---- Loading / error states ----
 function setLoading(el) { if (el) el.innerHTML = '<p class="view-desc">Loading&hellip;</p>'; }
-// A failed payload must say so where the reader is looking — never a blank view.
 function showBanner(viewId, msg) {
     const sec = document.getElementById("view-" + viewId);
     if (!sec) return;
@@ -584,18 +512,13 @@ function showBanner(viewId, msg) {
     b.textContent = "[ error ] " + msg;
 }
 
-// ---- Leaderboard (swebench-style sortable table) ----
 function cellPctHtml(cell) {
     const p = pct(cell);
     return '<span class="bar-ascii">' + asciiBar(p, 8) + '</span> ' +
         '<span class="cell-pct pct-' + pctClass(p) + '">' + p.toFixed(1) + '%</span> ' +
         '<span class="cell-count">(' + cell[0] + '/' + cell[1] + ')</span>';
 }
-// Errors: lower is better, so the color scale is inverted vs metrics.
 function errPctClass(p) { return p < 2 ? "high" : (p < 10 ? "mid" : "low"); }
-// Same arithmetic as pct() now that errors ship as an [errored, scope] pair (the
-// old pair read .errored/.scope vs .perfect/.total). Kept as its own name so the
-// call sites say which rate they mean.
 function errRate(cell) { return cell && cell[1] > 0 ? (cell[0] / cell[1]) * 100 : 0; }
 function errorCellHtml(cell) {
     const p = errRate(cell);
@@ -612,9 +535,6 @@ function buildLeaderboard(result) {
     const tbl = document.getElementById("leaderboard-table");
     if (!tbl) return;
     const decs = visibleDecs(), metrics = orderedMetrics();
-    // Header. "Errors" = how often the decompiler failed/timed out on a
-    // function it was asked to decompile (lower is better). The Compiles rate
-    // used to sit here; it moved to its own table on the distance page.
     const cols = [["__name__", "decompiler"], ["__overall__", "Union"]];
     for (const m of metrics) cols.push([m, metricShort(m)]);
     cols.push(["__errors__", "Errors"]);
@@ -626,20 +546,16 @@ function buildLeaderboard(result) {
             escapeHtml(label) + '<span class="arrow">' + arrow + '</span></th>';
     }
     tbl.querySelector("thead tr").innerHTML = head;
-    // Sort.
     decs.sort((a, b) => {
         let va = sortValue(a, state.sortKey, result), vb = sortValue(b, state.sortKey, result);
         if (typeof va === "string") return state.sortDir * va.localeCompare(vb);
         return state.sortDir * (va - vb);
     });
-    // Rows.
     let body = "";
     decs.forEach((d, i) => {
         let row = '<tr class="binrow"><td class="lb-rank">#' + (i + 1) + '</td>' +
             '<td class="lb-name lb-name-stacked" title="' + escapeHtml(decTip(d)) + '">' +
             decNameHtml(d, {stacked: true}) + '</td>';
-        // data-label lets the stacked (mobile) card show each cell's column name
-        // (see the max-width:700px block in app.css); ignored on the desktop table.
         row += '<td class="metric-cell col-overall" data-label="Union">' + cellPctHtml(overallCell(result, d)) + '</td>';
         for (const m of metrics) row += '<td class="metric-cell" data-label="' + escapeHtml(metricShort(m)) + '">' + cellPctHtml(metricCell(result, d, m)) + '</td>';
         row += '<td class="metric-cell" data-label="Errors">' + errorCellHtml(errorCell(result, d)) + '</td>';
@@ -657,7 +573,6 @@ function buildLeaderboard(result) {
     });
 }
 
-// ---- Metrics perfect-rate table ----
 function buildMetricsTable(result) {
     const tbl = document.getElementById("metrics-perfect-table");
     if (!tbl) return;
@@ -678,9 +593,6 @@ function buildMetricsTable(result) {
     tbl.querySelector("tbody").innerHTML = body;
 }
 
-// ---- Distance table (the data page's #distance section; lower is better) ----
-// mean/median/n/at0 are precomputed per combo; see docs/site.md. A null
-// cell means no function under this combo had a finite distance for that metric.
 function buildDistance(result) {
     const tbl = document.getElementById("distance-table");
     if (!tbl) return;
@@ -696,9 +608,6 @@ function buildDistance(result) {
             return av - bv;
         });
     const rows = mkRows(groups.main), subRows = mkRows(groups.subset);
-    // Best (lowest) mean per metric -> highlight. Full-coverage rows only: a
-    // sample-set-only backend's mean covers a fraction of this dataset, so it
-    // neither takes nor sets the highlight.
     const best = {};
     metrics.forEach((m, i) => {
         best[m] = Math.min.apply(null, rows.map(r => r.cells[i] ? r.cells[i].mean : Infinity));
@@ -729,13 +638,6 @@ function buildDistance(result) {
     toggleSubsetNote("distance-subset-note", subRows.length > 0);
 }
 
-// ---- Compile-rate table (lives on the data page's #compiles section) ----
-// The per-decompiler Compiles rate — the share of a decompiler's
-// byte_match-measured functions whose output actually recompiled — moved off the
-// leaderboard to here. It is one number per decompiler (see aggregate.py's
-// `compile`), so unlike the metrics it gets its own small table rather than a
-// column. Sorted highest-first; the sample-set-only backends render below a
-// dashed break off their preset, exactly like the distance table (splitDecs()).
 function buildCompile(result) {
     const tbl = document.getElementById("compile-table");
     if (!tbl) return;
@@ -760,16 +662,6 @@ function buildCompile(result) {
     toggleSubsetNote("compile-subset-note", subRows.length > 0);
 }
 
-// ---- Cost table (the data page's #cost section) ----
-// Reads AGG.cost — a GLOBAL, combo-independent block (decompile time and $ do
-// not vary with the dataset preset or the normalize toggle), so buildCost runs
-// ONCE from init() after the aggregates land, never from refresh(). Shape per
-// decompiler: {time: {mean_s, median_s, n_functions, [n_binaries,] basis},
-// dollars: {total, per_function, model, estimated} | null}. `basis` is "batch"
-// (binary wall-time / functions) for traditional decompilers and "per-function"
-// (agent call incl. tool use) for the LLM backends — the data.md prose warns the
-// two are not directly comparable, which is also why the rows split main vs
-// sample-set (the same static split the other tables draw with subsetBreakRow).
 function fmtSecs(s) {
     return s >= 100 ? Math.round(s) + " s" : s.toFixed(1) + " s";
 }
@@ -779,8 +671,6 @@ function buildCost() {
     const cost = (AGG && AGG.cost) || {};
     tbl.querySelector("thead tr").innerHTML =
         "<th>decompiler</th><th>median time / fn</th><th>mean time / fn</th><th>est. cost</th>";
-    // Static split: LLM/sample-set-only backends below the break, always (cost is
-    // preset-independent, so unlike splitDecs() this does not consult the preset).
     const all = ((AGG && AGG.decompilers) || []).filter(d => cost[d]);
     const sso = (AGG && AGG.sample_set_only) || [];
     const median = d => {
@@ -791,8 +681,6 @@ function buildCost() {
     const timeCell = v => (v == null) ? "&mdash;" : fmtSecs(v);
     const rowHtml = (d, isSubset) => {
         const t = cost[d].time || {}, dol = cost[d].dollars;
-        // No dollars: em-dash for the batch rows (not applicable — no per-token
-        // cost), "n/a" for an LLM row (applicable but unpriced/no token data).
         const dolCell = dol
             ? '$' + dol.total.toFixed(2) + ' <span class="cell-count">($' +
               dol.per_function.toFixed(2) + '/fn, est.)</span>'
@@ -841,19 +729,12 @@ function refresh() {
     buildDistance(lastResult);
     buildCompile(lastResult);
     updateStats(lastResult);
-    // The About page's projects table is preset-aware; re-render it if it has been
-    // loaded (no-op before the About view is first opened, or if not in the DOM).
     renderDatasetProjects();
 }
 
-// ---- About page's dataset section (corpus-wide; independent of the selectors) ----
-// The corpus stats are selector-independent, but the projects table is preset-aware
-// (the sample-set preset lists only its sampled projects), so the loaded payload is
-// cached here and the table is re-rendered from it on preset change (refresh()).
 let _lastDataset = null;
 function buildDataset(ds) {
     const cats = ds.categories || [], summary = ds.summary || {};
-    // Category highlight buttons.
     const cc = document.getElementById("category-controls");
     if (cc) {
         cc.innerHTML = cats.map(c =>
@@ -873,7 +754,6 @@ function buildDataset(ds) {
             }
         }));
     }
-    // Summary.
     const sum = document.getElementById("dataset-summary");
     if (sum) {
         sum.innerHTML = '<div class="goal-body">' +
@@ -886,22 +766,12 @@ function buildDataset(ds) {
             '</strong> total source lines of code (project .c files)</div>' +
             '</div>';
     }
-    // Projects table: cache the payload, then render it preset-aware. refresh()
-    // calls renderDatasetProjects() again on preset change (no refetch).
     _lastDataset = ds;
     renderDatasetProjects();
 }
 
-// ---- Data page's pipeline-health section (corpus-wide; from data/dataset.json) ----
-// Split out of buildDataset when the joern scaffolds moved from the about page to
-// the data page (2026-07-23). Same lazy dataset.json payload — the fetch promise
-// is cached per file (loadData), so opening both pages fetches it once.
 function buildPipelineHealth(ds) {
     const joern = ds.joern || {};
-    // Pipeline health: source-side GED loss. A benchmark function has NO source
-    // CFG iff no decompiler ever got a GED value for it (source CFGs are
-    // decompiler-independent), so this is the share of functions GED cannot score
-    // because OUR source front-end (Joern) failed or was too slow on the source.
     const src = joern.source || {}, spot = joern.spot_check || {};
     const srcTotal = src.total || 0, srcLost = src.lost || 0;
     const srcPct = srcTotal ? (100 * srcLost / srcTotal) : 0;
@@ -920,7 +790,6 @@ function buildPipelineHealth(ds) {
                 '.</div>') : '') +
             '</div>';
     }
-    // Pipeline health: Joern failures on each decompiler's OUTPUT (corpus-wide).
     const out = joern.output || {};
     const jt = document.getElementById("joern-output-table");
     if (jt) {
@@ -938,12 +807,6 @@ function buildPipelineHealth(ds) {
     }
 }
 
-// The About page's projects table, filtered by the selected preset. Only the
-// sample-set preset narrows the list — to the projects it sampled (>=1 function
-// tagged sample-set, per the row's `presets`); every other preset shows the full
-// corpus (which those presets essentially are, and the user asked to filter only
-// the sample-set). Reads the cached payload so refresh() can re-render on a preset
-// change without refetching.
 function renderDatasetProjects() {
     const tbl = document.getElementById("dataset-projects");
     if (!tbl || !_lastDataset) return;
@@ -969,22 +832,11 @@ function renderDatasetProjects() {
     }
 }
 
-// ---- View page (source vs one decompiler, by difficulty tier) ----
-// Replaced the old Compare and Hardest views. samples.json entries carry a
-// `difficulty` tag (easy/medium/hard, assigned server-side from cross-decompiler
-// GED agreement); the three dropdowns pick the tier, the decompiler whose output
-// is shown, and the metric whose score is highlighted.
 let VIEW_SAMPLES = [];
-// Tier order for the view-page dropdown. `sample-set` is the dataset-selector's
-// curated slice (materialized at build time, difficulty="sample-set"); it lists
-// after the three GED-agreement tiers, and the decompiler dropdown gains codex
-// only because those entries carry codex output. A tier appears only when the
-// data has entries for it (initView filters this against VIEW_SAMPLES).
 const DIFFICULTIES = ["easy", "medium", "hard", "sample-set"];
 function sampleLabel(s) {
     return s.project + "/" + s.opt_level + "/" + s.binary + " :: " + s.function;
 }
-// The stable id used in the `fn` URL param: the label with no spaces around "::".
 function sampleKey(s) {
     return s.project + "/" + s.opt_level + "/" + s.binary + "::" + s.function;
 }
@@ -999,9 +851,6 @@ function viewControls() {
         body: document.getElementById("view-body")
     };
 }
-// Human explanation for a missing view-page source, keyed by the `source_status`
-// code the sample carries (stamped by scoring/report_extras.py). Any unknown or
-// null code falls back to a generic line rather than showing an empty panel.
 function sourceUnavailableReason(status) {
     switch (status) {
         case "binary_not_found":
@@ -1030,7 +879,6 @@ function renderViewEntry() {
         (s.difficulty ? (' &middot; <span class="tag score-bad">' +
             escapeHtml(s.difficulty) + '</span>') : '') +
         '</div>';
-    // Scores strip: the chosen decompiler's per-metric values, chosen metric first.
     const vals = (s.values && s.values[dec]) || {};
     const perf = (s.perfects && s.perfects[dec]) || {};
     let scores = "";
@@ -1046,9 +894,6 @@ function renderViewEntry() {
     }
     html += '<div class="cmp-scores">' + escapeHtml(dec) + ': ' + (scores || '&mdash;') + '</div>';
     const code = (s.decompiled || {})[dec];
-    // Always a two-column grid: source on the left (or, when it is missing, a
-    // short explanation of why), the chosen decompiler's output on the right.
-    // Both code panels are syntax-highlighted — hlC escapes its input for us.
     html += '<div class="cmp-grid" style="grid-template-columns:repeat(2,minmax(0,1fr));">';
     if (s.source_code) {
         const badge = s.source_status === "preprocessed"
@@ -1093,7 +938,6 @@ function initView(samples) {
     VIEW_SAMPLES = samples || [];
     const c = viewControls();
     if (!c.fn) return;
-    // Difficulty tiers present in the data; legacy payloads (no tags) get "all".
     const tiers = DIFFICULTIES.filter(t => VIEW_SAMPLES.some(s => s.difficulty === t));
     if (c.tier) {
         (tiers.length ? tiers : ["__all__"]).forEach(t => {
@@ -1102,7 +946,6 @@ function initView(samples) {
             c.tier.appendChild(o);
         });
     }
-    // Decompilers: union over the entries (covers versioned ids), sorted.
     const decs = [];
     for (const s of VIEW_SAMPLES) {
         for (const d in (s.decompiled || {})) if (decs.indexOf(d) < 0) decs.push(d);
@@ -1111,7 +954,7 @@ function initView(samples) {
     if (c.dec) {
         decs.forEach(d => {
             const o = document.createElement("option");
-            o.value = d; o.textContent = decName(d);  // value stays the raw id
+            o.value = d; o.textContent = decName(d);
             c.dec.appendChild(o);
         });
     }
@@ -1122,8 +965,6 @@ function initView(samples) {
             c.metric.appendChild(o);
         });
     }
-    // Deep-link the tier/dec/metric selects from the initial URL; the function is
-    // selected after fillViewFunctions lists it.
     const fnIdx = applyViewParams(c);
     if (c.tier) c.tier.addEventListener("change", () => { fillViewFunctions(); syncUrl(); });
     if (c.dec) c.dec.addEventListener("change", () => { renderViewEntry(); syncUrl(); });
@@ -1135,14 +976,8 @@ function initView(samples) {
         c.fn.value = String(fnIdx);
         renderViewEntry();
     }
-    // Reflect the resolved view state in the URL (idempotent; keeps a deep link
-    // canonical and drops any unknown params the reader arrived with).
     if (state.view === "view") syncUrl();
 }
-// Apply the view page's URL params (once, from the initial load). Returns the
-// VIEW_SAMPLES index the `fn` param names, or -1. Unknown values are ignored: a
-// param only takes effect when it matches a real option, and a named function
-// additionally forces its own difficulty tier so its option is actually listed.
 function applyViewParams(c) {
     const optOf = sel => Array.from(sel.options).map(o => o.value);
     let fnIdx = -1;
@@ -1164,24 +999,14 @@ function applyViewParams(c) {
     return fnIdx;
 }
 
-// baseName strips a versioned id's "@version" suffix. It outlived the removed
-// Historical view (whose legend keyed by base name): the decompiler registry
-// still uses it to resolve a versioned id ("ghidra@12.1") to its "ghidra" entry.
 function baseName(dec) { const a = dec.indexOf("@"); return a >= 0 ? dec.substring(0, a) : dec; }
 
-// ---- Theme toggle ----
-// Dark is the default; light is an explicit opt-in, persisted in localStorage.
-// The FOUC-free <head> script (html.py) already applied the stored/URL theme
-// before first paint, and the button LABEL is CSS-driven off data-theme — so all
-// that is left for the client is the click. The whole page is pure CSS and
-// re-tints for free (the removed historical charts, which baked colors at render
-// time, were the only thing that had to be redrawn on a live flip).
 function currentTheme() {
     return document.documentElement.dataset.theme === "light" ? "light" : "dark";
 }
 function applyTheme(theme) {
     document.documentElement.dataset.theme = theme;
-    try { localStorage.setItem("decbench-theme", theme); } catch (e) { /* private mode */ }
+    try { localStorage.setItem("decbench-theme", theme); } catch (e) { }
 }
 function initThemeToggle() {
     const btn = document.getElementById("theme-toggle");
@@ -1191,14 +1016,8 @@ function initThemeToggle() {
     });
 }
 
-// ---- Lazy views ----
-// Fetched on FIRST navigation, once. Each also waits on aggregates, which carry
-// the metric registry these views label their columns and scores with.
 const LAZY_VIEWS = {
     about: {file: "dataset", body: "dataset-summary", render: buildDataset},
-    // The data page's pipeline-health section reads the SAME dataset.json as the
-    // about page — loadData caches the fetch promise per file, so whichever view
-    // opens first pays for it and the other reuses the promise.
     data: {file: "dataset", body: "joern-source", render: buildPipelineHealth},
     view: {file: "samples", body: "view-body", render: initView}
 };
@@ -1207,7 +1026,7 @@ function ensureViewData(name) {
     const spec = LAZY_VIEWS[name];
     if (!spec || lazyStarted[name]) return;
     const body = document.getElementById(spec.body);
-    if (!body) return;  // the view rendered its empty state: nothing to fill.
+    if (!body) return;
     lazyStarted[name] = true;
     setLoading(body);
     Promise.all([loadData("aggregates"), loadData(spec.file)])
@@ -1218,11 +1037,6 @@ function ensureViewData(name) {
         });
 }
 
-// ---- View routing ----
-// Two modes, one DOM update. Split mode reflects the view in the URL PATH
-// (site/<view>/) so it is linkable and the back button works; the single-file /
-// inline report keeps its pure #hash behavior. showView only touches the DOM; the
-// URL is written by navigate()/syncUrl().
 function showView(name) {
     state.view = name;
     document.querySelectorAll(".view").forEach(v => {
@@ -1236,20 +1050,15 @@ function showView(name) {
 function validViews() {
     return Array.from(document.querySelectorAll(".view")).map(v => v.getAttribute("data-view"));
 }
-// Renamed views: an old `#<hash>` deep link routes to the view's new id (e.g. the
-// distance page became the data page, 2026-07-23). Only consulted when the hash
-// is not itself a valid view id, so an in-page section anchor (#cost, #compiles)
-// that is NOT a view id still falls through to native scrolling untouched.
 const LEGACY_HASH_VIEWS = {distance: "data"};
-// The view a `#hash` names: the hash itself when it is a valid view id, its
-// legacy mapping when that resolves to one, else null (not a view hash).
 function resolveViewHash(hash) {
     const views = validViews();
     if (views.indexOf(hash) >= 0) return hash;
     const mapped = LEGACY_HASH_VIEWS[hash];
     return (mapped && views.indexOf(mapped) >= 0) ? mapped : null;
 }
-// The view a fresh load opens on when the URL names none. It is config —
+// The default view is config (views.toml's `default = true`) and reaches us
+// through the DOM: routing runs before aggregates.json lands.
 // views.toml's `default = true` — and reaches us through the DOM: the renderer
 // marks that section `active` (on a subpage, the subpage's own view), and routing
 // runs before aggregates.json lands, so we cannot wait to read it from there.
@@ -1257,7 +1066,8 @@ function defaultView() {
     const el = document.querySelector(".view.active") || document.querySelector(".view");
     return el ? el.getAttribute("data-view") : null;
 }
-// Split mode: the view named by the path segment just under the site root, or null
+// The source of truth AFTER a browser navigation, when the DOM's `.active` is
+// stale.
 // (the root, or an unknown segment). The source of truth AFTER a browser navigation,
 // when the DOM's `.active` is stale.
 function pathView() {
@@ -1269,16 +1079,10 @@ function pathView() {
     const seg = rest.split("/")[0];
     return validViews().indexOf(seg) >= 0 ? seg : null;
 }
-// Where a fresh load lands: a valid legacy `#hash` (so old site/#about links keep
-// working, and a renamed view's old hash — #distance — still routes) wins;
-// otherwise the renderer already marked the right section active (a path
-// subpage, or the inline default), so the DOM fallback covers it.
 function routeTarget() {
     const hash = (location.hash || "").replace("#", "");
     return resolveViewHash(hash) || defaultView();
 }
-// The canonical URL for the current state. Split mode carries the view in the path;
-// inline mode leaves the path+hash alone and only attaches the query.
 function viewUrl(view) {
     const qs = currentQuery();
     if (ROOT !== null) return basePath() + (view ? view + "/" : "") + (qs ? "?" + qs : "");
@@ -1289,35 +1093,27 @@ function writeUrl(push) {
     try {
         if (push) history.pushState({view: state.view}, "", url);
         else history.replaceState(history.state, "", url);
-    } catch (e) { /* file:// and sandboxed frames forbid the history API */ }
+    } catch (e) { }
 }
-// A state change (dataset / normalize / view select) replaces — no new history
-// entry. A nav pushes a new entry in split mode, replaces in inline (hash left as is).
 function syncUrl() { writeUrl(false); }
 function navigate(view) {
     showView(view);
     writeUrl(ROOT !== null);
 }
 function onPopState() {
-    // The URL is the source of truth after Back/Forward; do not push again. A
-    // legacy `#hash` entry (the URL a pre-subpage deep link loaded with) names
-    // its view in the hash, not the path — honor it exactly as routeTarget() did.
     const hash = (location.hash || "").replace("#", "");
     const name = resolveViewHash(hash)
         || pathView() || (AGG && AGG.default_view) || defaultView();
     if (name) showView(name);
 }
-// In-page `#view` links in the prose (e.g. about.md's "see the data page") change
-// the hash without a popstate; route them in both delivery modes. A hash that is
-// neither a view id nor a legacy view alias (e.g. the data page's own #cost /
-// #compiles section anchors) is left to the browser's native anchor scrolling.
 function onHashChange() {
     const hash = (location.hash || "").replace("#", "");
     const name = resolveViewHash(hash);
     if (name) showView(name);
     maybeScrollToHash();
 }
-// A section-anchor deep link (the data page's #distance / #compiles / #cost, incl.
+// The browser's native on-load scroll fires while these sections are still
+// empty, so re-scroll once the async tables have rendered.
 // the old /distance/ URL that now redirects to /data/#distance) must scroll to its
 // heading AFTER the async tables render: the browser's native on-load scroll fires
 // while those sections are still empty, so the heading has moved by the time the
@@ -1332,10 +1128,10 @@ function initNav() {
     document.querySelectorAll(".nav-item").forEach(a => {
         const id = a.getAttribute("data-view");
         // Rewrite the href to the real subpage URL so middle-click / copy-link work
+// (the renderer ships "#id" for the no-JS and single-file forms).
         // (the renderer ships "#id" for the no-JS and single-file forms).
         if (ROOT !== null) { try { a.setAttribute("href", basePath() + id + "/"); } catch (e) {} }
         a.addEventListener("click", e => {
-            // Leave modified clicks (new tab, download, non-primary button) to the href.
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || (e.button && e.button !== 0)) return;
             e.preventDefault();
             navigate(id);
@@ -1347,14 +1143,11 @@ function initNav() {
     if (target) showView(target);
 }
 
-// ---- URL <-> state (query params, both modes) ----
 function defaultPresetName() {
     const presets = (AGG && AGG.presets) || [];
     const def = presets.filter(p => p.default)[0] || presets[0];
     return def ? def.name : null;
 }
-// Minimal, clean query for the current state: dataset only when NOT the default
-// preset, norm only when on, and the view-page selectors only while on that page.
 function currentQuery() {
     const params = new URLSearchParams();
     if (state.dataset && state.dataset !== defaultPresetName()) params.set("dataset", state.dataset);
@@ -1374,7 +1167,8 @@ function setDatasetDesc() {
     const p = (AGG.presets || []).filter(x => x.name === state.dataset)[0];
     const el = document.getElementById("dataset-desc");
     if (el) el.textContent = p ? p.description : "";
-    // The leaderboard's per-dataset explainer paragraph. `long_description` is
+    // `long_description` is packaged, maintainer-authored inline HTML from
+// content/datasets.toml — not run data — so innerHTML is safe here.
     // final inline HTML from content/datasets.toml (packaged, maintainer-authored
     // — not run data), so innerHTML is safe; empty (older aggregates.json or an
     // unregistered preset) renders nothing.
@@ -1386,14 +1180,10 @@ function setDatasetDesc() {
 }
 function initDatasetSelector() {
     const presets = AGG.presets || [];
-    // The opening preset is explicit (`default = true` in datasets.toml), never
-    // positional; a valid `dataset` URL param overrides it (deep link), and an
-    // unknown one is ignored. Sync the buttons so state and UI cannot disagree.
     const def = presets.filter(p => p.default)[0] || presets[0];
     const wanted = INIT_PARAMS.get("dataset");
     state.dataset = presets.some(p => p.name === wanted) ? wanted : (def ? def.name : null);
     state.normalize = INIT_PARAMS.get("norm") === "1";
-    // Only the preset buttons carry data-dataset (the normalize toggle does not).
     const btns = document.querySelectorAll(".ds-btn[data-dataset]");
     btns.forEach(b => {
         b.classList.toggle("active", b.getAttribute("data-dataset") === state.dataset);
@@ -1407,7 +1197,6 @@ function initDatasetSelector() {
         });
     });
     setDatasetDesc();
-    // "normalize failures": restrict to functions every decompiler decompiled.
     const nb = document.getElementById("normalize-btn");
     if (nb) {
         nb.classList.toggle("active", state.normalize);
@@ -1423,19 +1212,12 @@ function initDatasetSelector() {
 function init() {
     initNav();
     initThemeToggle();
-    // Color the about page's server-rendered <pre data-lang> blocks. They are in
-    // the DOM from page load in both modes (all view sections ship in every page),
-    // so this runs once here rather than via a DOMContentLoaded auto-init.
     if (typeof applyStaticHighlights === "function") applyStaticHighlights(document);
     loadData("aggregates").then(agg => {
         AGG = agg;
         initDatasetSelector();
         refresh();
-        // Cost is combo-independent (AGG.cost is global, not per-combo), so it is
-        // built once here rather than on every refresh().
         buildCost();
-        // Section anchors (e.g. a /distance/ -> /data/#distance redirect) scroll
-        // only now that the tables they point at have rendered.
         maybeScrollToHash();
     }).catch(err => {
         ["leaderboard", "about", "data"].forEach(v => showBanner(v,

--- a/decbench/rendering/content.py
+++ b/decbench/rendering/content.py
@@ -61,21 +61,15 @@ __all__ = [
 
 _CONTENT_DIR = "content"
 
-# `# <title>` / `# [tag] <title>` — opens a section of a view markdown file.
 _SECTION_RE = re.compile(r"^#[ \t]+(?:\[(?P<tag>[a-z]+)\][ \t]*)?(?P<title>.*)$")
-# `## [1] <title>` — opens a goal card in metrics.md.
 _CARD_RE = re.compile(r"^##[ \t]+\[(?P<num>\d+)\][ \t]*(?P<title>.*)$")
 _METRIC_LINE_RE = re.compile(r"^metric:[ \t]*(?P<name>.+)$")
 _PERFECT_RE = re.compile(r"^\*\*perfect\s*=\*\*[ \t]*(?P<rest>.+)$")
 _COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _WRAPPING_P_RE = re.compile(r"^<p[^>]*>(?P<inner>.*)</p>\s*$", re.DOTALL)
-# `<details class="metric-viz">...</details>` — a hand-authored raw-HTML island.
-# Mistune knows nothing of SVG: blank-line-separated `<text>`/`<rect>` runs inside
-# one are "loose paragraphs" to it, and the `<p>` it wraps them in — INSIDE an
-# `<svg>` — is invalid foreign content that makes the browser abandon SVG parsing.
-# Islands are therefore lifted out before markdown rendering and spliced back in
-# verbatim afterwards. Lines inside an island still must not start with `# `/`## `
-# (the section/card splitters are line-based and run first).
+# Raw-HTML islands are lifted out before markdown rendering and spliced back
+# verbatim: mistune wraps blank-line-separated SVG runs in a `<p>`, which inside
+# an `<svg>` makes the browser abandon SVG parsing entirely.
 _ISLAND_RE = re.compile(r"<details class=\"metric-viz\"[^>]*>.*?</details>", re.DOTALL)
 _ISLAND_TOKEN = "decbench-viz-island-{index}"
 
@@ -111,9 +105,8 @@ class _ReportRenderer(_RawTextRenderer):
         return super().heading(text, level, **attrs)
 
 
-# escape=False: the prose IS final HTML (<em>, <strong>, &mdash;) and must pass
-# through untouched. The content directory ships with the package; it is never
-# user-supplied, so there is no injection surface here.
+# escape=False: the prose is already final HTML. The content directory ships with
+# the package and is never user-supplied, so there is no injection surface.
 _render_view = mistune.create_markdown(renderer=_ReportRenderer(escape=False))
 _render_inline = mistune.create_markdown(renderer=_RawTextRenderer(escape=False))
 
@@ -210,11 +203,6 @@ class ViewContent:
     empty_title: str = ""
     empty_html: str = ""
     goals: tuple[GoalCard, ...] = ()
-
-    @property
-    def has_empty_state(self) -> bool:
-        """Whether the view declares an ``# [empty]`` section."""
-        return bool(self.empty_html)
 
 
 @dataclass(frozen=True)
@@ -328,7 +316,6 @@ class Content:
     decompilers: tuple[DecompilerSpec, ...] = ()
     pricing: tuple[ModelPricing, ...] = ()
 
-    # -- views -------------------------------------------------------------
     def view(self, view_id: str) -> ViewContent:
         """Return one view's prose by id."""
         return self.views[view_id]
@@ -371,7 +358,6 @@ class Content:
         views[view_id] = _parse_view(view_id, markdown_text, self.metrics)
         return replace(self, views=views)
 
-    # -- metrics -----------------------------------------------------------
     def metric(self, name: str) -> MetricSpec | None:
         """Look up a metric's presentation, or ``None`` if it is unregistered."""
         for m in self.metrics:
@@ -396,7 +382,6 @@ class Content:
         spec = self.metric(metric)
         return spec.display_name if spec else metric
 
-    # -- datasets ----------------------------------------------------------
     @property
     def default_dataset(self) -> DatasetPresetSpec | None:
         """The preset the report opens with (explicit, never positional)."""
@@ -405,7 +390,6 @@ class Content:
                 return p
         return None
 
-    # -- decompilers -------------------------------------------------------
     def decompiler(self, dec_id: str) -> DecompilerSpec | None:
         """Presentation for a decompiler id, by exact match then base name.
 
@@ -422,7 +406,6 @@ class Content:
                 fallback = spec
         return fallback
 
-    # -- model pricing -----------------------------------------------------
     def model_pricing(self, name: str) -> ModelPricing | None:
         """The price card for a model id (exact match), or ``None`` if unknown."""
         for pricing in self.pricing:
@@ -472,8 +455,8 @@ def _render_with_islands(markdown: str, render: mistune.Markdown) -> str:
         return _ISLAND_TOKEN.format(index=len(islands) - 1)
 
     html = render(_ISLAND_RE.sub(_lift, markdown))
-    # Descending index: token "…-1" is a prefix of "…-10", so ascending bare-token
-    # replacement would corrupt the tenth island while splicing the second.
+    # Descending: token "…-1" is a prefix of "…-10", so ascending replacement would
+    # corrupt the tenth island while splicing the second.
     for index, island in reversed(list(enumerate(islands))):
         token = _ISLAND_TOKEN.format(index=index)
         for wrapped in (f"<p>{token}</p>", f'<p class="view-desc">{token}</p>'):

--- a/decbench/rendering/html.py
+++ b/decbench/rendering/html.py
@@ -66,28 +66,17 @@ __all__ = [
 CSS_FILE = "app.css"
 JS_FILE = "app.js"
 
-#: Icons shipped into the split site tree's root (``build_site``). Derived from
-#: ``assets/decbench_icon.png`` and vendored under ``assets/icons/`` (like the
-#: fonts) so the site renders them offline with no third-party dependency.
-FAVICON_FILE = "favicon.png"  # 64x64, <link rel="icon">
-APPLE_TOUCH_FILE = "apple-touch-icon.png"  # 180x180, iOS home-screen icon
-CARD_FILE = "decbench_card.png"  # 1200x630 Open Graph / Twitter share image
+FAVICON_FILE = "favicon.png"
+APPLE_TOUCH_FILE = "apple-touch-icon.png"
+CARD_FILE = "decbench_card.png"
 
-#: A comment stamped into every page this module builds. The split-site writer
-#: (:mod:`decbench.rendering.site`) uses it to tell a view subdirectory it wrote
-#: from an arbitrary directory a maintainer dropped in ``site/``: only a directory
-#: whose ``index.html`` carries this marker is safe to remove as a stale view.
+# Only a directory whose index.html carries this marker is safe to remove as a
+# stale view, so a maintainer's own directory under site/ is never deleted.
 SITE_PAGE_MARKER = "<!-- decbench:page -->"
 
-#: Theme bootstrap. Inlined into <head> BEFORE the stylesheet so the chosen theme
-#: is applied to <html> before first paint — a link/style loaded first would flash
-#: the default (dark) theme. It reads localStorage (in try/catch: file:// and
-#: privacy modes throw) plus an optional ``?theme=`` param (a debug/share
-#: convenience, documented in docs/site.md), then stamps
-#: ``data-theme`` on the document element. Dark is the default and the only
-#: theme when nothing is stored; there is deliberately NO OS-preference detection
-#: — only an explicit user choice switches to light. Lives in the shared skeleton
-#: (not :class:`PageAssets`) so both delivery modes get it identically.
+# Must be inlined before the stylesheet so the theme applies before first paint.
+# There is deliberately NO OS-preference detection: dark is the default and only
+# an explicit user choice switches to light.
 _THEME_BOOTSTRAP = (
     "<script>(function(){try{"
     "var q=new URLSearchParams(location.search).get('theme');"
@@ -98,9 +87,6 @@ _THEME_BOOTSTRAP = (
     "}catch(e){}})();</script>"
 )
 
-#: The sidebar theme-toggle button. Both labels ship; CSS shows the right one for
-#: the active theme (data-theme), so it is correct at first paint and app.js only
-#: has to wire the click.
 _THEME_TOGGLE = (
     '<button class="ds-btn theme-toggle" id="theme-toggle" type="button"'
     ' aria-label="toggle light or dark theme">'
@@ -112,16 +98,10 @@ _ASSETS_DIR = "assets"
 _FONTS_DIR = "fonts"
 _ICONS_DIR = "icons"
 
-#: The single-file report's favicon: a small 32x32 icon inlined as a data: URI
-#: (the report links no files, and it stays light — see :func:`_inline_favicon_link`).
-#: It is never written to the site tree; only :data:`FAVICON_FILE` /
-#: :data:`APPLE_TOUCH_FILE` / :data:`CARD_FILE` are (:func:`iter_site_icons`).
 _INLINE_FAVICON_FILE = "favicon-32.png"
 
-# `url(fonts/x.woff2)` in app.css. It resolves against the STYLESHEET's url when
-# the sheet is linked (site/app.css -> site/fonts/x.woff2, correct) but against
-# the DOCUMENT's url when the sheet is inlined into a <style> — which is why the
-# single-file mode substitutes a data: URI rather than shipping a broken path.
+# A url() in app.css resolves against the stylesheet when linked but against the
+# document when inlined, so single-file mode substitutes a data: URI.
 _FONT_URL_RE = re.compile(r"url\((?P<q>['\"]?)(?P<path>fonts/[^)'\"]+)(?P=q)\)")
 _FONT_MIME = {
     ".woff2": "font/woff2",
@@ -129,11 +109,6 @@ _FONT_MIME = {
     ".ttf": "font/ttf",
     ".otf": "font/otf",
 }
-
-
-# --------------------------------------------------------------------------
-# Packaged assets
-# --------------------------------------------------------------------------
 
 
 def asset_text(name: str) -> str:
@@ -220,11 +195,6 @@ def _json_for_script(payload: Any) -> str:
     strict ``JSON.parse`` would reject an ``Infinity``, so the build fails loud.
     """
     return json.dumps(payload, allow_nan=False).replace("<", "\\u003c")
-
-
-# --------------------------------------------------------------------------
-# Delivery modes
-# --------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -352,11 +322,6 @@ def static_assets() -> PageAssets:
     )
 
 
-# --------------------------------------------------------------------------
-# Public entry points
-# --------------------------------------------------------------------------
-
-
 def render_html_report(
     scoreboard: Scoreboard,
     output_path: Path,
@@ -436,12 +401,7 @@ def build_page(
     )
     stamp = scoreboard.generated_at.strftime("%Y-%m-%d %H:%M")
 
-    # Theme UI ships only where the client that drives it does — the two
-    # data-bearing delivery modes. A scoreboard-only static report has no app.js,
-    # so a toggle would be inert and the bootstrap pointless; leave it untouched.
     theme_head = _THEME_BOOTSTRAP if has_data else ""
-    # og/twitter tags only when the caller supplies them (the split site); the
-    # single-file report is shared as a file, not a URL, so it emits none.
     social_head = _social_meta_html(social) if social is not None else ""
     if has_data:
         side_foot = (
@@ -486,11 +446,6 @@ def build_page(
     {assets.body_end_html}
 </body>
 </html>"""
-
-
-# --------------------------------------------------------------------------
-# Sidebar
-# --------------------------------------------------------------------------
 
 
 def _default_view_id(content: Content, visible: tuple[ViewSpec, ...]) -> str:
@@ -592,11 +547,6 @@ def _dataset_selector(function_data: FunctionData, content: Content) -> str:
         </div>"""
 
 
-# --------------------------------------------------------------------------
-# View sections
-# --------------------------------------------------------------------------
-
-
 def _view_section(
     content: Content,
     spec: ViewSpec,
@@ -672,16 +622,8 @@ def _generated_table(
             return _static_leaderboard_table(scoreboard, content)
         return '<table id="leaderboard-table"><thead><tr></tr></thead><tbody></tbody></table>'
     if view_id == "about" and function_data is None:
-        # With data, about.md carries the empty `metrics-perfect-table` scaffold
-        # inline (mid-page, where the metrics section sits) and app.js fills it;
-        # only the no-JS/no-data report needs a renderer-built static table.
         return _static_metrics_table(scoreboard, content)
     return ""
-
-
-# --------------------------------------------------------------------------
-# No-JS static fallbacks
-# --------------------------------------------------------------------------
 
 
 def _pct_class(pct: float) -> str:

--- a/decbench/rendering/site.py
+++ b/decbench/rendering/site.py
@@ -49,31 +49,18 @@ _DATA_DIR = "data"
 _FONTS_DIR = "fonts"
 _INDEX = "index.html"
 
-#: The root's own hop to itself, and a subpage's hop up to the root (used for the
-#: ``<base href>`` and the ``__DECBENCH_ROOT__`` stamp — see :func:`linked_assets`).
 _ROOT_HOP = ""
 _SUBPAGE_HOP = "../"
 
-#: Pages runs Jekyll over an uploaded tree unless this file exists, and Jekyll
-#: silently drops paths that start with `_`. We have none today; one added later
-#: would vanish in production and nowhere else.
+# Pages runs Jekyll over an uploaded tree unless this file exists, and Jekyll
+# silently drops paths starting with `_` — in production and nowhere else.
 _NOJEKYLL = ".nojekyll"
 
-#: Renamed views whose OLD URLs must keep working: old id -> (current view id,
-#: section anchor on that view). Each gets a marker-less redirect stub at
-#: ``<old>/index.html`` (see :func:`_write_legacy_redirects`). The distance page
-#: became the data page on 2026-07-23 (four linkable sections: distance /
-#: compiles / pipeline health / cost); ``/distance/`` links exist in the wild, so
-#: they land on the data page's ``#distance`` section rather than its top.
 _LEGACY_REDIRECTS = {"distance": ("data", "distance")}
 
-#: The redirect stub. Deliberately does NOT contain
-#: :data:`~decbench.rendering.html.SITE_PAGE_MARKER`: the subpage prune loop
-#: (:func:`_write_view_subpages`) deletes any non-current view directory whose
-#: index.html carries the marker, and this stub must survive every rebuild. The
-#: meta refresh is the no-JS fallback; the script hop preserves ``?query`` deep
-#: links and honors an incoming ``#hash`` (a meta refresh drops both), defaulting
-#: to the section anchor so a bare ``/distance/`` link lands on the right section.
+# Deliberately carries no SITE_PAGE_MARKER: the subpage prune deletes marked
+# non-current view directories, and these stubs must survive every rebuild. The
+# script hop preserves ?query and #hash, which a bare meta refresh drops.
 _REDIRECT_STUB = """<!doctype html>
 <html lang="en">
 <head>
@@ -112,8 +99,6 @@ def build_site(
     """
     from decbench.rendering.visibility import apply_hidden_decompilers
 
-    # Hide site-hidden decompilers (content/site.toml) from EVERY page and
-    # payload; their results stay on disk, untouched.
     scoreboard, function_data = apply_hidden_decompilers(scoreboard, function_data)
     content = content or load_content()
 
@@ -125,10 +110,6 @@ def build_site(
     (out_dir / _DATA_DIR).mkdir()
     (out_dir / _FONTS_DIR).mkdir()
 
-    # Payloads are computed once, up front: the per-page social share text (the
-    # top-3 by Union) is derived from the aggregates payload, so it must exist
-    # before any page is written. (The writer used to emit index.html first, then
-    # the payloads.)
     payloads = build_payloads(function_data, scoreboard)
     root_social, view_social = _social_meta(content, payloads["aggregates"])
 
@@ -141,16 +122,11 @@ def build_site(
     (out_dir / CSS_FILE).write_text(asset_text(CSS_FILE), encoding="utf-8")
     (out_dir / JS_FILE).write_text(asset_text(JS_FILE), encoding="utf-8")
     (out_dir / _NOJEKYLL).write_text("", encoding="utf-8")
-    # GitHub Pages custom domain. Workflow deploys take the domain from the repo's
-    # Pages settings, but the CNAME file keeps the tree self-documenting and keeps
-    # the domain if publishing ever moves back to a branch source.
     if content.site.pages_domain:
         (out_dir / "CNAME").write_text(content.site.pages_domain + "\n", encoding="utf-8")
 
     for name, blob in iter_font_assets():
         (out_dir / _FONTS_DIR / name).write_bytes(blob)
-    # Favicon, apple-touch icon, and the Open Graph / Twitter share card sit at the
-    # tree root, next to index.html (the head links and og:image reference them there).
     for name, blob in iter_site_icons():
         (out_dir / name).write_bytes(blob)
 
@@ -158,9 +134,6 @@ def build_site(
         _write_json(out_dir / _DATA_DIR / f"{name}.json", payload)
 
     _write_view_subpages(scoreboard, function_data, content, out_dir, view_social)
-    # LAST, after the subpage prune: the stubs are marker-less on purpose (the
-    # prune only deletes marked pages), but writing them after keeps the ordering
-    # obvious and correct even if that invariant ever changes.
     current = {spec.id for spec in content.visible_views(function_data is not None)}
     _write_legacy_redirects(out_dir, current, content.site.pages_domain)
 
@@ -179,7 +152,6 @@ def _write_legacy_redirects(out_dir: Path, current_view_ids: set[str], domain: s
     for old_id, (target, anchor) in _LEGACY_REDIRECTS.items():
         if old_id in current_view_ids:
             continue
-        # Canonicalize to the target VIEW (not the anchor): the section is one page.
         canonical = f"https://{domain}/{target}/" if domain else f"../{target}/"
         stub_dir = out_dir / old_id
         stub_dir.mkdir(exist_ok=True)
@@ -211,8 +183,6 @@ def _write_view_subpages(
         if not child.is_dir() or child.name in (_DATA_DIR, _FONTS_DIR) or child.name in current:
             continue
         index = child / _INDEX
-        # An unreadable / non-UTF-8 index.html is by definition not one of ours —
-        # skip it rather than abort the build over a hand-added page.
         try:
             ours = index.is_file() and SITE_PAGE_MARKER in index.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
@@ -236,12 +206,6 @@ def _write_view_subpages(
         )
 
 
-# --------------------------------------------------------------------------
-# Social share metadata (Open Graph / Twitter), baked per page at build time
-# --------------------------------------------------------------------------
-
-#: Generic fallback description for any view without a bespoke one below (keeps a
-#: newly-added view from shipping an empty og:description).
 _GENERIC_DESC = (
     "A ground-truth decompiler benchmark: control flow, types, and recompilation "
     "over real C projects, firmware, and malware."
@@ -266,7 +230,6 @@ def _social_meta(
     image = f"{base}{CARD_FILE}"
     descriptions = _view_descriptions(aggregates)
 
-    # The site always has function data here, so every registered view is visible.
     per_view: dict[str, SocialMeta] = {}
     for spec in content.visible_views(True):
         per_view[spec.id] = SocialMeta(
@@ -276,8 +239,6 @@ def _social_meta(
             image_url=image,
         )
 
-    # The root index renders the default (leaderboard) view but under the bare
-    # domain, so it gets its own title and canonical URL and the leaderboard's text.
     root = SocialMeta(
         title="DecBench — decompiler benchmark",
         description=descriptions.get(content.default_view, _GENERIC_DESC),

--- a/decbench/rendering/visibility.py
+++ b/decbench/rendering/visibility.py
@@ -68,7 +68,6 @@ def _filter_function_data(function_data: FunctionData, hidden: set[str]) -> Func
         sample.decompiled = {d: c for d, c in sample.decompiled.items() if d in keep}
         sample.values = {d: v for d, v in sample.values.items() if d in keep}
         sample.perfects = {d: v for d, v in sample.perfects.items() if d in keep}
-    # A sample whose only shown output was a hidden decompiler has nothing left.
     fd.samples = [s for s in fd.samples if s.decompiled]
 
     fd.hardest = [h for h in fd.hardest if not is_hidden(h.decompiler, hidden)]

--- a/decbench/results_store.py
+++ b/decbench/results_store.py
@@ -41,23 +41,16 @@ from typing import Any
 from decbench.models.function_data import FunctionData, HistoryPoint
 from decbench.models.scoreboard import Scoreboard
 
-#: (opt_level, project, binary_stem, decompiler) — the granularity every overlay merge,
-#: guard counter and audit row works at.
 Slice = tuple[str, str, str, str]
-#: (project, opt_level, binary_stem, function) — a single function's identity, the shape
-#: used by ``sample_set_manifest.json``.
 FnKey = tuple[str, str, str, str]
 Log = Callable[[str], None]
 
 PERFECT = {"ged": 0.0, "type_match": 1.0, "byte_match": 1.0}
 
-# All benchmark project dirs (top-level *.toml only; cps/disabled/ excluded).
-# sailr = x86, cps = ARM firmware, malware = ARM/PE. Anchored to the repo root
-# (this file is <repo>/decbench/results_store.py) rather than the cwd: a finalize
-# run from the wrong directory must NOT silently find zero projects — that would
-# drop every project label (malware/cps/arch), and losing the `malware` label
-# would let the code-carrying report extras embed real malware source (the leak
-# `decbench-malware-publishing-guard` closed). finalize_tree hard-fails on empty.
+# Anchored to the repo root, not the cwd: a finalize run from the wrong directory
+# must not silently find zero projects, which would drop every project label and
+# let the code-carrying report extras embed real malware source. finalize_tree
+# hard-fails on empty.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_DIRS = [
     _REPO_ROOT / "projects/sailr",
@@ -65,7 +58,7 @@ PROJECT_DIRS = [
     _REPO_ROOT / "projects/malware",
 ]
 
-GUARD_PRINT_CAP = 100  # max aggregated regression lines printed before "... and N more"
+GUARD_PRINT_CAP = 100
 
 
 class CoverageRegressionError(RuntimeError):
@@ -80,9 +73,6 @@ def gather_project_tomls() -> list[Path]:
     return sorted(out, key=lambda p: p.stem)
 
 
-# --------------------------------------------------------------------------- #
-# Raw layer: checkpoints.
-# --------------------------------------------------------------------------- #
 def load_checkpoints(
     root: Path, exclude_projects: Collection[str] = (), log: Log = print
 ) -> tuple[dict[str, dict], dict[str, dict]]:
@@ -93,7 +83,6 @@ def load_checkpoints(
     skipped (its project then legitimately drops, which the guard will surface unless
     it is in ``exclude_projects``).
     """
-    # Register model/metric modules so the pickles resolve their classes.
     import decbench.decompilers  # noqa: F401
     import decbench.metrics  # noqa: F401
 
@@ -115,10 +104,6 @@ def load_checkpoints(
     return all_decompile, all_evaluate
 
 
-# --------------------------------------------------------------------------- #
-# Overlay merges (moved from scripts/rebuild_function_data.py, with the clears
-# scoped to SLICES instead of whole decompiler columns).
-# --------------------------------------------------------------------------- #
 def slices_from_overlay_keys(new: dict[str, Any]) -> set[Slice]:
     """The ``(opt, project, binary, dec)`` slices an overlay's entry keys cover."""
     covered: set[Slice] = set()
@@ -205,7 +190,6 @@ def update_ged(fd: FunctionData, new: dict[str, dict], covered: set[Slice] | Non
                 val = float(rec["value"])
                 f.values.setdefault(dec, {})["ged"] = val
                 f.perfects.setdefault(dec, {})["ged"] = bool(rec.get("perfect", val == 0.0))
-                # GED distance IS the graph edit distance (the value itself).
                 f.distances.setdefault(dec, {})["ged"] = val
                 n += 1
     return n
@@ -236,8 +220,6 @@ def update_byte_match(
                 if rec is None:
                     in_slice = (g.opt_level, g.project, g.binary, dec) in covered
                     if not add_only and in_slice:
-                        # No fresh value (artifact gone / abstained): drop any
-                        # stale value, distance, perfect and compile flag.
                         mv.pop("byte_match", None)
                         f.perfects.get(dec, {}).pop("byte_match", None)
                         f.distances.get(dec, {}).pop("byte_match", None)
@@ -251,9 +233,6 @@ def update_byte_match(
                 if rec.get("dist") is not None:
                     f.distances.setdefault(dec, {})["byte_match"] = float(rec["dist"])
                 else:
-                    # Non-compiling (or extract-failed): no fresh distance. Clear
-                    # any stale one so the distance view + a compile proxy can't
-                    # read a value left over from a prior computation.
                     f.distances.get(dec, {}).pop("byte_match", None)
                 t = tally.setdefault(dec, {"comp": 0, "tot": 0})
                 t["tot"] += 1
@@ -280,8 +259,6 @@ def update_type_match(fd: FunctionData, new: dict[str, dict[str, Any]]) -> int:
                 rec = per.get(f"{g.project}::{g.opt_level}::{g.binary}::{f.function}")
                 if rec is None:
                     continue
-                # Back-compat: older type_match_new.json stored a bare float; the
-                # new form is {"value": accuracy, "dist": type-flips (fp+fn)}.
                 if isinstance(rec, dict):
                     val = float(rec["value"])
                     dist = rec.get("dist")
@@ -355,9 +332,6 @@ def apply_overlays(
     return counts, bm_tally
 
 
-# --------------------------------------------------------------------------- #
-# Sample-set manifest (the frozen membership store).
-# --------------------------------------------------------------------------- #
 def load_sample_manifest(root: Path) -> set[FnKey] | None:
     """The frozen sample-set membership, or None when the tree has no manifest."""
     path = root / "sample_set_manifest.json"
@@ -367,9 +341,6 @@ def load_sample_manifest(root: Path) -> set[FnKey] | None:
     return {(e["project"], e["opt"], e["binary"], e["function"]) for e in data.get("functions", [])}
 
 
-# --------------------------------------------------------------------------- #
-# Coverage-regression guard.
-# --------------------------------------------------------------------------- #
 def _iter_group_dicts(fd_or_raw: FunctionData | dict) -> Iterable[tuple[str, str, str, list]]:
     """Yield ``(project, opt, binary, functions)`` from a model OR a raw JSON dict.
 
@@ -399,8 +370,6 @@ def coverage_counts(fd_or_raw: FunctionData | dict) -> dict[str, dict[str, int]]
         c: dict[str, int] = out.setdefault(f"{project}::{opt}::{binary}", {})
         c["functions"] = c.get("functions", 0) + len(functions)
         for f in functions:
-            # `.get`/`getattr` defaults so a pre-`decompiled`-field tree (older
-            # function_results.json) counts cleanly instead of KeyError-ing.
             values = f.get("values") if isinstance(f, dict) else f.values
             decompiled = f.get("decompiled") if isinstance(f, dict) else f.decompiled
             for dec, mv in (values or {}).items():
@@ -503,18 +472,14 @@ def write_function_data_guarded(
         )
     tmp = root / "function_results.json.tmp"
     fd.to_json(tmp)
-    # COPY (not rename) the old file to .prev, then a single atomic replace: a
-    # crash mid-write can never leave function_results.json absent (which would
-    # disable the guard on the next run), only a stale tmp.
+    # Copy (not rename) to .prev, then one atomic replace, so a crash mid-write can
+    # never leave function_results.json absent and disable the next run's guard.
     if fd_path.exists():
         shutil.copy2(fd_path, root / "function_results.prev.json")
     os.replace(tmp, fd_path)
     log(f"[guard] wrote {fd_path}")
 
 
-# --------------------------------------------------------------------------- #
-# The canonical rebuild.
-# --------------------------------------------------------------------------- #
 def finalize_tree(
     root: Path,
     *,
@@ -546,9 +511,8 @@ def finalize_tree(
     tomls = [t for t in gather_project_tomls() if t.stem not in excluded_projects]
     all_decompile, all_evaluate = load_checkpoints(root, excluded_projects, log=log)
     if not tomls and all_decompile:
-        # No project TOMLs found but checkpoints exist -> almost certainly a
-        # wrong-cwd / bad-install run. Refuse rather than rebuild label-less (which
-        # would strip malware/cps labels and risk leaking malware source).
+        # Checkpoints but no project TOMLs means a wrong-cwd run; rebuilding label-less
+        # would strip the malware/cps labels and risk leaking malware source.
         raise RuntimeError(
             f"finalize_tree: no project TOMLs under {[str(d) for d in PROJECT_DIRS]} "
             f"but {len(all_decompile)} checkpoints present — refusing to rebuild "
@@ -572,13 +536,9 @@ def finalize_tree(
         decompile_results=all_decompile,
         projects=projects,
     )
-    # attach_extras derives compile rates from the inline (checkpoint) byte_match;
-    # for the overlaid decompilers the reeval tally is the published number.
     if bm_tally:
         fd.compile_rates.update({d: t["comp"] / t["tot"] for d, t in bm_tally.items() if t["tot"]})
 
-    # Sample-set: the frozen manifest (minus excluded projects) is the single source
-    # of truth for membership; the seeded draw only runs on manifest-less trees.
     members = load_sample_manifest(root)
     if members is not None:
         members = {m for m in members if m[0] not in excluded_projects}
@@ -587,8 +547,6 @@ def finalize_tree(
     elif seed is not None:
         assign_datasets(fd, seed=seed)
 
-    # Carry forward the fields that exist ONLY in the previous derived file, and
-    # reuse its raw parse for the guard's old-coverage counts (parse once, not twice).
     old_counts: dict[str, dict[str, int]] | None = None
     prev_path = root / "function_results.json"
     if prev_path.exists():
@@ -626,14 +584,11 @@ def finalize_tree(
     return fd, scoreboard
 
 
-# --------------------------------------------------------------------------- #
-# Audit: find silent coverage gaps across every layer.
-# --------------------------------------------------------------------------- #
 @dataclass
 class CoverageGap:
     """One suspicious ``(opt, project, binary, decompiler)`` slice."""
 
-    kind: str  # SILENT-DROP | OVERLAY-GAP | DECOMPILE-FAILURE | PARTIAL
+    kind: str
     opt: str
     project: str
     binary: str
@@ -654,8 +609,6 @@ class CoverageGap:
         )
 
 
-# Built-in sample-set-only backends, kept for trees whose old checkpoints predate
-# the DecompilerMetadata.extra["slice_scoped"] flag (which audit_tree also honors).
 _LLM_BASENAMES = {"codex", "claude-code", "kimi-code"}
 
 
@@ -748,11 +701,11 @@ def audit_tree(root: Path, log: Log = print) -> list[CoverageGap]:
         for (optn, proj, stem, dec), names in sorted(ckpt_names.items()):
             base_dec = dec.split("@", 1)[0]
             if published_decs and dec not in published_decs and base_dec not in published_decs:
-                continue  # decompiler intentionally removed from the dataset (e.g. phoenix)
+                continue
             if (base_dec in _LLM_BASENAMES or dec in scoped_decs) and (
                 llm_slices is None or (proj, optn, stem) not in llm_slices
             ):
-                continue  # off-slice sparsity is by design (sample-set-only backend)
+                continue
             key: Slice = (optn, proj, stem, dec)
             markers = _artifact_marker_names(root / optn / proj / "decompiled" / f"{dec}_{stem}.c")
             pubnames = published_names.get((optn, proj, stem))
@@ -762,8 +715,6 @@ def audit_tree(root: Path, log: Log = print) -> list[CoverageGap]:
                 n > 0 for o, n in per_dec_opts.get((stem, dec), {}).items() if o != optn
             )
             if pubnames is None:
-                # The whole (opt, project, binary) group is absent from the
-                # published data — the historical "coreutils vanished" class.
                 if names or markers:
                     gaps.append(
                         CoverageGap(
@@ -780,17 +731,9 @@ def audit_tree(root: Path, log: Log = print) -> list[CoverageGap]:
                         )
                     )
                 continue
-            # Compare only functions that exist as published rows: a checkpoint
-            # holds everything the tool decompiled (library/sub_* included), while
-            # the dataset legitimately keeps only attributable source rows.
             ckpt_n = len(names & pubnames)
             art = len(markers & pubnames)
             if pub == 0 and ov > 0:
-                # The corrected overlay HAS metric values for this slice, but the
-                # published dataset has none — a real merge drop. (A decompiled
-                # artifact with NO overlay entry is not a drop: the function may be
-                # legitimately unmeasurable — ARM byte_match abstains, no source
-                # CFG for GED — so it falls to OVERLAY-GAP below, not here.)
                 gaps.append(CoverageGap("SILENT-DROP", optn, proj, stem, dec, ckpt_n, art, ov, pub))
             elif len(names) == 0 and len(markers) == 0 and sibling_ok:
                 gaps.append(

--- a/decbench/scoring/aggregator.py
+++ b/decbench/scoring/aggregator.py
@@ -36,21 +36,11 @@ class AggregatedMetric:
 
 
 @dataclass
-class PerFunctionResults:
-    """Per-function metric values across decompilers for computing Overall."""
-
-    # function_key -> metric_name -> is_perfect
-    function_perfects: dict[str, dict[str, bool]] = field(default_factory=dict)
-
-
-@dataclass
 class AggregatedResults:
     """Fully aggregated results ready for scoreboard generation."""
 
-    # decompiler -> metric -> AggregatedMetric
     by_decompiler: dict[str, dict[str, AggregatedMetric]] = field(default_factory=dict)
 
-    # decompiler -> function_key -> metric -> is_perfect
     per_function: dict[str, dict[str, dict[str, bool]]] = field(default_factory=dict)
 
     total_functions: int = 0
@@ -68,14 +58,12 @@ def aggregate_results(
     """Aggregate evaluation results across all projects and binaries."""
     aggregated = AggregatedResults()
 
-    # decompiler -> metric -> list of (value, is_perfect)
     all_values: dict[str, dict[str, list[tuple[float, bool]]]] = {}
 
     decompilers_seen: set[str] = set()
     metrics_seen: set[str] = set()
     binary_count = 0
-    # Distinct project::opt::binary::function keys across all decompilers
-    # and metrics, so totals are not inflated by either dimension.
+    # Distinct project::opt::binary::function keys, so totals are not inflated.
     distinct_functions: set[str] = set()
 
     for project_name, opt_results in evaluation_results.items():
@@ -109,7 +97,6 @@ def aggregate_results(
                                 (value.value, is_perfect)
                             )
 
-                            # Track per-function perfects for Overall computation
                             opt_value = (
                                 opt_level.value
                                 if hasattr(opt_level, "value")
@@ -124,7 +111,6 @@ def aggregate_results(
                                 aggregated.per_function[dec_name][func_key] = {}
                             aggregated.per_function[dec_name][func_key][metric_name] = is_perfect
 
-    # Compute aggregates
     for dec_name in all_values:
         aggregated.by_decompiler[dec_name] = {}
 

--- a/decbench/scoring/cost.py
+++ b/decbench/scoring/cost.py
@@ -43,18 +43,11 @@ __all__ = [
     "scan_structured_costs",
 ]
 
-#: Trace ``.md`` header lines written by ``llm_dec._save_trace``.
 _TRACE_MODEL_RE = re.compile(r"^- model:\s*(?P<model>.+?)\s*$", re.MULTILINE)
 _TRACE_STATUS_RE = re.compile(r"^- status:\s*(?P<status>ok|FAILED|TIMEOUT)\s*$", re.MULTILINE)
 _TRACE_ELAPSED_RE = re.compile(r"^- elapsed:\s*(?P<secs>\d+(?:\.\d+)?)s\s*$", re.MULTILINE)
 
-#: The four normalized token buckets every parser emits (pricing.toml's axes).
 _TOKEN_KEYS = ("input", "cached_input", "cache_write", "output")
-
-
-# ---------------------------------------------------------------------------
-# Batch decompile times (the traditional decompilers)
-# ---------------------------------------------------------------------------
 
 
 def _read_toml_header(path: Path) -> dict[str, Any] | None:
@@ -134,11 +127,6 @@ def scan_decompile_times(tree: Path, opt_levels: Iterable[str]) -> dict[str, dic
         }
         for dec in sorted(totals)
     }
-
-
-# ---------------------------------------------------------------------------
-# LLM session token parsing (shared with llm_dec's structured capture)
-# ---------------------------------------------------------------------------
 
 
 def _claude_session_tokens(records: list[dict[str, Any]]) -> dict[str, int] | None:
@@ -223,11 +211,6 @@ def parse_session_tokens(path: Path) -> dict[str, int] | None:
         _l.debug("cost: unreadable session log %s: %s", path, e)
         return None
     return _claude_session_tokens(records) or _codex_session_tokens(records)
-
-
-# ---------------------------------------------------------------------------
-# LLM per-function facts: trace scan (historical) + structured fields (new runs)
-# ---------------------------------------------------------------------------
 
 
 def _elapsed_stats(values: list[float]) -> dict[str, float]:
@@ -317,7 +300,7 @@ def scan_structured_costs(tree: Path, opt_levels: Iterable[str]) -> dict[str, di
         except OSError:
             continue
         if "time_seconds" not in text:
-            continue  # no structured fields — the trace scan's territory
+            continue
         try:
             data = toml.loads(text)
         except Exception:  # noqa: BLE001
@@ -325,7 +308,6 @@ def scan_structured_costs(tree: Path, opt_levels: Iterable[str]) -> dict[str, di
         dec = str(data.get("decompiler") or "")
         if not dec:
             continue
-        # The header `version` is "<model> (<cli version>)" for the LLM backends.
         if dec not in model:
             raw = str(data.get("version") or "")
             model[dec] = raw.split(" (")[0] or None
@@ -350,11 +332,6 @@ def scan_structured_costs(tree: Path, opt_levels: Iterable[str]) -> dict[str, di
         }
         for dec in sorted(elapsed)
     }
-
-
-# ---------------------------------------------------------------------------
-# The cost_info blob
-# ---------------------------------------------------------------------------
 
 
 def _discover_opt_levels(tree: Path) -> list[str]:
@@ -383,7 +360,7 @@ def build_cost_info(
     """
     opts = list(opt_levels) if opt_levels is not None else _discover_opt_levels(tree)
     llm = scan_llm_traces(traces_dir) if traces_dir is not None else {}
-    llm.update(scan_structured_costs(tree, opts))  # structured fields are preferred
+    llm.update(scan_structured_costs(tree, opts))
     return {
         "decompile_time": scan_decompile_times(tree, opts),
         "llm": llm,

--- a/decbench/scoring/datasets.py
+++ b/decbench/scoring/datasets.py
@@ -56,10 +56,6 @@ __all__ = [
     "DEFAULT_SAMPLE_SEED",
 ]
 
-# Fixed default seed for the `sample-set` sample so the selection is
-# reproducible across runs/machines. Override per call
-# (``assign_datasets(seed=...)``) or via the ``DECBENCH_SAMPLE_SEED``
-# environment variable to roll a different sample.
 DEFAULT_SAMPLE_SEED = 1337
 
 
@@ -81,9 +77,6 @@ def _resolve_seed(seed: int | None) -> int:
     return DEFAULT_SAMPLE_SEED
 
 
-#: The presets this module knows how to assign, in selector order. Names only:
-#: each one's label and description are the renderer's business (see the module
-#: docstring), and duplicating them here is how they drift.
 PRESETS: list[DatasetPreset] = [
     DatasetPreset(name="unoptimized"),
     DatasetPreset(name="optimized"),
@@ -96,10 +89,6 @@ _O2 = "O2"
 _O2_NOINLINE = "O2-noinline"
 _O0 = "O0"
 
-#: Binary labels that mark a group as built for a non-x86 (ARM) target. The CPS
-#: firmware projects all carry ``cps`` plus arch labels like ``armv7`` or
-#: ``cortex-m4``; the sailr packages and the malware targets are x86 (ELF or
-#: PE), so none of these labels appear there.
 _ARM_LABELS = frozenset({"cps", "arm", "armv7", "aarch64", "arm64", "bare-metal", "embedded-linux"})
 
 
@@ -220,11 +209,11 @@ def _sample_even(
                     if id(f) in chosen_fns:
                         continue
                     if g.project in exclude_projects:
-                        continue  # refill pass only: never pick the excluded project
+                        continue
                     if (g.project, g.opt_level, g.binary, f.function) in exclude_members:
-                        continue  # refill pass only: never re-pick a dropped member
+                        continue
                     if not _scoreable(f):
-                        continue  # phantom/unmeasurable row: never worth a slot
+                        continue
                     if one_per_binary and _binkey(g) in used_bins:
                         continue
                     idx = j
@@ -236,8 +225,8 @@ def _sample_even(
                     used_bins.add(_binkey(g))
                     advanced = True
 
-    pass_once(one_per_binary=True)  # at most one function per binary...
-    pass_once(one_per_binary=False)  # ...relaxed only if binaries run short
+    pass_once(one_per_binary=True)
+    pass_once(one_per_binary=False)
     return picked
 
 
@@ -324,7 +313,6 @@ def assign_datasets(
     records = _apply_opt_presets(function_data, k)
 
     if sample_members is not None:
-        # Frozen membership: tag exactly the manifest's functions, no draw.
         matched: set[tuple[str, str, str, str]] = set()
         for g, f in records:
             key = (g.project, g.opt_level, g.binary, f.function)
@@ -341,7 +329,6 @@ def assign_datasets(
         function_data.dataset_presets = [p.model_copy() for p in PRESETS]
         return function_data
 
-    # sample-set: even sample across five categories and across projects.
     rng = random.Random(_resolve_seed(seed))
     buckets = _sample_buckets(records, large_threshold(function_data, k=k))
     per_bucket = max(1, sample_total // len(buckets))
@@ -388,19 +375,11 @@ def topup_sample_members(
 
     buckets = _sample_buckets(records, large_threshold(function_data, k=k))
 
-    # Classify each removed pick into its MOST-SPECIFIC owning bucket, so the
-    # refill draws its replacement from the same bucket. The buckets overlap
-    # (`large` ⊂ `optimized`, `unoptimized-arm` ⊂ `unoptimized`) and each is
-    # quota-limited, so a pick the broad bucket left unpicked can still have
-    # been drawn by the specific one. Crediting the FIRST (broadest) match
-    # would zero the specific buckets' refill counts — every record is in one
-    # of the first three by opt level — and silently convert e.g. an ARM slot
-    # into a general unoptimized one, shrinking the sub-quota the bucket exists
-    # to guarantee. The refill loop below still runs in draw order so the rng
-    # stream is unchanged.
+    # Most-specific bucket wins: the buckets overlap and each is quota-limited, so
+    # crediting the broadest match would zero the specific buckets' refill counts
+    # and shrink the sub-quota they exist to guarantee.
     refill_per_bucket: dict[str, int] = {name: 0 for name in buckets}
     assigned: set[tuple[str, str, str, str]] = set()
-    # Pin the kept picks so the refill never reuses their functions/binaries.
     chosen: set[int] = set()
     used_bins: set[tuple[str, str, str]] = set()
     for name in reversed(list(buckets)):
@@ -416,10 +395,8 @@ def topup_sample_members(
                 assigned.add(key)
                 refill_per_bucket[name] += 1
 
-    # A removed pick whose record is GONE from the dataset entirely (a dropped
-    # or renamed function) appears in no bucket, so the loop above cannot credit
-    # it and its slot would silently vanish, leaving the manifest short. Charge
-    # those to the bucket their opt level belongs to.
+    # A removed pick whose record is gone entirely appears in no bucket, so charge
+    # it to its opt level's bucket or its slot silently vanishes.
     _OPT_BUCKET = {_O0: "unoptimized", _O2_NOINLINE: "optimized", _O2: "inlined"}
     for key in sorted(removed - assigned):
         bucket = _OPT_BUCKET.get(key[1])
@@ -432,8 +409,6 @@ def topup_sample_members(
         need = refill_per_bucket[name]
         if need <= 0:
             continue
-        # exclude_projects/exclude_members here are safe: `chosen`/`used_bins`
-        # already pin every surviving pick, so the skips cannot perturb them.
         for g, f in _sample_even(
             items, need, chosen, used_bins, rng, exclude_projects, exclude_members
         ):

--- a/decbench/scoring/function_data_builder.py
+++ b/decbench/scoring/function_data_builder.py
@@ -19,14 +19,10 @@ if TYPE_CHECKING:
     from decbench.models.project import OptimizationLevel, Project
 
 
-# Placeholder names a decompiler assigns to an address it could not resolve to a
-# real symbol (stripped binary). A universe row under such a name is a PHANTOM:
-# either a non-source function pulled in by a narrow-to-source miss, or a real
-# source function whose address failed to relabel (ARM Thumb T-bit / PE
-# ImageBase). Once _relabel_to_dwarf has run (with the Thumb + PE fixes), any
-# name still matching this and scoring NO metric for anyone is genuinely
-# non-source and must not become its own universe key that every other
-# decompiler is marked "failed" on.
+# Placeholder names a decompiler assigns to an address it could not resolve.
+# One that still matches after _relabel_to_dwarf AND scores no metric for anyone
+# is genuinely non-source, and must not become a universe key every other
+# decompiler is then marked failed on.
 _UNRESOLVED_NAME = re.compile(r"^(sub|FUN|fcn|loc|nullsub|unk|off|byte|word|dword|j)_[0-9a-fA-F]+$")
 
 
@@ -168,13 +164,9 @@ def build_function_data(
     """
     projects_by_name = {p.name: p for p in projects}
 
-    # The universe (which functions each decompiler produced) must be built even
-    # for a (project, opt, binary) that has NO eval section — e.g. a
-    # DECOMPILE_ONLY re-decompile whose inline metrics were skipped, to be layered
-    # back by the reeval scripts. Without this, such a binary/project is driven
-    # only by evaluation_results below and silently vanishes from the dataset
-    # (the historical "coreutils dropped" bug). Add empty eval cells for every
-    # decompiled binary so the loop reaches its decompile-derived universe.
+    # The universe must be built even for a (project, opt, binary) with NO eval
+    # section (e.g. a DECOMPILE_ONLY re-decompile), or such a binary is driven only
+    # by evaluation_results and silently vanishes from the dataset.
     evaluation_results = _with_decompile_cells(evaluation_results, decompile_results)
 
     decompilers_seen: set[str] = set()
@@ -190,7 +182,6 @@ def build_function_data(
             opt_value = opt_level.value if hasattr(opt_level, "value") else str(opt_level)
 
             for binary_name, dec_results in binary_results.items():
-                # records keyed by function name for this binary
                 records: dict[str, FunctionRecord] = {}
                 func_order: list[str] = []
 
@@ -216,14 +207,6 @@ def build_function_data(
                             if dist is not None:
                                 record.distances.setdefault(dec_name, {})[metric_name] = dist
 
-                # --- Decompile success/failure universe --------------------
-                # Record, per (function, decompiler), whether the decompiler
-                # actually produced output. The universe is every name any
-                # decompiler decompiled (plus explicit failures); a decompiler
-                # that didn't produce a universe function "errored" on it (failed
-                # or timed out). This makes a decompiler's metric denominator =
-                # the set it decompiled — one denominator across all metrics — and
-                # powers the Errors column + the normalize-failures view.
                 dec_map = _dec_results_for(decompile_results, project_name, opt_level, binary_name)
                 allfail_decs: set[str] = set()
                 for dec_name, dr in dec_map.items():
@@ -237,13 +220,6 @@ def build_function_data(
                     names = list(dr.functions.keys()) + [f for f in ff if f != "all"]
                     for fn in names:
                         if fn not in records:
-                            # Don't mint a phantom universe row for an unresolved
-                            # placeholder name that scored no metric for anyone
-                            # (records already holds everything that scored a
-                            # metric, since the metric loop above ran first).
-                            # These are non-source functions (narrow miss) or
-                            # unrelabeled addresses; a real source function is
-                            # relabeled to its DWARF name before this point.
                             if _is_unresolved_name(fn):
                                 continue
                             records[fn] = FunctionRecord(function=fn)
@@ -259,10 +235,7 @@ def build_function_data(
                             and dec_name not in rec.values
                             and fn not in (meta.failed_functions or [])
                         ):
-                            # Slice-scoped backend (LLM sample-set) never
-                            # attempted this function: no flag at all, not False.
                             continue
-                        # a computed metric implies the function was decompiled
                         rec.decompiled[dec_name] = bool(ok or dec_name in rec.values)
 
                 if project is not None:
@@ -270,7 +243,6 @@ def build_function_data(
                 else:
                     bin_labels = list(_opt_only_labels(opt_value))
 
-                # Assign function labels (inherit binary labels + auto labels)
                 for func_name in func_order:
                     line_count = _line_count_for(
                         decompile_results,

--- a/decbench/scoring/improvements.py
+++ b/decbench/scoring/improvements.py
@@ -38,12 +38,8 @@ class ImprovementCase:
     metric: str
 
     base_value: float
-    # None when the target produced no value for this metric on this function
-    # (e.g. it failed to decompile it) and ``include_target_missing`` is set.
     target_value: float | None
     base_perfect: bool
-    # Base's advantage magnitude (>= 0), always oriented "higher = base wins by
-    # more"; ``inf`` when the target is missing entirely.
     margin: float
     target_missing: bool
 
@@ -154,16 +150,14 @@ def find_improvement_cases(
         for rec in group.functions:
             base_value = rec.values.get(base, {}).get(metric)
             if base_value is None or not math.isfinite(base_value):
-                continue  # base must actually have a (finite) score to be winning
+                continue
             base_perfect = bool(rec.perfects.get(base, {}).get(metric, False))
             if perfect_only and not base_perfect:
                 continue
 
             target_value = rec.values.get(target, {}).get(metric)
-            # A non-finite target score (e.g. GED's ``inf`` error sentinel) is a
-            # tooling failure, not a place the target is genuinely worse — treat
-            # it exactly like a missing value so it is gated behind
-            # ``include_target_missing`` and never ranked as a real metric win.
+            # A non-finite target score is a tooling failure, not a place the target is
+            # genuinely worse, so treat it exactly like a missing value.
             if target_value is not None and not math.isfinite(target_value):
                 target_value = None
             target_missing = target_value is None
@@ -196,8 +190,6 @@ def find_improvement_cases(
             _resolve_locations(group_cases, results_root, base, target, fd.decompilers)
         cases.extend(group_cases)
 
-    # Largest base advantage first (target-missing → inf sorts first), then a
-    # stable secondary order so equal-margin rows are deterministic.
     cases.sort(
         key=lambda c: (
             -c.margin if math.isfinite(c.margin) else float("-inf"),
@@ -232,10 +224,6 @@ def _resolve_locations(
     comp = results_tree.compiled_dir(results_root, g.opt_level, g.project)
     binary_path = results_tree.resolve_binary(comp, g.binary)
 
-    # Addresses are decompiler-emitted (in the .c header). Any decompiler that
-    # decompiled the function has the same file-space address, so try the base
-    # first, then the target, then any other decompiler's artifact for this
-    # binary until every function is located.
     addr_map: dict[str, int] = {}
     tried: set[str] = set()
     wanted = {c.function for c in group_cases}
@@ -306,7 +294,6 @@ def render_text(
     addr_w = max(addr_w, 3)
     func_w = min(max(len(c.function) for c in cases), 48)
 
-    # Group consecutive cases by (project, opt, binary) preserving margin order.
     last_key: tuple[str, str, str] | None = None
     for c in cases:
         key = (c.project, c.opt_level, c.binary)

--- a/decbench/scoring/report_extras.py
+++ b/decbench/scoring/report_extras.py
@@ -33,13 +33,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Label carried by every :class:`BinaryGroup` built from an ``is_malware``
-#: project (see ``projects/malware/*.toml``). It is the render-time signal that
-#: a function's code is REAL MALWARE source.
+# The render-time signal that a function's code is REAL MALWARE source.
 MALWARE_LABEL = "malware"
 
-#: Opt-OUT switch: set ``DECBENCH_PUBLISH_MALWARE=1`` to put malware code back
-#: into the report payloads. Default is to EXCLUDE.
+# Opt-OUT switch: default is to EXCLUDE malware code from report payloads.
 PUBLISH_MALWARE_ENV = "DECBENCH_PUBLISH_MALWARE"
 
 
@@ -191,7 +188,6 @@ def _lookup_decompiled(
             return None
         binary_results = opt_results.get(opt_level)
         if binary_results is None:
-            # Fall back to matching by string value of the opt key.
             ov = _opt_value(opt_level)
             for key, val in opt_results.items():
                 if _opt_value(key) == ov:
@@ -360,7 +356,6 @@ def build_hardest(
         excluded = set()
     dropped: Counter[str] = Counter()
 
-    # (metric, dec) -> list of candidate dicts
     buckets: dict[tuple[str, str], list[dict[str, Any]]] = {}
     perfect_cache: dict[str, float] = {}
 
@@ -384,7 +379,7 @@ def build_hardest(
                                 continue
                             distance = abs(value - perfect)
                             if distance == 0.0:
-                                continue  # perfect ⇒ not "hard"
+                                continue
                             buckets.setdefault((metric_name, dec_name), []).append(
                                 {
                                     "metric": metric_name,
@@ -402,7 +397,6 @@ def build_hardest(
 
     entries: list[HardestEntry] = []
     for (metric_name, dec_name), candidates in buckets.items():
-        # Worst first: farthest from perfect, then larger raw value as tiebreak.
         candidates.sort(key=lambda c: (c["distance"], c["value"]), reverse=True)
         kept = 0
         for c in candidates:
@@ -417,7 +411,7 @@ def build_hardest(
                 c["function"],
             )
             if not code:
-                continue  # require code to be worth showing
+                continue
             size = _lookup_line_count(
                 decompile_results,
                 c["project"],
@@ -531,8 +525,6 @@ def build_samples(
     if samples:
         return samples
 
-    # Fallback for corpora the tiers cannot see (single-decompiler runs, no GED):
-    # untiered samples of any function with decompiled code, bounded like before.
     limit = per_tier
     for group in function_data.groups:
         if len(samples) >= limit:
@@ -659,7 +651,7 @@ def build_sample_set_samples(
                 if code:
                     decompiled[dec] = code
             if not decompiled:
-                continue  # nothing to show (or only hidden-decompiler output)
+                continue
             binary = reader.binary(group.opt_level, group.project, group.binary)
             source, source_status = function_source_ex(binary, record.function)
             samples.append(
@@ -743,7 +735,6 @@ def build_history(
                     )
                 )
                 continue
-            # Tuple / list form.
             seq = list(item)
             if len(seq) < 2:
                 continue
@@ -782,8 +773,6 @@ def attach_extras(
     default — see :func:`publish_malware_allowed`. The score/aggregate path is
     deliberately untouched: malware functions still count in every metric.
     """
-    # Derived once from the label signal (+ is_malware when projects are given)
-    # and shared by both code-carrying builders.
     excluded = malware_projects(function_data, projects)
 
     try:
@@ -803,9 +792,6 @@ def attach_extras(
         except Exception:
             function_data.history = []
 
-    # Tag each function with its dataset presets (unoptimized/optimized/inlined/
-    # large/sample-set) so the report shows a single dataset selector instead of
-    # many toggles.
     try:
         from decbench.scoring.datasets import assign_datasets
 
@@ -813,8 +799,6 @@ def attach_extras(
     except Exception:
         pass
 
-    # Difficulty-tiered View samples (original source vs each decompiler's
-    # output; easy/medium/hard from cross-decompiler GED agreement).
     try:
         function_data.samples = build_samples(
             function_data, decompile_results, excluded_projects=excluded
@@ -822,7 +806,6 @@ def attach_extras(
     except Exception:
         function_data.samples = []
 
-    # Per-decompiler recompilation (compilability) rate for the Metrics page.
     try:
         function_data.compile_rates = compute_compile_rates(evaluation_results)
     except Exception:

--- a/decbench/scoring/scoreboard.py
+++ b/decbench/scoring/scoreboard.py
@@ -139,7 +139,6 @@ def build_scoreboard(
         total_binaries=aggregated.total_binaries,
     )
 
-    # Build per-decompiler scores
     for dec_name in decompilers:
         if dec_name not in aggregated.by_decompiler:
             continue
@@ -152,7 +151,6 @@ def build_scoreboard(
             total_binaries_evaluated=aggregated.total_binaries,
         )
 
-        # Per-metric scores
         for metric_name, agg_metric in dec_metrics.items():
             ms = MetricScore(
                 metric_name=metric_name,
@@ -165,10 +163,8 @@ def build_scoreboard(
             )
             dec_score.metric_scores[metric_name] = ms
 
-        # Compute Union: functions perfect on AT LEAST ONE metric, counted over
-        # functions that were evaluated on at least one metric. A function whose
-        # metrics all abstained (nothing measurable) is EXCLUDED rather than
-        # counted as a failure — "couldn't measure" != "wrong".
+        # Counted over functions evaluated on at least one metric: a function whose
+        # metrics all abstained is EXCLUDED, not counted as a failure.
         per_func = aggregated.per_function.get(dec_name, {})
         all_metric_names = aggregated.metrics
 
@@ -191,13 +187,11 @@ def build_scoreboard(
 
         scoreboard.decompiler_scores[dec_name] = dec_score
 
-    # Assign ranks per metric
     for metric_name in aggregated.metrics:
         rankings = scoreboard.get_metric_rankings(metric_name)
         for rank, (dec_name, _) in enumerate(rankings, 1):
             scoreboard.decompiler_scores[dec_name].metric_scores[metric_name].rank = rank
 
-    # Assign overall ranks
     overall_rankings = scoreboard.get_overall_rankings()
     for rank, (dec_name, _) in enumerate(overall_rankings, 1):
         scoreboard.decompiler_scores[dec_name].overall_rank = rank

--- a/decbench/scoring/view_samples.py
+++ b/decbench/scoring/view_samples.py
@@ -33,9 +33,6 @@ import random
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-# Same-package internals: the sample-set's even-spread sampler and seed
-# resolution, reused so the tiers obey the identical project/binary spread
-# rules as the dataset presets.
 from decbench.scoring.datasets import _resolve_seed, _sample_even
 
 if TYPE_CHECKING:
@@ -43,12 +40,8 @@ if TYPE_CHECKING:
 
 __all__ = ["DIFFICULTY_TIERS", "select_view_functions"]
 
-#: Tier names, in display order.
 DIFFICULTY_TIERS = ("easy", "medium", "hard")
 
-#: At most this many hard-tier candidates come from any one project, so a single
-#: pathological project cannot fill the whole tier. Relaxed only if the tier
-#: would otherwise come up short.
 _HARD_PER_PROJECT_CAP = 10
 
 
@@ -135,7 +128,6 @@ def select_view_functions(
         "medium": _sample_even(medium_pool, quota, chosen, used_bins, rng),
     }
 
-    # hard: worst-first, capped per project (relax the cap only if short).
     hard_pool.sort(key=lambda t: -t[2])
     picked: list[tuple[BinaryGroup, FunctionRecord]] = []
     per_project: dict[str, int] = {}

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -30,16 +30,15 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-# ELF e_machine / PE COFF machine -> short arch name.
 _ELF_MACHINES = {0x28: "arm", 0xB7: "aarch64", 0x3E: "x86-64", 0x03: "x86", 0xF3: "riscv"}
 _PE_MACHINES = {0x14C: "x86", 0x8664: "x86-64", 0xAA64: "aarch64", 0x1C0: "arm"}
 
 
 @dataclass
 class BinInfo:
-    fmt: str  # "elf" | "pe"
-    arch: str  # "x86" | "x86-64" | "arm" | "aarch64" | ...
-    bits: int  # 32 | 64
+    fmt: str
+    arch: str
+    bits: int
 
 
 def detect(path: Path) -> BinInfo | None:
@@ -47,7 +46,7 @@ def detect(path: Path) -> BinInfo | None:
     try:
         with open(path, "rb") as f:
             head = f.read(2)
-            if head == b"\x7fE":  # ELF
+            if head == b"\x7fE":
                 f.seek(0)
                 if f.read(4) != b"\x7fELF":
                     return None
@@ -55,7 +54,7 @@ def detect(path: Path) -> BinInfo | None:
                 arch = _ELF_MACHINES.get(struct.unpack("<H", f.read(2))[0], "other")
                 bits = 64 if arch in ("x86-64", "aarch64") else 32
                 return BinInfo("elf", arch, bits)
-            if head == b"MZ":  # PE
+            if head == b"MZ":
                 f.seek(0x3C)
                 pe_off = struct.unpack("<I", f.read(4))[0]
                 f.seek(pe_off)
@@ -94,13 +93,9 @@ def tool_available(name: str) -> bool:
     return shutil.which(name) is not None
 
 
-# Codegen-relevant flags to carry over from the original build (NOT -g; we add
-# it). Besides -m*/-O*, a whitelist of -f flags that change emitted code:
-# dropping them made byte_match unwinnable for whole projects (openssh's
-# -fzero-call-used-regs=all pads every epilogue with zeroing, its -ftrapv turns
-# arithmetic into __addv* calls; sysvinit's -fomit-frame-pointer switches every
-# stack access from rbp- to rsp-relative). Header-independent, codegen-only
-# flags only — nothing here affects parsing or needs libc headers.
+# Codegen-relevant flags carried over from the original build (never -g). Only
+# codegen-only, header-independent flags: dropping them made byte_match
+# unwinnable for whole projects (e.g. -fzero-call-used-regs, -fomit-frame-pointer).
 _FLAG_RE = re.compile(
     r"(?:^|\s)(-m(?:arch|tune|cpu|thumb|float-abi|fpu|abi)?=?\S*|-O[0-3sgz]?"
     r"|-f(?:no-)?(?:omit-frame-pointer|zero-call-used-regs=\S+|trapv|wrapv"
@@ -129,7 +124,6 @@ def producer_flags(path: Path) -> list[str]:
                 continue
             text = prod.value.decode() if isinstance(prod.value, bytes) else str(prod.value)
             flags = [m.group(1).strip() for m in _FLAG_RE.finditer(text)]
-            # -masm=att is asm-syntax only (no codegen effect); drop it.
             return [f for f in flags if f and not f.startswith("-masm")]
     except Exception:
         pass
@@ -149,8 +143,6 @@ def capstone_arch_mode(info: BinInfo, thumb: bool = False):
         return capstone.CS_ARCH_ARM64, capstone.CS_MODE_ARM
     return None
 
-
-# --- DWARF (ELF or PE) -------------------------------------------------------
 
 _DWARF_SECS = (
     ".debug_info",
@@ -242,7 +234,6 @@ def dwarf_info(path: Path):
         return None
     if info.fmt == "pe":
         return pe_dwarf_info(path)
-    # ELF: read the debug sections into memory, build a self-contained DWARFInfo.
     try:
         from elftools.elf.elffile import ELFFile
 
@@ -264,9 +255,6 @@ def dwarf_info(path: Path):
             return _build_dwarfinfo(secs, elf.little_endian, addr_size, march)
     except Exception:
         return None
-
-
-# --- function bytes ----------------------------------------------------------
 
 
 def _dwarf_function_range(path: Path, func_name: str) -> tuple[int, int] | None:
@@ -300,7 +288,6 @@ def function_bytes(path: Path, func_name: str, address: int) -> bytes | None:
         b = _elf_function_bytes(path, func_name, address)
         if b is not None:
             return b
-    # DWARF-range + content-at-VA (works for PE, and ELF as a fallback).
     rng = _dwarf_function_range(path, func_name)
     if rng is None:
         return None
@@ -345,13 +332,11 @@ def object_text_bytes(obj_path: Path, func_name: str) -> bytes | None:
     byte_match compiles one function, so the object's ``.text`` is essentially
     that function (alignment padding is dropped by the disassembler's nop skip).
     """
-    # ELF object: precise symtab extraction (existing behaviour).
     info = detect(obj_path)
     if info is not None and info.fmt == "elf":
         b = _elf_object_function(obj_path, func_name)
         if b is not None:
             return b
-    # COFF (MinGW) object, or ELF fallback: take the .text section via LIEF.
     try:
         import lief
 

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -18,16 +18,12 @@ if TYPE_CHECKING:
 
 _LINE_MARKER = re.compile(r'^#\s+\d+\s+"([^"]*)"')
 
-# Aggregate/array return type: ``unsigned int [4] name(`` -> ``unsigned int name(``.
-# angr/ghidra render a by-value aggregate/array return as ``T [N] name(...)``
-# which is not valid C, so Joern parses NOTHING for such a function and it silently
-# drops out of GED's denominator. Anchored at line start (re.M) so it only ever
-# rewrites a top-level function SIGNATURE, never an in-body array declaration such as
-# ``char buf[16];`` (which is indented and/or not followed by an identifier + ``(``).
+# ``T [N] name(...)`` is not valid C, so Joern parses nothing for such a function
+# and it silently drops out of GED's denominator. Anchored at line start so it
+# only rewrites a signature, never an in-body ``char buf[16];``.
 _AGG_RETURN = re.compile(r"^([A-Za-z_][\w ]*?)\s*\[\d+\]\s+([A-Za-z_]\w*\s*\()", re.M)
 
-# Binary Ninja register annotations: ``char arg3 @ rax`` -> ``char arg3``. ``@`` is
-# not legal C, so its presence breaks Joern's parse for the whole function.
+# ``@`` is not legal C and breaks Joern's parse for the whole function.
 _REG_ANNOTATION = re.compile(r"\s*@\s*[a-z]\w+\b")
 
 
@@ -82,12 +78,12 @@ def strip_system_headers(preprocessed: str) -> str:
     code that was compiled (the right ifdef branches) — fair and small.
     """
     keep: list[str] = []
-    in_system = True  # before the first marker
+    in_system = True
     for line in preprocessed.splitlines():
         m = _LINE_MARKER.match(line)
         if m is not None:
             in_system = _is_system_header(m.group(1))
-            continue  # drop the marker line itself
+            continue
         if not in_system:
             keep.append(line)
     return "\n".join(keep) + "\n"
@@ -189,10 +185,8 @@ def extract_cfgs_from_source(
         )
 
     cfgs = {}
-    # Always parse via a UNIQUE temp .c: Joern names its workspace after the input
-    # file's basename, so parsing the same filename concurrently (e.g. the same
-    # function file across opt levels) would collide. A unique temp name avoids
-    # that. For .i we also strip the inlined system headers first.
+    # Joern names its workspace after the input basename, so a unique temp name is
+    # what keeps concurrent parses of the same filename from colliding.
     temp_c_path = Path(tempfile.mktemp(suffix=".c"))
     if source_path.suffix == ".i":
         temp_c_path.write_text(strip_system_headers(source_path.read_text(errors="replace")))
@@ -204,13 +198,11 @@ def extract_cfgs_from_source(
     parse_path = temp_c_path
 
     try:
-        # parse_source returns dict[str, Function] or dict[tuple[str,str], Function]
         parsed = parse_source(parse_path)
 
         if parsed is None:
             return cfgs
 
-        # Extract CFGs for each function
         for key, func in parsed.items():
             func_name = func.name if hasattr(func, "name") else str(key)
             cfg = func.cfg if hasattr(func, "cfg") else None
@@ -247,10 +239,7 @@ def extract_cfgs_from_decompilation(
 
     cfgs = {}
 
-    # Write decompiled code to temp file and parse
     with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
-        # Write all functions, sanitizing decompiler-specific C quirks that would
-        # otherwise break Joern's parse and drop the function from GED coverage.
         for func in decompilation.functions.values():
             f.write(f"// Function: {func.name}\n")
             f.write(sanitize_decompiled_c(func.decompiled_code))
@@ -275,66 +264,3 @@ def extract_cfgs_from_decompilation(
         temp_path.unlink(missing_ok=True)
 
     return cfgs
-
-
-def cfg_to_dict(cfg: DiGraph) -> dict:  # type: ignore
-    """Convert a CFG to a serializable dictionary.
-
-    Args:
-        cfg: NetworkX DiGraph
-
-    Returns:
-        Dictionary representation
-    """
-    return {
-        "nodes": list(cfg.nodes()),
-        "edges": list(cfg.edges()),
-        "node_count": cfg.number_of_nodes(),
-        "edge_count": cfg.number_of_edges(),
-    }
-
-
-def compute_cfg_stats(cfg: DiGraph) -> dict:  # type: ignore
-    """Compute statistics about a CFG.
-
-    Args:
-        cfg: NetworkX DiGraph
-
-    Returns:
-        Dictionary of statistics
-    """
-    import networkx as nx
-
-    nodes = cfg.number_of_nodes()
-    edges = cfg.number_of_edges()
-
-    stats = {
-        "nodes": nodes,
-        "edges": edges,
-        "size": nodes + edges,
-        "cyclomatic_complexity": edges - nodes + 2,
-    }
-
-    # Try to compute more stats
-    try:
-        if nodes > 0:
-            stats["density"] = nx.density(cfg)
-
-            # Find entry and exit nodes
-            in_degrees = dict(cfg.in_degree())
-            out_degrees = dict(cfg.out_degree())
-
-            entry_nodes = [n for n, d in in_degrees.items() if d == 0]
-            exit_nodes = [n for n, d in out_degrees.items() if d == 0]
-
-            stats["entry_nodes"] = len(entry_nodes)
-            stats["exit_nodes"] = len(exit_nodes)
-
-            # Average branching factor
-            if nodes > 0:
-                stats["avg_out_degree"] = sum(out_degrees.values()) / nodes
-
-    except Exception:
-        pass
-
-    return stats

--- a/decbench/utils/results_tree.py
+++ b/decbench/utils/results_tree.py
@@ -26,11 +26,8 @@ from pathlib import Path
 
 from decbench.utils import binfmt
 
-# The header comment DecompilationResult.to_c_file writes before each function
-# block: ``// Function: <name> @ 0x<addr>``.
 FUNCTION_MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
 
-# Optimization sub-directories a results tree can contain (top level, per-opt).
 OPT_LEVELS = ("O0", "O2", "O2-noinline")
 
 

--- a/decbench/utils/source_extract.py
+++ b/decbench/utils/source_extract.py
@@ -48,10 +48,8 @@ def _dwarf_decl(binary_path: Path) -> dict[str, tuple[str, int]]:
             dw = elf.get_dwarf_info()
             for cu in dw.iter_CUs():
                 lp = dw.line_program_for_CU(cu)
-                # DW_AT_decl_file indexing differs by DWARF version: pre-v5 is
-                # 1-based (entry 0 is unused), v5 is 0-based (entry 0 is the
-                # primary source). Prepend a placeholder only for pre-v5 so the
-                # index lines up either way.
+                # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
+                # makes the index line up either way.
                 version = 4
                 if lp is not None:
                     version = lp.header.get("version", cu.header.get("version", 4))
@@ -175,33 +173,28 @@ def extract_from_text(text: str, func_name: str, decl_line: int = 0) -> str | No
     """
     pat = re.compile(r"(^|[^\w])" + re.escape(func_name) + r"\s*\(")
     lines = text.splitlines(keepends=True)
-    # Precompute byte offset of each line start for decl_line proximity.
     offsets = []
     acc = 0
     for ln in lines:
         offsets.append(acc)
         acc += len(ln)
 
-    # (proximity, signature_start_offset, body_end_offset)
     candidates: list[tuple[int, int, int]] = []
     for m in pat.finditer(text):
         paren = text.index("(", m.start())
         close = _match_paren(text, paren)
         if close is None:
             continue
-        # The next non-space char after ')' decides definition vs prototype.
         j = close + 1
         while j < len(text) and text[j] in " \t\r\n":
             j += 1
         if j >= len(text):
             continue
         if text[j] == ";":
-            continue  # prototype / forward declaration, never a definition
+            continue
         if text[j] != "{":
-            # Possible K&R definition. The ';' guard above is essential: an
-            # empty/bare-param prototype would otherwise let the loose scan below
-            # stitch across to an unrelated later '{'. Accept only a bare-
-            # identifier param list, then a run of ';'-terminated declarations.
+            # The ';' guard above is essential: an empty/bare-param prototype would let the
+            # loose scan below stitch across to an unrelated later '{'.
             params = text[paren + 1 : close]
             if not re.fullmatch(r"[\s\w,]*", params):
                 continue
@@ -209,14 +202,8 @@ def extract_from_text(text: str, func_name: str, decl_line: int = 0) -> str | No
             if body is None:
                 continue
             j = body
-        # Reject if this looks like a call inside another body: require the
-        # token before the name (ignoring the return type) to start a logical
-        # line — i.e. the line's first non-space isn't itself a statement.
-        line_no = text.count("\n", 0, m.start())  # 0-based
-        # Find start of the signature: walk back to the line that begins the
-        # return type (previous blank line or '}' / ';').
+        line_no = text.count("\n", 0, m.start())
         sig_start = text.rfind("\n", 0, m.start())
-        # extend upward over the return-type line(s)
         k = line_no
         while k > 0:
             prev = lines[k - 1].strip()
@@ -255,10 +242,6 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
     if binary_path is None:
         return None, "binary_not_found"
     binary_path = Path(binary_path)
-    # A missing binary only loses the DWARF *hint* (_dwarf_decl swallows the open
-    # failure); the sibling sources may still hold the function — e.g. a partial
-    # results snapshot whose artifacts were pruned but whose .c/.i were kept. Only
-    # a missing directory means there is nothing to search at all.
     if not binary_path.parent.is_dir():
         return None, "binary_not_found"
 
@@ -274,8 +257,6 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
         if not sources:
             continue
         any_sources = True
-        # Prefer the DWARF-named file (matched on stem, since decl_file is foo.c
-        # but the preprocessed file is foo.i), then any file containing the name.
         ordered: list[Path] = []
         if decl_stem:
             ordered = [p for p in sources if p.stem == decl_stem]
@@ -289,8 +270,7 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
             if func_name not in text:
                 continue
             found_name = True
-            # decl_line indexes the original .c; it does not correspond to the
-            # preprocessed .i line numbers, so only use it as a hint for .c.
+            # decl_line indexes the original .c, not the preprocessed .i line numbers.
             line_hint = decl_line if (ext == ".c" and p.stem == decl_stem) else 0
             snippet = extract_from_text(text, func_name, line_hint)
             if snippet:

--- a/docker/r2dec-decompile.py
+++ b/docker/r2dec-decompile.py
@@ -32,7 +32,6 @@ import r2pipe
 
 _R2_FLAGS = ["-2", "-e", "bin.relocs.apply=true", "-e", "scr.color=0"]
 
-# r2 names for the ELF/PE entry alias (== _start / CRT entry), not user code.
 _ENTRY_NAMES = frozenset({"entry0", "entry1", "entry.init0", "entry.fini0", "entry.preinit0"})
 
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -195,6 +195,24 @@ DECBENCH_WORKERS=40 GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1 \
 - `DECBENCH_OPT_LEVELS` (comma list, e.g. `"O0"` to narrow the run)
 - `DECBENCH_METRICS` (comma list, e.g. `"ged"` for a GED-only run)
 
+### Per-decompiler wall-clock budgets
+
+`DECOMPILER_TIMEOUT` in `scripts/run_benchmark.py` overrides
+`DECBENCH_DECOMPILE_TIMEOUT` per backend (each with its own
+`DECBENCH_<NAME>_TIMEOUT` env override). The fairness principle: every backend
+gets enough time to finish the largest source-function set, so a slow-but-working
+one is not truncated and counted as thousands of failures while a faster one
+finishes. Small binaries finish in seconds, so these defaults only bite the ~10
+big targets (bash, openssh, coreutils, the large ARM firmware).
+
+| Backend | Default | Why |
+| --- | --- | --- |
+| `angr` | 3600 s | ~15-20 s/function; a big binary legitimately needs ~1 h. |
+| `ghidra` / `binja` / `r2dec` | 1800 s | Fast per function, but a few large binaries overrun 300 s. r2dec's `aaa` analysis alone can run minutes. |
+| `kuna` | 900 s | Emits its JSON only at the very end, so a kill yields ZERO functions; needs a budget above its slowest binary (~450 s on bash). Its per-FUNCTION guard is `--max-fn-seconds`, passed by the backend. |
+| `dewolf` | 1200 s | A z3/sympy simplification pipeline that blows up per function. Capped lower than angr because the cap bounds *hangs*, not a slow-but-progressing decompile. |
+| `codex` / `claude-code` / `kimi-code` | 3600 s | One agentic CLI call per function (~minutes). The backend checkpoints after each function, so a large budget bounds a stuck call while still crediting finished ones. |
+
 Resume MERGES per project AND per decompiler:
 `DECBENCH_DECOMPILERS=r2dec python scripts/run_benchmark.py results/full_run`
 ADDS r2dec (or dewolf) to every project's checkpoint without re-running the

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -84,8 +84,8 @@ from decbench.models.decompilation import (
 | `get_version(self) -> str \| None` | The realized version string (shown in the report). |
 | `decompile_binary(self, binary_path, functions=None, output_dir=None, function_names=None, progress_path=None) -> DecompilationResult` | The core method. |
 
-`discover_functions`, `decompile_function`, and `cleanup` have usable defaults;
-override them only if helpful.
+`decompile_function` has a usable default (it calls `decompile_binary` with a
+single target); override it only if helpful.
 
 ### `decompile_binary` signature — match it exactly
 

--- a/scripts/compile_all.py
+++ b/scripts/compile_all.py
@@ -21,16 +21,10 @@ from pathlib import Path
 from decbench.models.project import OptimizationLevel, Project
 from decbench.pipeline.compile import compile_project
 
-# Use 'spawn': fresh worker processes with no inherited lock state. The default
 # 'fork' deadlocks when a worker is forked while the parent's pool-management
-# thread holds an internal mutex (observed: late workers wedged on futex_wait
-# with downloads done but never extracted).
+# thread holds an internal mutex.
 _MP = multiprocessing.get_context("spawn")
 
-# All benchmark project dirs (top-level *.toml only; cps/disabled/ is excluded
-# since glob is non-recursive). sailr is x86 (host-compilable); cps (ARM) and
-# malware (ARM/PE) need the cross/mingw toolchains, so those are compiled inside
-# the decbench-cps-toolchain Docker image. Restrict with the trailing `only` args.
 PROJECT_DIRS = [Path("projects/sailr"), Path("projects/cps"), Path("projects/malware")]
 
 
@@ -117,7 +111,7 @@ def _build_one(toml_path: str, opt_value: str, out_dir: str) -> dict:
 def main() -> int:
     out_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("results/sailr_full")
     workers = int(sys.argv[2]) if len(sys.argv) > 2 else 78
-    only = set(sys.argv[3:])  # optional: restrict to these project stems
+    only = set(sys.argv[3:])
 
     out_dir.mkdir(parents=True, exist_ok=True)
     tomls = gather_tomls()
@@ -148,7 +142,6 @@ def main() -> int:
                 flush=True,
             )
 
-    # Per-project summary across opt levels
     by_proj: dict[str, dict[str, int]] = {}
     for r in reports:
         by_proj.setdefault(r["project"], {})[r["opt"]] = r["elf_binaries"]

--- a/scripts/compute_cost_info.py
+++ b/scripts/compute_cost_info.py
@@ -58,8 +58,8 @@ def main() -> None:
             f"{_fmt_secs(elapsed.get('median_s'))}  {entry['functions']} ({note})"
         )
 
-    # Guarded write (decbench.results_store): this script only ADDS cost_info, so
-    # any coverage regression the guard reports means the file changed under us.
+    # This script only ADDS cost_info, so any coverage regression the guard reports
+    # means the file changed under us.
     from decbench.results_store import write_function_data_guarded
 
     write_function_data_guarded(fd, root)

--- a/scripts/compute_dataset_info.py
+++ b/scripts/compute_dataset_info.py
@@ -23,8 +23,8 @@ from pathlib import Path
 
 from decbench.models.function_data import FunctionData
 
-OPT_FOR_LOC = "O0"  # source is identical across opt levels; count once
-SKIP_C = ("conftest.c",)  # autoconf probe noise
+OPT_FOR_LOC = "O0"
+SKIP_C = ("conftest.c",)
 
 
 def count_loc(root: Path) -> tuple[int, dict[str, int]]:
@@ -61,7 +61,6 @@ def sample_i_files(root: Path, per_project: int) -> list[Path]:
         cand = sorted(
             f for f in comp.glob("*.i") if "conftest" not in f.name and not f.name.startswith("a-")
         )
-        # spread across the project's units rather than taking the first N
         if len(cand) > per_project:
             step = len(cand) / per_project
             cand = [cand[int(i * step)] for i in range(per_project)]
@@ -140,14 +139,13 @@ def main() -> None:
         "loc_by_project": loc_by_project,
         "joern": joern,
     }
-    # Guarded write (decbench.results_store): this script only ADDS dataset_info,
-    # so any coverage regression the guard reports means the file changed under us.
+    # This script only ADDS dataset_info, so any coverage regression the guard
+    # reports means the file changed under us.
     from decbench.results_store import write_function_data_guarded
 
     write_function_data_guarded(fd, root)
     print("[dataset] wrote dataset_info into function_results.json", flush=True)
-    # Hard-exit so any still-running (slow/hung) Joern worker threads can't block
-    # the interpreter from exiting on the thread join.
+    # Hard-exit so a hung Joern worker thread cannot block interpreter shutdown.
     os._exit(0)
 
 

--- a/scripts/cps_compile_smoke.py
+++ b/scripts/cps_compile_smoke.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from decbench.models.project import Project
 from decbench.pipeline.compile import compile_project
 
-# ELF e_machine values we care about.
 _EM = {0x28: "ARM", 0xB7: "AArch64", 0x3E: "x86-64", 0x03: "x86"}
 
 

--- a/scripts/decompile_one.py
+++ b/scripts/decompile_one.py
@@ -27,8 +27,8 @@ from decbench.pipeline.decompile import decompile_binary
 
 def main() -> int:
     binary, dec_name, out_dir, pkl_out = sys.argv[1:5]
-    # The binary handed to us is a STRIPPED copy (no symbols), so the filter is a
-    # JSON list of target ADDRESSES (DWARF low_pc), not names.
+    # The binary is a STRIPPED copy, so the filter is a JSON list of target
+    # ADDRESSES (DWARF low_pc), not names.
     target_addrs: set[int] | None = None
     if len(sys.argv) > 5 and sys.argv[5] not in ("", "NONE"):
         try:
@@ -36,9 +36,8 @@ def main() -> int:
             target_addrs = {int(a) for a in loaded} or None
         except Exception:
             target_addrs = None
-    # Write partial progress straight to the output pickle, so if the
-    # orchestrator kills this process on timeout, the functions completed so far
-    # are still recoverable. The final write below replaces it atomically.
+    # Partial progress goes straight to the output pickle so a timeout kill still
+    # leaves the finished functions recoverable; the final write replaces it.
     result = decompile_binary(
         Path(binary),
         dec_name,

--- a/scripts/export_sample_set.py
+++ b/scripts/export_sample_set.py
@@ -88,7 +88,6 @@ def collect_sample_set(
     ``--base`` manifest is given); to preserve an existing manifest's picks use
     :func:`topup_from_base`.
     """
-    # seed=None -> DEFAULT_SAMPLE_SEED (1337)
     assign_datasets(fd, seed=seed)
     members = {
         (g.project, g.opt_level, g.binary, f.function)
@@ -194,7 +193,6 @@ def main() -> int:
         out = fr_json.parent / "sample_set_manifest.json"
 
     excluded = frozenset(exclude)
-    # One parse of the (large) dataset for both the presence check and the draw.
     fd = FunctionData.from_json(fr_json)
     present = {g.project for g in fd.groups}
     for name in sorted(excluded - present):
@@ -209,7 +207,6 @@ def main() -> int:
 
     drop_members: frozenset[tuple[str, str, str, str]] = frozenset()
     if base is not None and base.is_file():
-        # Top-up: preserve the base manifest's surviving picks, refill freed slots.
         base_members = {_key(e) for e in json.loads(base.read_text()).get("functions", [])}
         if drop_unscoreable:
             drop_members = unscoreable_members(fd, base_members)
@@ -244,7 +241,6 @@ def main() -> int:
 
     manifest.to_json(out)
 
-    # Report the shape so the operator can sanity-check the slice.
     by_opt: dict[str, int] = {}
     by_proj: dict[str, int] = {}
     for e in manifest.functions:

--- a/scripts/finalize_results.py
+++ b/scripts/finalize_results.py
@@ -26,8 +26,8 @@ import multiprocessing
 import sys
 from pathlib import Path
 
-# Match the run drivers: 'fork' deadlocks once angr's threads are live, and library
-# code reached from here may create pools.
+# 'fork' deadlocks once angr's threads are live, and library code reached from
+# here may create pools.
 if multiprocessing.get_start_method(allow_none=True) != "spawn":
     multiprocessing.set_start_method("spawn", force=True)
 

--- a/scripts/ingest_history.py
+++ b/scripts/ingest_history.py
@@ -30,9 +30,6 @@ from pathlib import Path
 from decbench.models.function_data import FunctionData, HistoryPoint
 from decbench.scoring.scoreboard import build_scoreboard_from_function_data
 
-# Best-known Ghidra release dates (published date of the labeled line), for the
-# HistoryPoint.date metadata. The chart orders by version, not date, so a missing
-# entry only drops the tooltip date, never the point.
 _GHIDRA_DATES = {
     "10.4": "2023-09-29",
     "11.0": "2023-12-22",
@@ -82,7 +79,7 @@ def build_points(run_dir: Path, base: str, metrics: list[str] | None) -> list[Hi
                 ),
             )
         )
-    points.sort(key=lambda t: t[0])  # oldest version first
+    points.sort(key=lambda t: t[0])
     return [p for _k, p in points]
 
 
@@ -118,8 +115,6 @@ def main() -> int:
 
     target_path = args.target_dir / "function_results.json"
     fd = FunctionData.from_json(target_path)
-    # --replace clears everything; otherwise drop only this base's existing points
-    # (re-ingest is idempotent) and keep any other bases'.
     kept = [] if args.replace else [h for h in fd.history if h.decompiler != args.base]
     fd.history = kept + points
     fd.to_json(target_path)

--- a/scripts/prune_published_dataset.py
+++ b/scripts/prune_published_dataset.py
@@ -70,7 +70,6 @@ def expected_paths(repo: Path) -> set[str]:
             expected.add(entry["source_cfg_path"])
         for rel in entry.get("results", {}).values():
             expected.add(rel)
-            # The publisher also copies the sibling variables .toml when present.
             if rel.endswith(".c"):
                 expected.add(rel[:-2] + ".toml")
     return expected
@@ -110,10 +109,8 @@ def main() -> int:
         print("[prune] dry run — re-run with --apply to git rm these")
         return 0
 
-    # git rm in batches to stay under argv limits. -f: orphans often carry
-    # working-tree drift (hardlinks shared with the results tree), and git rm
-    # refuses locally-modified files without it; the manifest reconciliation,
-    # not content, is what decides deletion.
+    # Batched to stay under argv limits. -f because orphans often carry working-tree
+    # drift and git rm refuses locally-modified files without it.
     for i in range(0, len(orphans), 500):
         batch = orphans[i : i + 500]
         subprocess.run(["git", "-C", str(repo), "rm", "--quiet", "-f", "--", *batch], check=True)

--- a/scripts/rebuild_function_data.py
+++ b/scripts/rebuild_function_data.py
@@ -25,10 +25,6 @@ from pathlib import Path
 
 from decbench.models.function_data import FunctionData, HardestEntry, SampleEntry
 from decbench.models.scoreboard import Scoreboard
-
-# The overlay merges live in decbench.results_store now (slice-scoped clears; see
-# its docstrings) — this script keeps its historical role of an overlay remerge
-# over an existing function_results.json, without touching checkpoints.
 from decbench.results_store import (
     load_sample_manifest,
     read_ged_overlay,
@@ -50,7 +46,7 @@ from decbench.utils.source_extract import function_source, function_source_ex
 
 MARKER = re.compile(r"^// Function: (\S+) @ (0x[0-9a-fA-F]+)\s*$", re.M)
 PERFECT = {"ged": 0.0, "type_match": 1.0, "byte_match": 1.0}
-PER_TIER = 100  # View-page samples per difficulty tier
+PER_TIER = 100
 HARDEST_PER = 12
 
 
@@ -115,7 +111,7 @@ def build_samples(fd: FunctionData, reader: DiskReader) -> list[SampleEntry]:
                 if code:
                     decompiled[dec] = code
             if not decompiled:
-                continue  # nothing to compare
+                continue
             source, source_status = function_source_ex(binary, f.function)
             out.append(
                 SampleEntry(
@@ -209,18 +205,9 @@ def recompute_scoreboard(fd: FunctionData, old: Scoreboard) -> Scoreboard:
 
 def main() -> None:
     root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/sailr_full")
-    # --add-only: fold a PARTIAL byte_match_new (e.g. the Docker ARM/PE recompile)
-    # into an already-complete dataset without dropping existing (x86) values, and
-    # keep the existing compile_rates.
     add_only = "--add-only" in sys.argv[2:]
-    # --ged: merge ged_new.json (header-stripped source CFGs) instead of byte_match;
-    # keeps byte_match + compile_rates untouched.
     ged_mode = "--ged" in sys.argv[2:]
-    # --type-match: merge type_match_new.json (recomputed from checkpoints after a
-    # calibration fix) instead of byte_match; keeps byte_match/ged/compile_rates.
     tm_mode = "--type-match" in sys.argv[2:]
-    # --allow-drops: let the coverage guard's regressions through (see
-    # decbench.results_store.write_function_data_guarded).
     allow_drops = "--allow-drops" in sys.argv[2:]
     fd = FunctionData.from_json(root / "function_results.json")
     reader = DiskReader(root)
@@ -250,8 +237,6 @@ def main() -> None:
         rates_str = ", ".join(f"{d}={100*r:.1f}%" for d, r in (fd.compile_rates or {}).items())
         print(f"[rebuild] compile rates: {rates_str}", flush=True)
 
-    # The frozen manifest (when the tree has one) is the single source of truth
-    # for sample-set membership; the seeded draw only runs on manifest-less trees.
     assign_datasets(fd, sample_members=load_sample_manifest(root))
     fd.samples = build_samples(fd, reader)
     fd.hardest = build_hardest(fd, reader)

--- a/scripts/reeval_bytematch.py
+++ b/scripts/reeval_bytematch.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from decbench.utils.results_tree import OPT_LEVELS, resolve_binary, split_functions
 
 DECOMPILERS = ("angr", "ghidra", "ida", "binja", "kuna", "r2dec", "dewolf")
-# DECBENCH_REEVAL_DECOMPILERS (comma list, e.g. "angr,mydec") overrides the default tuple.
 if os.environ.get("DECBENCH_REEVAL_DECOMPILERS"):
     DECOMPILERS = tuple(
         d.strip() for d in os.environ["DECBENCH_REEVAL_DECOMPILERS"].split(",") if d.strip()
@@ -46,8 +45,6 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
     binary = Path(binary_path)
     out: dict[str, dict] = {}
     funcs = split_functions(Path(c_path))
-    # The decompiler's OWN sibling signatures: gives internal calls real
-    # prototypes during the fixup compile (matches compute_for_binary's path).
     context = derive_context_decls({n: c for n, (_a, c) in funcs.items()})
     for name, (addr, code) in funcs.items():
         fd = FunctionDecompilation(
@@ -62,20 +59,15 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
             out[name] = {"value": 0.0, "compilable": False, "error": str(e)[:120]}
             continue
         md = mv.metadata or {}
-        # ABSTAIN, don't score 0: when byte_match can't be measured for this
-        # binary (no matching recompile toolchain — ARM/PE on an x86 host), the
-        # per-function call still returns 0/skipped. Emitting it would make the
-        # rebuild count it as a non-compiling failure and tank the (x86) compile
-        # rate + perfect %. Omit it entirely so rebuild_function_data DROPS
-        # byte_match for that function (per-metric denominators already differ;
-        # GED + type_match carry ARM/PE) — matching compute_for_binary's
-        # binary-level abstain.
+        # Abstain rather than score 0: the per-function call still returns 0 when no
+        # matching toolchain exists, and emitting it would tank the x86 compile rate.
+        # Omitting it makes rebuild_function_data drop byte_match for the function.
         if md.get("skipped"):
             continue
         out[name] = {
             "value": float(mv.value),
             "compilable": bool(md.get("compilable", False)),
-            "dist": md.get("changed_lines"),  # changed asm lines (distance view)
+            "dist": md.get("changed_lines"),
         }
     key = f"{opt}::{project}::{stem}::{dec}"
     return key, out
@@ -97,7 +89,7 @@ def build_tasks(
                 continue
             for dec in DECOMPILERS:
                 for cf in sorted(dec_dir.glob(f"{dec}_*.c")):
-                    stem = cf.name[len(dec) + 1 : -2]  # strip "dec_" and ".c"
+                    stem = cf.name[len(dec) + 1 : -2]
                     binary = resolve_binary(comp, stem)
                     if binary is not None:
                         tasks.append((opt, proj.name, stem, dec, str(binary), str(cf)))
@@ -107,11 +99,7 @@ def build_tasks(
 def main() -> None:
     root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/sailr_full")
     workers = int(sys.argv[2]) if len(sys.argv) > 2 else 16
-    # Optional trailing project stems restrict the reeval (e.g. only the ARM/PE
-    # projects when recomputing byte_match in the cross-toolchain container).
     only = {a for a in sys.argv[3:] if not a.lstrip("-").isdigit()} or None
-    # Overridable so a re-scored pass (e.g. after a metric cache_version bump)
-    # can run side-by-side without touching the published checkpoints/overlay.
     ckpt_dir = Path(os.environ.get("DECBENCH_REEVAL_CKPT_DIR", root / "reeval_bm"))
     ckpt_dir.mkdir(exist_ok=True)
 
@@ -134,7 +122,6 @@ def main() -> None:
             if done % 25 == 0 or done == len(pending):
                 print(f"[reeval] {done}/{len(pending)} binaries done", flush=True)
 
-    # Merge all checkpoints into one map.
     merged: dict[str, dict] = {}
     for cp in ckpt_dir.glob("*.json"):
         key = cp.stem.replace("__", "::")

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -28,11 +28,6 @@ import pickle
 import sys
 from pathlib import Path
 
-# Every decompiler whose checkpoints may carry stale inline GED. r2dec/dewolf
-# joined the tree after the first reeval; a refresh must cover them too, or the
-# scoped update_ged overlay leaves their columns on the inline values forever.
-# codex/claude-code (sample-set-only) are included for the same reason — their
-# slice is tiny (~250 fns each) so covering them costs nearly nothing.
 DECOMPILERS = (
     "angr",
     "ghidra",
@@ -44,16 +39,14 @@ DECOMPILERS = (
     "codex",
     "claude-code",
 )
-# DECBENCH_REEVAL_DECOMPILERS (comma list, e.g. "angr,mydec") overrides the default tuple.
 if os.environ.get("DECBENCH_REEVAL_DECOMPILERS"):
     DECOMPILERS = tuple(
         d.strip() for d in os.environ["DECBENCH_REEVAL_DECOMPILERS"].split(",") if d.strip()
     )
 OPT_LEVELS = ("O0", "O2", "O2-noinline")
-SRC_OPT = "O0"  # source CFGs are opt-independent; extract once from here
+SRC_OPT = "O0"
 
 
-# ---- Stage A: source CFGs per project -------------------------------------
 def src_cfgs_for_i(i_path: str) -> tuple[str, dict]:
     """Worker: extract (stripped) source CFGs for one .i file."""
     from decbench.utils.cfg import extract_cfgs_from_source
@@ -69,7 +62,6 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
     """Extract + cache source CFGs per project (one pickle each)."""
     src_dir = root / "ged_src"
     src_dir.mkdir(exist_ok=True)
-    # Gather .i files per project that still need a source-CFG cache.
     todo: dict[str, list[str]] = {}
     for proj in projects:
         if (src_dir / f"{proj}.pkl").exists():
@@ -87,7 +79,6 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
     if not todo:
         print("[ged/src] all source-CFG caches present", flush=True)
         return src_dir
-    # path -> project, for routing results
     owner = {p: proj for proj, paths in todo.items() for p in paths}
     all_paths = list(owner)
     print(
@@ -95,11 +86,9 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
         f"{len(todo)} projects, {workers} workers",
         flush=True,
     )
-    # proj -> {translation-unit stem -> {function name -> CFG}}. Keeping source
-    # CFGs PER-TU (not a project-wide name-keyed union) lets stage B pair each
-    # binary against its OWN translation unit, so per-program functions
-    # (main/usage/static helpers) are scored against the right body instead of an
-    # arbitrary same-named function from another binary (the collision bug).
+    # Source CFGs stay PER-TU (not a project-wide name-keyed union) so stage B can
+    # pair each binary against its own translation unit — otherwise main/usage/static
+    # helpers score against an arbitrary same-named function from another binary.
     acc: dict[str, dict] = {proj: {} for proj in todo}
     ctx = mp.get_context("spawn")
     done = 0
@@ -116,10 +105,6 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
     return src_dir
 
 
-# ---- Stage B: GED per (opt, project, binary, dec) -------------------------
-# Per-worker cache: src_pkl path -> (per_stem_dict, best_source_by_name). A pool
-# worker handles many (binary, dec) tasks for the same project, so the cross-TU
-# best-by-name fallback is computed once per project pickle, not per task.
 _SRC_CACHE: dict[str, tuple[dict, dict]] = {}
 
 
@@ -150,17 +135,12 @@ def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
     per_stem, best_by_name = _load_src(src_pkl)
     src_cfgs = resolved_source_for_binary(stem, per_stem, best_by_name)
     try:
-        # sanitize_decompiled=True mirrors the live pipeline: clean decompiler-
-        # specific C quirks (array-return types, binja @reg, ida __int128) so
-        # Joern parses functions it would otherwise drop from GED coverage.
         dec_cfgs = extract_cfgs_from_source(Path(c_path), sanitize_decompiled=True) or {}
     except Exception:  # noqa: BLE001
         dec_cfgs = {}
-    # The decompiler's own claim of which functions this artifact holds. Joern
-    # keys CFGs by the parsed BODY name; when that differs from the marker name
-    # (e.g. ida marker `_rl_set_screen_size` over a `rl_set_screen_size` body)
-    # the entry would land on a universe row this decompiler never owned —
-    # misattribution, not a score. Only emit functions the markers declare.
+    # Joern keys CFGs by the parsed BODY name, which can differ from the marker name
+    # (ida's `_rl_set_screen_size` over a `rl_set_screen_size` body). Emitting only
+    # marker-declared functions avoids attributing a row the decompiler never owned.
     markers = set(
         re.findall(
             r"^// Function: (\S+) @ 0x[0-9a-fA-F]+\s*$",
@@ -226,9 +206,8 @@ def main() -> None:
         ckpt = ckpt_dir / (f"{t[0]}::{t[1]}::{t[2]}::{t[3]}".replace("::", "__") + ".json")
         if not ckpt.exists():
             return True
-        # A checkpoint older than its decompiled artifact was computed against a
-        # PREVIOUS decompile of this binary — its entries may reference functions
-        # the artifact no longer holds (the kuna/betaflight stale-overlay bug).
+        # A checkpoint older than its artifact was computed against a PREVIOUS decompile
+        # and may reference functions the artifact no longer holds.
         return ckpt.stat().st_mtime < Path(t[4]).stat().st_mtime
 
     pending = [t for t in tasks if _pending(t)]
@@ -236,9 +215,8 @@ def main() -> None:
 
     ctx = mp.get_context("spawn")
     done = 0
-    # maxtasksperchild bounds the per-worker _SRC_CACHE: without recycling, a
-    # long-lived worker accumulates every project pickle it ever touches
-    # (multi-GB each for the big projects) and 40 workers OOM a 256 GB box.
+    # maxtasksperchild bounds the per-worker _SRC_CACHE: without recycling, workers
+    # accumulate every project pickle they touch and 40 of them OOM a 256 GB box.
     with ctx.Pool(processes=workers, maxtasksperchild=8) as pool:
         for key, result in pool.imap_unordered(eval_one, pending):
             (ckpt_dir / (key.replace("::", "__") + ".json")).write_text(json.dumps(result))
@@ -255,12 +233,9 @@ def main() -> None:
             merged[f"{key}::{func}"] = v
     out_path = root / "ged_new.json"
     out_path.write_text(json.dumps(merged))
-    # Sidecar: EVERY (opt, project, binary, dec) slice this reeval evaluated —
-    # including slices whose checkpoint is empty (nothing measurable in the
-    # artifact). The overlay merge (decbench.results_store.update_ged) uses this
-    # as its covered-slice set, so "evaluated, found nothing" clears stale inline
-    # values while "never evaluated" keeps them. Without the sidecar the merge
-    # falls back to inferring coverage from the entry keys (conservative).
+    # Sidecar of EVERY slice this reeval evaluated, including empty ones, so the
+    # overlay merge can tell "evaluated, found nothing" (clears stale inline values)
+    # from "never evaluated" (keeps them).
     (root / "ged_new.slices.json").write_text(json.dumps(sorted(slices)))
     perf = sum(1 for v in merged.values() if v.get("perfect"))
     print(

--- a/scripts/reeval_typematch.py
+++ b/scripts/reeval_typematch.py
@@ -22,7 +22,6 @@ root = Path(sys.argv[1])
 args = [a for a in sys.argv[2:] if not a.startswith("--")]
 emit = "--emit" in sys.argv
 
-# old stored type_match, keyed (project, opt, binary, function, dec)
 with open(root / "function_results.json") as _fh:
     fd = json.load(_fh)
 old = {}
@@ -50,8 +49,6 @@ for proj in projects:
         optn = getattr(opt, "value", str(opt))
         for binn, decs in bins.items():
             for dname, dr in decs.items():
-                # dname here is the decompiler id used in the run; normalize to
-                # the unversioned name used in function_results (angr/ida/...).
                 try:
                     mr = metric.compute_for_binary(dr)
                 except Exception as e:  # noqa: BLE001
@@ -60,12 +57,6 @@ for proj in projects:
                 for fn, mv in mr.function_results.items():
                     key = (proj, optn, binn, fn, dname)
                     n = mv.value
-                    # Emit EVERY freshly computed value (not only those already in
-                    # function_results.json), so newly-recovered functions — e.g.
-                    # angr ARM functions that were previously misnamed
-                    # sub_* and had no type_match — are captured. The OLD-vs-NEW
-                    # comparison stats below still only cover functions present in
-                    # `old` (there is nothing to compare against otherwise).
                     if emit:
                         md = mv.metadata or {}
                         dist = int(md.get("fp", 0)) + int(md.get("fn", 0))
@@ -94,10 +85,8 @@ for d in sorted(agg):
 if emit:
     out_path = root / "type_match_new.json"
     if args and out_path.is_file():
-        # Project-scoped run: MERGE into the existing overlay instead of
-        # overwriting it with only the scoped projects' entries — a scoped
-        # --emit used to silently shrink type_match_new.json to the projects it
-        # covered (the same silent-loss class as the GED clear-then-rewrite).
+        # Project-scoped runs MERGE into the existing overlay: overwriting used to
+        # silently shrink type_match_new.json to only the projects covered.
         from decbench.results_store import merge_typematch_overlay
 
         with open(out_path) as _if:

--- a/scripts/repair_decompiled_flags.py
+++ b/scripts/repair_decompiled_flags.py
@@ -161,11 +161,9 @@ def main() -> None:
     if total == 0:
         print("[repair] nothing to change; not rewriting")
         return
-    # Round-trip sanity: the untouched heavyweight fields must survive the write.
     assert fd.samples is not None and fd.hardest is not None, "samples/hardest lost in round-trip"
-    # Guarded write (decbench.results_store). Flag flips only ever ADD coverage;
-    # the LLM off-slice prune legitimately REMOVES phantom rows, which the guard
-    # will report — --allow-drops is the explicit sign-off for that.
+    # Flag flips only ever ADD coverage, but the LLM off-slice prune legitimately
+    # REMOVES phantom rows — --allow-drops is the explicit sign-off for that.
     from decbench.results_store import write_function_data_guarded
 
     write_function_data_guarded(fd, root, allow_drops="--allow-drops" in sys.argv[1:])

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -31,24 +31,17 @@ import time
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-# Force 'spawn' for ALL pools (including those created inside the decompile /
-# evaluate pipeline). 'fork' deadlocks here because the parent imports angr
-# (which starts threads) before forking workers — a forked child can wedge on a
-# mutex the parent held at fork time. spawn starts clean processes instead.
-# Must be set before any pool is created and before angr is imported below.
+# Must run before any pool is created and before angr is imported below: a
+# forked worker can wedge on a mutex the angr-importing parent held at fork.
 if multiprocessing.get_start_method(allow_none=True) != "spawn":
     multiprocessing.set_start_method("spawn", force=True)
 
-# Register backends + metrics
 import decbench.metrics  # noqa: F401,E402
-from decbench.models.decompilation import DecompilationResult, DecompilerMetadata
-from decbench.models.project import OptimizationLevel, Project
-from decbench.pipeline.evaluate import evaluate_project
-from decbench.pipeline.executor import PipelineConfig, PipelineExecutor
-
-# The project universe lives in decbench.results_store now (shared with the
-# canonical finalize); gather_tomls keeps its historical name here.
-from decbench.results_store import PROJECT_DIRS  # noqa: F401  (re-exported for callers)
+from decbench.models.decompilation import DecompilationResult, DecompilerMetadata  # noqa: E402
+from decbench.models.project import OptimizationLevel, Project  # noqa: E402
+from decbench.pipeline.evaluate import evaluate_project  # noqa: E402
+from decbench.pipeline.executor import PipelineConfig, PipelineExecutor  # noqa: E402
+from decbench.results_store import PROJECT_DIRS  # noqa: F401,E402
 from decbench.results_store import gather_project_tomls as gather_tomls
 from decbench.utils.cfg import extract_cfgs_from_source
 
@@ -57,9 +50,6 @@ OPT_LEVELS = [
     OptimizationLevel.O2,
     OptimizationLevel.O2_NOINLINE,
 ]
-# Scoped-run knobs. DECBENCH_OPT_LEVELS narrows which opt levels are discovered/
-# run (e.g. "O0" for the historical Ghidra pass); DECBENCH_METRICS narrows which
-# metrics evaluate (e.g. "ged"). Defaults: all three levels, all metrics.
 if os.environ.get("DECBENCH_OPT_LEVELS"):
     OPT_LEVELS = [
         OptimizationLevel(v.strip())
@@ -71,33 +61,12 @@ METRICS = [
 ] or None
 DECOMPILERS = (os.environ.get("DECBENCH_DECOMPILERS") or "angr,ghidra").split(",")
 WORKERS = int(os.environ.get("DECBENCH_WORKERS") or "40")
-# Hard per-(binary, decompiler) wall-clock budget. angr's decompiler can spin at
-# 100% CPU for many minutes on a single binary; without this a few binaries would
-# dominate the whole run. Binaries that exceed it are recorded as decompiler
-# timeouts (no functions credited) — an honest data point about decompiler speed.
+# Hard per-(binary, decompiler) budget; an overrun is recorded as a decompiler
+# timeout (no functions credited) rather than silently dropped.
 DECOMPILE_TIMEOUT = int(os.environ.get("DECBENCH_DECOMPILE_TIMEOUT") or "300")
-# Per-decompiler wall-clock budget (seconds). FAIRNESS PRINCIPLE: every backend
-# gets a budget large enough to finish the largest source-function set, so a
-# slow-but-working backend is not truncated (and counted as thousands of
-# failures) while a faster one finishes. Small binaries finish in seconds, so the
-# large defaults only bite the ~10 big binaries (bash, openssh, coreutils, big
-# ARM firmware).
-#   - angr: the angr engine runs ~15-20s/function; a big binary legit needs up
-#     to ~1h. angr previously got 3600s only via a one-off scoped rerun.
-#   - ghidra/binja: fast per function but a few large binaries still overrun 300s.
-#   - kuna: a Ghidra port that emits its JSON only at the very end (a kill yields
-#     ZERO functions), so it needs a budget above its slowest binary (~450s on
-#     bash) — 900s. Its per-FUNCTION hang guard is now --max-fn-seconds (passed by
-#     the backend), so a pathological function can't hang the batch; the
-#     process-group SIGKILL stays as a belt-and-suspenders leak guard.
-#   - dewolf: Binary Ninja frontend + a z3/sympy logic-simplification pipeline
-#     that can blow up on complex control flow (the paper's main timeout source);
-#     runs out-of-process in its own venv. A single stuck function can otherwise
-#     burn the whole budget with little recovered, so it is capped at 1200s —
-#     lower than angr because dewolf's blowups are per-function hangs the
-#     cap exists to bound, not a slow-but-progressing whole-binary decompile.
-#   - r2dec: radare2 `aaa` analysis then per-function pseudo-C; `aaa` on a big
-#     binary can run minutes, so budget like ghidra/binja.
+# Per-decompiler budgets (seconds). Every backend gets enough time to finish the
+# largest source-function set, so a slow-but-working one is not truncated into
+# thousands of spurious failures. Rationale per backend: docs/benchmarking.md.
 DECOMPILER_TIMEOUT = {
     "kuna": int(os.environ.get("DECBENCH_KUNA_TIMEOUT") or "900"),
     "angr": int(os.environ.get("DECBENCH_ANGR_TIMEOUT") or "3600"),
@@ -105,10 +74,6 @@ DECOMPILER_TIMEOUT = {
     "binja": int(os.environ.get("DECBENCH_BINJA_TIMEOUT") or "1800"),
     "dewolf": int(os.environ.get("DECBENCH_DEWOLF_TIMEOUT") or "1200"),
     "r2dec": int(os.environ.get("DECBENCH_R2DEC_TIMEOUT") or "1800"),
-    # LLM / coding-agent backends: one agentic CLI call per function is slow
-    # (~minutes). The sample-set takes at most a few functions per binary, and
-    # the backend checkpoints after each function, so a large per-binary budget
-    # bounds a stuck call while still crediting finished functions.
     "codex": int(os.environ.get("DECBENCH_CODEX_TIMEOUT") or "3600"),
     "claude-code": int(os.environ.get("DECBENCH_CLAUDE_CODE_TIMEOUT") or "3600"),
     "kimi-code": int(os.environ.get("DECBENCH_KIMI_CODE_TIMEOUT") or "3600"),
@@ -137,8 +102,6 @@ def _load_sampleset_manifest() -> dict[tuple[str, str, str], set[str]] | None:
     gate: dict[tuple[str, str, str], set[str]] = {}
     for e in data.get("functions", []):
         gate.setdefault((e["project"], e["opt"], e["binary"]), set()).add(e["function"])
-    # Only the main process announces the gate; spawn workers re-import this
-    # module and would otherwise spam the log once per worker.
     if multiprocessing.current_process().name == "MainProcess":
         print(
             f"[sampleset] gate ACTIVE: {len(data.get('functions', []))} functions "
@@ -198,8 +161,6 @@ def project_source_functions(
     """
     if not source_stems:
         return {}
-    # binfmt.dwarf_info reads DWARF from ELF *or* PE (the MinGW malware targets),
-    # so this filter works for x86/ARM ELF and PE alike.
     try:
         from decbench.utils import binfmt
 
@@ -212,9 +173,8 @@ def project_source_functions(
     try:
         for cu in dw.iter_CUs():
             lp = dw.line_program_for_CU(cu)
-            # DW_AT_decl_file indexing is 1-based pre-DWARF5 (entry 0 unused) and
-            # 0-based in DWARF5 (entry 0 = primary source); prepend a placeholder
-            # only for pre-v5 so the index lines up either way.
+            # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
+            # makes the index line up either way.
             version = 4
             if lp is not None:
                 version = lp.header.get("version", cu.header.get("version", 4))
@@ -234,11 +194,6 @@ def project_source_functions(
                     continue
                 base = os.path.basename(files[fi.value])
                 stem = base[:-2] if base.endswith(".c") else base
-                # Match the decl-file stem to a compiled source unit. Exact match
-                # for sailr/cps (basename.i <-> basename.c); also accept the
-                # object-prefixed naming some targets use (e.g. malware's
-                # `mydoom-main.i` <-> decl `main.c`), where the source stem is a
-                # `<prefix>-<decl>` / `<prefix>_<decl>` suffix.
                 matched: str | None = None
                 if stem in source_stems:
                     matched = stem
@@ -340,18 +295,11 @@ def _relabel_to_dwarf(
     """
     from decbench.decompilers.raw import common
 
-    # PE: pre-fix decompiles stored function addresses as bare RVAs (0x1110)
-    # because elf_min_vaddr returned 0 for PE; DWARF low_pc is the linked VA
-    # (ImageBase + RVA). Adding the ImageBase recovers the DWARF key. For ELF the
-    # base is the min PT_LOAD vaddr, which is already folded into fd.address, so
-    # ``addr + base`` is just a harmless non-matching candidate.
+    # Pre-fix PE decompiles stored bare RVAs; adding the ImageBase recovers the
+    # DWARF key. Harmless for ELF, where the base is already folded into fd.address.
     base = common.elf_min_vaddr(unstripped)
     new_funcs: dict[str, object] = {}
     for fd in list(result.functions.values()):
-        # Resolve the DWARF name, tolerating two address-space mismatches:
-        #  - ARM/Thumb: angr reports a Thumb entry with the LSB set (odd),
-        #    while DWARF low_pc is even (0x8008001 vs 0x8008000).
-        #  - PE ImageBase: an RVA-based address needs + base to reach the VA.
         addr = int(fd.address)
         dn = (
             addr2name.get(addr)
@@ -362,8 +310,6 @@ def _relabel_to_dwarf(
         if dn and dn != fd.name:
             fd.decompiled_code = re.sub(r"\b" + re.escape(fd.name) + r"\b", dn, fd.decompiled_code)
             fd.name = dn
-        # Keep the larger body if two addresses collapse to one DWARF name
-        # (duplicate low_pc), so a real body is not clobbered by a trivial stub.
         prev = new_funcs.get(fd.name)
         if prev is None or len(fd.decompiled_code or "") >= len(
             getattr(prev, "decompiled_code", "") or ""
@@ -392,7 +338,6 @@ def _timed_decompile(
         str(pkl),
         names_file,
     ]
-    # Versioned specs (e.g. "ghidra@11.4") share their base tool's budget.
     timeout_s = DECOMPILER_TIMEOUT.get(
         dec_name, DECOMPILER_TIMEOUT.get(dec_name.split("@", 1)[0], DECOMPILE_TIMEOUT)
     )
@@ -400,8 +345,8 @@ def _timed_decompile(
     timed_out = False
     proc = None
     try:
-        # start_new_session so the worker leads its own process group and we can
-        # kill the WHOLE group (worker + kuna/JVM/IDA/... it spawned) on timeout.
+        # The worker leads its own process group so a timeout can kill the WHOLE group
+        # (worker plus the kuna/JVM/IDA process it spawned).
         proc = subprocess.Popen(
             cmd,
             start_new_session=True,
@@ -413,7 +358,7 @@ def _timed_decompile(
         except subprocess.TimeoutExpired:
             failure = f"timeout>{timeout_s}s"
             timed_out = True
-            _kill_process_group(proc)  # reap the worker AND the tool it spawned
+            _kill_process_group(proc)
             rc = None
         if not timed_out:
             if rc == 0 and pkl.exists():
@@ -428,14 +373,9 @@ def _timed_decompile(
     except Exception as e:  # noqa: BLE001
         failure = f"{type(e).__name__}: {e}"
     finally:
-        # Belt-and-suspenders: never leave a tool subprocess (esp. a hung kuna)
-        # orphaned and spinning, whatever path we exited on.
         if proc is not None and proc.poll() is None:
             _kill_process_group(proc)
 
-    # On timeout/error, try to recover whatever the worker checkpointed: a
-    # partial decompilation (e.g. angr got 12/40 functions before the kill) is
-    # far more useful than nothing.
     partial = None
     if pkl.exists():
         try:
@@ -494,8 +434,6 @@ def decompile_project_timed(
     if not tasks:
         return results, stats
 
-    # Per binary: a stripped copy for the decompiler + a JSON of the target
-    # ADDRESSES (the decompiler sees no names, so we filter/match by address).
     names_dir = Path(tempfile.mkdtemp(prefix="decaddrs_"))
     addr_files: dict[str, str] = {}
     stripped: dict[str, Path] = {}
@@ -522,8 +460,6 @@ def decompile_project_timed(
             for fut in as_completed(futs):
                 stem, dec_name = futs[fut]
                 res = fut.result()
-                # Re-symbolize from the stripped decompile + point eval at the
-                # unstripped (DWARF) binary; rewrite the .c artifact to match.
                 orig = by_stem.get(stem)
                 amap = source_fn_map.get(stem) or {}
                 if orig is not None:
@@ -591,9 +527,6 @@ def main() -> int:
     out_dir = Path(args[0]) if args else Path("results/sailr_full")
     only = set(args[2:]) if len(args) > 2 and args[1] == "--" else set()
 
-    # Incremental runs: re-run ONLY decompilers missing from a checkpoint, plus
-    # any listed in DECBENCH_REDO_DECOMPILERS (force-redo even if present, e.g.
-    # after fixing a backend). Existing decompilers' results are kept & merged.
     redo = {d for d in (os.environ.get("DECBENCH_REDO_DECOMPILERS") or "").split(",") if d}
 
     ckpt_dir = out_dir / "checkpoints"
@@ -610,7 +543,6 @@ def main() -> int:
         flush=True,
     )
 
-    # Accumulated results across all projects (for final aggregation).
     all_decompile: dict = {}
     all_evaluate: dict = {}
 
@@ -626,8 +558,6 @@ def main() -> int:
                 existing = None
 
         present = _present_decompilers(existing["decompile"]) if existing else set()
-        # Decompilers to (re)run for this project: those requested but absent,
-        # plus any force-redo. If the checkpoint already has everything, resume.
         to_run = [d for d in DECOMPILERS if d not in present or d in redo]
         if existing is not None and not to_run:
             all_decompile[name] = existing["decompile"]
@@ -646,8 +576,6 @@ def main() -> int:
             continue
 
         t0 = time.time()
-        # Start from existing results so prior decompilers are preserved; the
-        # per-opt merge below adds/overwrites only the `to_run` decompilers.
         proj_dec: dict = dict(existing["decompile"]) if existing else {}
         proj_eval: dict = dict(existing["evaluate"]) if existing else {}
         print(f"[{name}] running decompilers={to_run} (have={sorted(present)})", flush=True)
@@ -656,25 +584,16 @@ def main() -> int:
                 proj_dec[opt] = {}
                 proj_eval[opt] = {}
                 continue
-            # 1) Compute the per-binary decompile filter from DWARF FIRST (cheap
-            #    DWARF read) — the project's OWN src functions, not the .i universe.
-            #    SKIP binaries whose filter is empty: those have no usable debug
-            #    info (e.g. some LTO'd cps firmware), so the only alternative is
-            #    decompiling ALL ~10k+ library/RTOS functions, which times out
-            #    every decompiler and produces noisy, un-typed results. Skipping
-            #    keeps the benchmark to functions we can actually attribute, and
-            #    avoids the (very slow) source-CFG extraction for skipped projects.
+            # Binaries with an empty DWARF filter have no usable debug info; decompiling
+            # their ~10k+ library functions instead would time out every backend.
             ts = time.time()
             source_stems = set(project.preprocessed_sources.get(opt, {}).keys())
             src_fn_names: dict[str, dict[int, str]] = {}
             kept_binaries = []
-            needed_stems: set[str] = set()  # source .i stems holding target functions
+            needed_stems: set[str] = set()
             for b in project.compiled_binaries[opt]:
                 addr_stem: dict[int, str] = {}
                 fns = project_source_functions(b, source_stems, stem_out=addr_stem)
-                # sample-set gate: keep only the frozen slice's function names for
-                # this (project, opt, binary), and skip binaries with none — so
-                # the expensive LLM backends never touch off-slice functions.
                 if SAMPLESET_GATE is not None:
                     allowed = SAMPLESET_GATE.get((name, opt.value, b.stem))
                     fns = {a: nm for a, nm in fns.items() if allowed and nm in allowed}
@@ -696,12 +615,6 @@ def main() -> int:
             project.compiled_binaries[opt] = kept_binaries
             n = len(kept_binaries)
 
-            # 2) Extract source CFGs (for GED) — for a gated (sample-set) run, only
-            #    for the .i files that actually hold the target functions, so Joern
-            #    doesn't parse a whole firmware source tree to score a few functions.
-            #    DECOMPILE_ONLY skips evaluate, so the source CFGs are never used —
-            #    skip the (often multi-minute) Joern parse entirely then. A
-            #    downstream reeval_ged pass rebuilds them from its own cache anyway.
             if os.environ.get("DECBENCH_DECOMPILE_ONLY") == "1":
                 src_cfgs = {}
             else:
@@ -716,8 +629,6 @@ def main() -> int:
                 flush=True,
             )
 
-            # 2) Decompile, restricted to source functions where known. Only the
-            #    `to_run` decompilers (incremental); merge into any existing.
             td = time.time()
             print(
                 f"[{name}/{opt.value}] decompiling {n} binaries x {to_run} "
@@ -743,10 +654,6 @@ def main() -> int:
                 flush=True,
             )
 
-            # 3) Evaluate, reusing the source CFGs (no re-extraction).
-            # DECBENCH_DECOMPILE_ONLY: skip the Joern GED eval here (a downstream
-            # reeval_ged pass re-scores every decompiler from the fresh .c anyway, so
-            # evaluating here is redundant double-Joern — the load hog). Decompile-only.
             te = time.time()
             if os.environ.get("DECBENCH_DECOMPILE_ONLY") == "1":
                 print(f"[{name}/{opt.value}] evaluating... SKIPPED (DECOMPILE_ONLY)", flush=True)
@@ -790,17 +697,11 @@ def main() -> int:
             flush=True,
         )
 
-    # ---- Finalize: the CANONICAL rebuild (decbench.results_store) ----
-    # Always regenerates the derived files from EVERY checkpoint in the tree —
-    # a scoped `-- project` resume can no longer shrink function_results.json to
-    # this run's projects (the historical silent-drop path). Overlays are applied
-    # slice-scoped, the sample-set pins to the frozen manifest, and the coverage
-    # guard refuses any unexplained shrink (DECBENCH_ALLOW_DROPS=1 overrides).
+    # The canonical rebuild: regenerates derived files from EVERY checkpoint in the
+    # tree, so a scoped resume can no longer silently shrink function_results.json.
     print("\nFinalizing (canonical rebuild from ALL checkpoints)...", flush=True)
     from decbench.results_store import CoverageRegressionError, finalize_tree
 
-    # finalize_tree re-loads every checkpoint from disk; free the in-memory
-    # accumulators first so the two copies don't both sit in RAM at peak.
     all_decompile.clear()
     all_evaluate.clear()
     try:

--- a/scripts/run_small.py
+++ b/scripts/run_small.py
@@ -152,9 +152,7 @@ def main() -> int:
     print(f"=== small validation: {project_name} {opts} specs={specs} ===")
     project = Project(config=ProjectConfig(name=project_name, labels=["sailr"]))
 
-    # project -> OptimizationLevel -> binary -> dec_id -> {metric: MetricResult}
     evaluation: dict = {project_name: {}}
-    # project -> OptimizationLevel -> binary -> dec_id -> DecompilationResult
     decompiled: dict = {project_name: {}}
 
     for opt_str in opts:
@@ -170,9 +168,6 @@ def main() -> int:
         binaries = binaries[:max_bins]
         print(f"[{opt_str}] {len(binaries)} binary(ies); extracting source CFGs...")
         src_cfgs = _source_cfgs(sources)
-        # Target functions that exist in BOTH source (so they have a source CFG
-        # to score against) AND the binary's symbol table (so a slow decompiler
-        # only does these few, never falling back to all ~hundreds).
         bin_funcs = _binary_func_names(binaries[0])
         common = sorted(set(src_cfgs) & bin_funcs) if bin_funcs else sorted(src_cfgs)
         targets = common[:max_funcs] or sorted(src_cfgs)[:max_funcs]
@@ -201,7 +196,7 @@ def main() -> int:
                 if res is None:
                     print(f"    [{spec}] decompile produced no result")
                     continue
-                dec_id = res.decompiler.decompiler_name  # == backend .id
+                dec_id = res.decompiler.decompiler_name
                 metric_results = evaluate_decompilation(res, src_cfgs)
                 evaluation[project_name][opt][stem][dec_id] = metric_results
                 decompiled[project_name][opt][stem][dec_id] = res
@@ -214,7 +209,6 @@ def main() -> int:
                 dt = time.time() - t0
                 print(f"    [{dec_id}] {got} funcs in {dt:.0f}s scored={scored}")
 
-    # Aggregate + scoreboard
     aggregated = aggregate_results(evaluation)
     scoreboard = build_scoreboard(
         aggregated,
@@ -225,7 +219,6 @@ def main() -> int:
     )
     function_data = build_function_data(evaluation, [project], decompiled)
 
-    # Build REAL history from the Ghidra versions we ran (two points = a line).
     history_inputs = []
     for dec_id, ds in scoreboard.decompiler_scores.items():
         if "@" not in dec_id:

--- a/site/app.css
+++ b/site/app.css
@@ -33,57 +33,38 @@
 }
 
 /* ---- Theme ----
-   Dark is the default look. Two theme surfaces share ONE token set: this :root
-   block IS the dark palette; the :root[data-theme="light"] block below re-inks
-   every token for a light ground. The choice is an explicit user opt-in — the
-   FOUC-free head script (html.py) stamps data-theme on <html> from
-   localStorage['decbench-theme'] (or a ?theme= debug param) before first paint;
-   there is NO OS-preference detection. Anything hard-coded outside these two
-   blocks is a theme leak, so keep palette values here (or derived from --line-rgb
-   / the tint tokens). app.js reads the chart tokens via getComputedStyle, so the
-   whole palette — chart chrome included — lives in this one file. */
+   This :root block IS the dark palette; :root[data-theme="light"] below re-inks
+   every token for a light ground. The head script (html.py) stamps data-theme on
+   <html> before first paint, so there is no FOUC. ---- */
 :root {
     --bg: #000;
     --code-bg: #141414;
     --code-border: #545454;
     --text: #DBDBDB;
     --text-muted: #8a8a8a;
-    /* One ink channel drives every dashed rule, inverting hover and low-alpha
-       wash: --border-color and the rgba(var(--line-rgb), a) borders below all
-       follow it, so a single override in the light block re-inks them all. */
     --line-rgb: 219, 219, 219;
     --border-color: rgba(var(--line-rgb), 0.9);
     --border-dim: rgba(var(--line-rgb), 0.4);
     --green: #6ab04c;
     --amber: #d4a72c;
     --red: #c0504d;
-    /* License tags: dimmer than the --green/--amber score palette so they never
-       read as a bar (see .lic-open-source / .lic-closed-source). */
     --lic-open: #7f9e63;
     --lic-closed: #b39a54;
-    /* Diff-row washes (.dl-match/.dl-norm/.dl-diff, .cat-hl) + the red-tinted
-       "inserted node" panel in the about-page GED SVG. */
     --tint-green: rgba(106, 176, 76, 0.10);
     --tint-green-hl: rgba(106, 176, 76, 0.16);
     --tint-amber: rgba(212, 167, 44, 0.10);
     --tint-red: rgba(192, 80, 77, 0.14);
     --dl-diff-fg: #e2938f;
     --panel-red-tint: #1a0f0f;
-    /* Inset chrome under a code panel: a heavy black inset reads as depth on the
-       dark ground; on paper it becomes barely-there (a dark vignette would look
-       like grime), see the light override. */
     --pre-shadow: rgba(0, 0, 0, 0.8);
     --chart-grid: #333;
     --chart-axis: #666;
     --sidebar-w: 230px;
 }
 
-/* Light theme — terminal-on-paper. The SAME design system re-inked for a light
-   ground, NOT a naive invert: every token above is redeclared (except the ones
-   that derive from --line-rgb / the tint channel, which re-ink for free). The
-   --blue / --viz-* tokens are declared in the second :root block further down;
-   their light values live here too (this selector's higher specificity wins) so
-   ALL light overrides sit in one place. */
+/* Light theme — terminal-on-paper: every token above redeclared, not inverted.
+   Higher specificity, so it also owns the light values of the --blue / --viz-*
+   tokens declared in the second :root block below. */
 :root[data-theme="light"] {
     --bg: #f7f6f3;
     --code-bg: #ececea;
@@ -163,10 +144,8 @@ a { color: var(--text); text-decoration: none; }
 .side-foot { color: var(--text-muted); font-size: 0.78em; margin-top: auto; }
 
 /* ---- Theme toggle (sidebar foot) ----
-   A terminal-style button (.ds-btn) that flips the light/dark theme. Its LABEL is
-   driven purely by data-theme in CSS, so it reads correctly at first paint with no
-   JS flash: "[ light mode ]" while dark is active (a click switches TO light) and
-   "[ dark mode ]" once light is active. app.js wires only the click. */
+   The button LABEL is driven purely by data-theme in CSS, so it reads correctly
+   at first paint with no JS flash; app.js wires only the click. ---- */
 .theme-toggle { display: inline-block; margin-bottom: 0.55rem; }
 .theme-toggle .th-to-dark { display: none; }
 :root[data-theme="light"] .theme-toggle .th-to-light { display: none; }
@@ -192,13 +171,7 @@ h2.view-title:before { content: "## "; color: var(--text-muted); }
 h3.sub { font-size: 1rem; font-weight: 700; margin: 1.4rem 0 0.4rem; }
 h3.sub:before { content: "> "; color: var(--text-muted); }
 
-/* ---- Prose lists ----
-   Markdown bodies (the changelog's dated entries, any bulleted prose) render to
-   plain <ul>/<ol>. The browser default — ~40px indent and disc bullets — floats
-   the markers left of the terminal content column and clashes with the `## `/`> `
-   heading prefixes. Scope compact, muted, dash-marked lists to the content area so
-   a bullet reads like a terminal `- ` line and items sit under their date heading.
-   .view ul/ol/li here only ever match markdown output — no scaffold uses lists. */
+/* ---- Prose lists ---- */
 .view ul, .view ol {
     margin: 0.45rem 0 1.1rem;
     padding-left: 1.4em;
@@ -216,8 +189,6 @@ h3.sub:before { content: "> "; color: var(--text-muted); }
     color: var(--text-muted);
 }
 .view ol { list-style: decimal; }
-/* Nested lists share the gutter, don't compound the shrink, and lose the trailing
-   block margin so a sub-list hugs its parent item. */
 .view li > ul, .view li > ol { margin: 0.3rem 0 0; font-size: 1em; }
 
 /* ---- Tables ---- */
@@ -238,32 +209,21 @@ tr:last-child td { border-bottom: none; }
 .lb-rank { color: var(--text-muted); width: 2.6em; }
 .lb-name { font-weight: 700; font-size: 1.02em; }
 .lb-name .ver { color: var(--text-muted); font-weight: 400; font-size: 0.85em; }
-/* Linked decompiler names keep the terminal look: same color, underline on hover. */
 .lb-name a { color: inherit; text-decoration: none; }
 .lb-name a:hover { text-decoration: underline; }
 
-/* ---- Leaderboard stacked name cell (name / version / license) --------------
-   Only the leaderboard uses the stacked block (.lb-name-stacked); the metrics and
-   distance tables keep the compact inline `name <span.ver>` form above. The cell is
-   taller than one line, so the leaderboard top-aligns its cells (below) and the name
-   line — the thing the row is about — sits level with the rank and the metric bars. */
+/* ---- Leaderboard stacked name cell (name / version / license) ---- */
 .lb-name-stacked { vertical-align: top; }
 .lb-stack { display: flex; flex-direction: column; gap: 0.03rem; line-height: 1.25; }
-/* nowrap: "Binary Ninja" must not fold into a taller two-line row. */
 .lb-name-stacked .lb-nm { font-weight: 700; display: flex; align-items: center; white-space: nowrap; }
 .lb-name-stacked .ver,
 .lb-name-stacked .lic {
     font-weight: 400; font-size: 0.72em; letter-spacing: 0.02em; white-space: nowrap;
 }
 .lb-name-stacked .ver { color: var(--text-muted); }
-/* License: a subtle lowercase tag, not a loud badge — a tinted line that keeps the
-   terminal look. open-source reads muted green, closed-source muted amber (both
-   dimmer than the --green/--amber score palette so they never compete with a bar). */
 .lb-name-stacked .lic { text-transform: lowercase; }
 .lic-open-source { color: var(--lic-open); }
 .lic-closed-source { color: var(--lic-closed); }
-/* Taller name rows: top-align the whole leaderboard row and nudge the single-line
-   cells down so they line up with the NAME (first) line of the stacked block. */
 #leaderboard-table td { vertical-align: top; }
 #leaderboard-table td.lb-rank,
 #leaderboard-table td.metric-cell { padding-top: 0.5rem; }
@@ -275,9 +235,6 @@ td.metric-cell { white-space: nowrap; }
 .pct-mid { color: var(--amber); }
 .pct-low { color: var(--red); }
 .binrow:hover td { background: rgba(var(--line-rgb), 0.06); }
-/* Sample-set-only backends on the distance page: below a labeled dashed break,
-   muted — their numbers cover only this dataset's overlap with the sample-set
-   slice (see the .subset-note under each table). */
 .subset-break td {
     border-bottom: none; color: var(--text-muted); font-size: 0.78em;
     letter-spacing: 0.08em; text-align: center; padding: 0.6rem 0 0.25rem;
@@ -372,31 +329,23 @@ footer { color: var(--text-muted); font-size: 0.82em; margin-top: 1.5rem; }
     .layout { flex-direction: column; }
     .sidebar { width: 100%; min-width: 0; height: auto; position: static;
                border-right: none; border-bottom: dashed 1px var(--border-color); }
-    /* The layout is align-items:flex-start, so a column-direction .main is NOT
-       stretched — without an explicit width it grows to its widest content and
-       the whole page scrolls sideways. Pin it to the column's full width so wide
-       content (tables/SVGs/selects) overflows INSIDE .main, not the viewport. */
+    /* .main is in an align-items:flex-start column, so without an explicit width it
+       grows to its widest content and the whole page scrolls sideways. */
     .main { padding: 1.2rem 1rem 3rem; width: 100%; }
     .nav { flex-direction: row; flex-wrap: wrap; }
     .side-foot { margin-top: 0.5rem; }
 }
 
 /* ==========================================================================
-   Metric-visualization + syntax-highlight additions.
-
-   Appended after the base rules above (see viz/NOTES.md). Everything here is
-   NEW and namespaced tok- / viz- / dl- so it cannot collide with the rules
-   above; a couple of view-page helpers (.src-*) are tacked on at the very end.
+   Metric-visualization + syntax-highlight additions. Namespaced tok- / viz- /
+   dl- so they cannot collide with the base rules above.
    ========================================================================== */
 
-/* Dark values for the syntax/viz palette. Their LIGHT overrides live in the
-   :root[data-theme="light"] block near the top of this file (kept together with
-   the rest of the light palette; that selector's higher specificity wins). */
 :root {
-  --blue: #4a90d9;          /* chart blue — also numbers/immediates            */
-  --viz-type: #57b9ab;      /* types: a calm teal, distinct from kw/str        */
-  --viz-pp: #b083c9;        /* preprocessor / directives                       */
-  --viz-call: #d7cf94;      /* function calls: soft gold                       */
+  --blue: #4a90d9;
+  --viz-type: #57b9ab;
+  --viz-pp: #b083c9;
+  --viz-call: #d7cf94;
 }
 
 /* ---- Syntax token colours (dark terminal) ------------------------------- */
@@ -408,9 +357,9 @@ footer { color: var(--text-muted); font-size: 0.82em; margin-top: 1.5rem; }
 .tok-imm  { color: var(--blue); }
 .tok-pp   { color: var(--viz-pp); }
 .tok-call { color: var(--viz-call); }
-.tok-mn   { color: var(--amber); }            /* asm mnemonic                 */
-.tok-reg  { color: var(--text); }             /* asm register: default text   */
-.tok-lbl  { color: var(--green); }            /* asm label / address          */
+.tok-mn   { color: var(--amber); }
+.tok-reg  { color: var(--text); }
+.tok-lbl  { color: var(--green); }
 
 /* ---- Code panels inside a visualization --------------------------------- */
 /* Strip base.css pre chrome: the .viz-panel provides the frame instead.     */
@@ -466,7 +415,6 @@ pre.viz-code code {
 .viz-panel-h.is-dec   { color: var(--text); }
 .viz-panel svg { flex: 1; min-height: 0; }
 
-/* graph caption (under a CFG etc.) */
 .viz-cap {
   color: var(--text-muted);
   font-size: 0.76em;
@@ -577,7 +525,7 @@ pre.viz-code code {
 .dl-diff  { background: var(--tint-red); }
 .dl-diff  .dl-mk { color: var(--red); }
 .dl-diff  code { color: var(--dl-diff-fg); }
-.dl-op { color: var(--amber); }               /* normalized operand  ____     */
+.dl-op { color: var(--amber); }
 
 /* ---- Narrow layout ------------------------------------------------------- */
 @media (max-width: 700px) {
@@ -601,15 +549,9 @@ pre.viz-code code {
 
 
 /* ==========================================================================
-   Decompiler logos  (the SHOW_LOGOS experiment — gated in app.js)
-
-   Each .dlogo-<id> carries its logo as a self-contained data: URI (no network,
-   CSP-safe, no external host). Logos are grayscale + dimmed at rest so a column
-   of colored favicons doesn't turn the strict mono table into a sticker sheet;
-   hovering a row reveals the logo's true colour. Only the leaderboard's stacked
-   name line prepends a .dlogo span, and only when SHOW_LOGOS is on AND the
-   registry marks the id with a logo — flip SHOW_LOGOS off in app.js and this
-   whole block simply goes unused.
+   Decompiler logos (the SHOW_LOGOS experiment — gated in app.js). Each
+   .dlogo-<id> carries its logo as a self-contained data: URI: no network, no
+   external host, CSP-safe.
    ========================================================================== */
 .dlogo {
   display: inline-block;
@@ -620,75 +562,41 @@ pre.viz-code code {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  /* Uniform, terminal-friendly at rest; full colour on row hover (below). */
   filter: grayscale(1) brightness(1.5) contrast(0.95);
   opacity: 0.72;
   transition: filter 0.12s ease, opacity 0.12s ease;
 }
 .binrow:hover .dlogo { filter: none; opacity: 1; }
 
-/* Light theme: several marks (r2dec/dewolf/kuna) are RECOLOURED to light #DBDBDB
-   art for the dark ground — on paper they would vanish. Darken every logo to a
-   grey silhouette instead, and KEEP that filter on row hover (a light-art logo
-   has no useful full-colour form on a light page), so the column stays legible.
-   The colour-favicon marks (angr/ghidra/ida/binja) also darken to a clean grey,
-   matching the terminal-on-paper look rather than turning the table into stickers. */
 :root[data-theme="light"] .dlogo { filter: grayscale(1) brightness(0.4) contrast(1.1); opacity: 0.9; }
 :root[data-theme="light"] .binrow:hover .dlogo { filter: grayscale(1) brightness(0.4) contrast(1.1); opacity: 1; }
 
-/* angr — github.com/angr avatar (angr.io) */
 .dlogo-angr { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAM0klEQVR42sWZe4xc1XnAf+ecO/fenZl9za7tXXtfxmtj/ACMcIrdmAoF0qBWSSjgmkJBBByR0jRSRGjVBKVRqRIBStQmqhTaqGpDSiFpIKEY4vLGwWBjMLaxDV4vXnu93vU+vDuzM3Of5+sfs2tsbAgkbXOlo7nn3plzf/f7vvO9RvEbHuqUcfKCBpHaVOTd8/+3Q8+MD/0SSqE1KPXrCeAjgdn3XGsFrwDNLTCnGXK2k8x0B8XyJMWxScbGJihXw3d/pvVHk6r6KF+aXfMcaPk4fPriuXOuW9ax4LK21lYnm/PxAkv66YVEly8gGJtg4sQg/Qf379+9+61Htu6oPrBzL/sr1RqsUh8OUn0UqZ0PXVe77tevXLfmc73LF5N1FVRKpKVSIqlN7Ng0mZsuwVl/Eaoca+3kHCu+rpQrDB7exgvP/3jnzzcduuOZl3gmCBGtwdrfAHAWrg70jfClW9at/fbSy34HN5228ZGDkQ1ih2xe61y9pi4LgUFdkUdd6iGVEIhAxDq6JTHeCmul4Pf1beKRR3/ws/v/bfpPDw9R+lWQ6lfBLYD6v2pqfGz95/7k9xoKTpQc2KXFcR3T3omubwBtQARJLUwnqEubUWvrkUoAhIhUkbSEBCWMbbJO/e9G5dj1N//i7uJ939u9ettO3v4gSPNBcCtg/r2dHX3X3PmFpX5pIEiH+j2zZJl2Fi1GNWQho0ASSCNQFsIQ1dOA7m6A2IKakYDSKONCWlZ2aoeTJU2WrNzonbd45C+GjvY/3TfAYa3PbpPm/eDmQ/7ezo7+K7/6xUbZ/2JkbeI5q1aDAjs6jh09AaUq+A6qzqDiEMII3VNAdRcgThEEKxaxFlSKUoJWPul0vzaVQeleenvc2XF44649h/712HEmzwZpztC3UvhK6b9tanzm6r/8Qq/sfyHC9VznvBWQVFASozKC9kGSEDs4ikQxurkOKmXUwrnorlYkTvBzBrdO47ogaYJNU5RN0HhIMKxUsU86z73VNjfuuOHFl8e/O10hfa+vPANQgJtRX/7in910i18eCGyl6DnLV6LiaZSxKFdQvkJnNTS5mFYPOT5Zg/RBdc5FdbfjasvL20fY9ORR+g9V6GjPkMsKaVSDVGSQyhFtkiDpXvZHDaXS5tatO9LHz6bRkycCLIMFG9dcfF9jmxckRw74zrnLICqBimdGhFIhIgG+DhEdo3vzKB0iYRlRioyb5V/+fR8/fLiPppYsA4MRd91zlJFxwXgGQQEW7TZjx19yczYOrrt2w21rLpKVIjVnfgagzKh3ve9/a+nvr7Pxm9u1bmsHlYKN3oXTMZgYx0vom5jEd0OUjlGtBlEhrms4OjTNvrfG+eZda1h/zULu+MpiVl/QyONPl3B9jUWD0ogSlJNFH93kLOm63H7mysJ3HUdhrTpdxbPSWwiFr6675EcLegtpfGhfxunqRhlBmQRMCsZiTYKfg+f7xrnrFR+IWNWWgAg2qKK6evB7e7h09RyyWUVQqpIGESvOzbCoS6ElRScJKklQaYK2CqaPaie/NM7Pm7Noy0s7fnB8jOLshtGnOsNLlbrqnAuW2ujg/kTV+bX9nAaIjUAiFCFaRaADHt5VpKWtk289O8Ht//EWoYQoImwak8lofN+QJCnGmUlpEBryBrGnbFMREAsqg4y9Yhd1XWLXXpzZcIYNpjOT1S0t1+dzGZ1OjDoqk4EkQpKo5ufSCLERWsWEUcDB4RIH9u8hLo3xj/89yM9fO4bvptg0wdqUJE0AQUQQJYhYktSeYlAyIxhBGw9dOujUm4y+6MLeDY6pOW6lwJnduQXwzu2cv0bCaauS2EE8JApQRoO2NWMwAqmgUiGolNh7ZBxfJyiVkiYRWBdIMDpB6xRIEVLEpoi2CBaxae3ptnadNAUU2lYcmT5mF/cuX9Va2JcdHqVyGmALNLfPa/VtaTIC7ZJYqFbAZBAsNbsWErHUeYbzWoQXd04QuFCXsXysMwt47Hn2SXZufgRjpQYnAtSctdEWz8yo1VqUWJQVkiThyjXzaI7Hk3lzutx5c2gdHuUwzADO5HVzstksUg0tAlhBgipkagvJrGZcwZYst69t5RevjzIwEXLnFQtYUshRHZmifeVn+f6WIbY+9yzZXANWBK011WrAhStXcMeXbqOhsYEwjIijAJXJseO/7uPo0NM0rSjbfLaVpkbmAIcV4MwaYxPkPGOwQQRWQQoSW6iGYGtZMUqjUETWsrKljqduX8aR8YhLFuQIyhaihFzjfDKNmlDnyGQasDZFa02kNTrXQqFzOQ0NjQRBQBhUUZkchc4LKB56AtIqnu+RrSM/Gzmc0wKJtbXMJBEkFVQMGIuomagvFlKNyghBBAt9j94Oj2rV1rKZUCBOQGI0Fi0piEULKCwKiyQhSVQhiQLSuAoCxs0SRfa0gDsLdRJwCqbDagi+A7FAJIgCHI12DQoNqdRUnwBKCLA16VrAaggEJQqldM2DcPpAKbRxappQ+t1PEVACxieKQ6oB07Ob3Zn1SqMwOl0qMzdXryWyEIP2DTIVEI9UEUcw9R6mqQ6dd1FeBi2CIEhikUQhESira+bAe9ISEbRSmFNTFql5uqhygqaMQmWadKlYZHKKsdnbJwHHYGJo5HiwqGOeayOxOlV6/NVDjISaYE4brutiBspkpo/hq4A6X/CaPTINPk7eR3s+TIWo2GIyDsYYjDEzFZ2emTtofXo9KAjVEwM05V203+qM9L1kj48yelLFs4AnINo3PPLCOlZ90jh1SXHfoN7TuZjhW2+kvm0+nV09lCenkBNTuKPj2LcPwDvv4I0MYYbG0EGJ9MQkbVfEBFGV8fEJ4lRmNomhVJ6mXCljzLsJlNKGqDpNOLqbtlXzE+XPcw70v7lzdILKbKBxZgNyCmwvFh+4fjr4pGf8ZLwcO1MbbyTf3kaL59NZKFCuq4OODrINDVRtSrVcJV+XJS2WSCtlpsbGsT09XLptG4VMBt/zsWLRShNGIQt7urEitQRABCfjM3L4ddzqARq7r0rKUaR3vnHgoThBtAI7CzgrxS3w2L7+g/bC9nZnuq0NKTTjhCFOQzPZfB5tDI5xaMjliaOIQBTNzQVsoYBFKJamQSzXb/jjGTs8/UiShJGRERzHQcRivDxHXn+URXNS1IJ1uu/IK3rr9vjBU5NTzSll5WGY3D44+LSk1ombGhOZsRelFGmS1IKj1ogISisyjoNWYJTCATzH4GhDpVIhTdMzRqVSOQnneFkmju5jau9DnP+xdUliCs5Tz/3k5TcP1CLIbBHlvPctQ5i0cXR62q01SRzXWh4iiOPg1GUxp/RlEgSTJFiJT26QMwqgmU0zq97tP/0bVswPcM/bkOw99Iz/2OOjfx7Hp9fLZwAiYqy16CCsxcvUorXGei51TU2oJCUaHiba+ybh3n0kb71NMjSELRZJikXqN24kd9tttSfos3RwJCXb3M6Wh++mbmQzq2/ZGFXw/Z/854MPbHlV7VAK7CmV05mA1mKNwT86hA4CkvY2lOcR7d1L8MuthM89j31jF3p8nIwIjjH4rovyfSgWyRSLJ6V0+rIpCmhsbWfHk//Ekafu4roNn7J0fIZNT/x18Z8fnP58OpNinepCnfcWTOUwnIhdN8pXqnbeN77p2O5uq94Z0FOHBnDjmLpcDq+hAdPZiZqRkLW1cJjGMdrzanFKajngLKjWhmwux9MP/h39m77G+vWfsO6qO6Otr9zr3/P3u1YdG6V6tgL+DMAX4vh7n+3ru3XB6tXkBgdR+/u0ztYhvb0Rk5OuUopUa5JqFSVy8mVFa9JqFTdNUCKg1Ew4q90/1r+L5x74CnJ4M9fddG2SXXEzW7d/27/7vif+4LU97H2/7sJJQDsDuQXe+NrAwMdvmJq6f15LyxKbcbSOY91VKLj1ra02HBhIZHLSVcagjAGlajmfMSRxhDYuWilskjI1eoTDe7fQt+0him8/zoXLu+zKO78TJdkF/s+e/Lq95x+2r375dV79oNbH+/ZmXFB58KT2FuZTcP3NHR3f7+npQcdxEg8PJ8nkpCNxrBVo0QpTiTlyeQfH1jTB1DgSjtDgxXbRkuV26dprE6f9fP/AwC/58U/vf/7+H05eM3CUsV+reXS2RiW1mnn+VUp94xPd3bd2tbeTAdJymbhcTiSOkmSygnd1J97Vi2lw8tS3nePoub0Ojk//4Gs8++yPjj36RP+XNz/PQ1H8G7bf1Fnms2sthMJa+MOLs9kbepuaLmvN5x3fczGViKbPryF7/YWUhscZnRziQP++sd279zz+0iul+19/k22lMsn/agPzw7SAW2ot4LnNkLM9+NFCdHGMiePjDI6f4MR0tQZ1sgVsz0jGfrtN9Fmw//Mm+m/jb4j/AfRLg8hxhcQYAAAAAElFTkSuQmCC); }
-/* Ghidra — NationalSecurityAgency/ghidra dragon logo (ghidra-sre.org), text cropped */
 .dlogo-ghidra { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAIZklEQVR42u2Wa4xdVRXH/2s/zjn3MTN3Ou/3QKctUpGGhkILlAYQAR8UChqlAgIWgkiICFFTRFAa0YhCY1QgxJIIYhosAqXFCBhqebdDH9S2tDPTKTOdV+feO/d5zt57+WGmOpiKJH4z80t2ch47e6+91l7/tYAZZphhhhlm+F+g6S+CCMQMCwBEWDW7eXlBcGF5deV3srlo8KVc/vef9P3T7+sb/JHU5NK5sjm2AH/EBgTAATizubp1eXVq5TBTfT+Fr0tjD/Zly0PbR7IDJWPssfl8PAMFAW7qzx3z2q5ZXB2/cCG8ryRLFmFoQRawSiCwjFfI7mtLKP+re/tP3zuRG/k4nrhxTvNl91bXPH3IEqhCoC20cCGjO6GxLwrf+euR8fv+cnjk2UwYmelG0jHPOWacNqui7uauxls/Y7zVVXmDccHGhs6ASDCzkwJgJVTMQSkmvEk8OOjZF+7c13/TWDmMiACednwBAEJgSaqia0NLy/6JUhQ6TyIRWuSNc5BCSE2iQkt1JO7hRYq6H9zTt6w3nc8cM1Iee5iXSiQemN3y7KV5uTJTDku5kI0rMIJA+olKIWOBUFyGivJsjEccCqCFObmIvNP2Sep9t1jYTo4xPSJCEB7obH/izqrUwza0JSlJHwQLLaVqUlI5gowcmzByRMWwuACipbkqeeaWfOGPUWTLDEAKAKQl/a6z4+9nGnHqoDUFFEin2rRXtyImJ84SfT1d7qXhOdwdLNBBS42uj3qtMMyWJVHWmPLiROKyhamKU15IZ9c7ZkgiOAaSntZ3NNT9IWXZgEhpBqLWuPjl0cy6TGTeS2o1v1kqZcAsiDwOne1yoqNI+GBrLve2BE2GeHVX2y3f0Mm1RRuVuEiqYamvDpztNv1k49DNf34j2zc8HDkAqKnRtOK86k98r71uQ2KjnZONrFGKlHYcRsrzvjD4wcnvjqf3AEBHIlb1/dq6NZ9LxG8+zA5Vhl19QottjX7/ss3d7WBGbcwPvjyr+ovfqqxa5zl2ZQAKMCkpva8PDy15avToa1Tned6THe07T1WyK5O3Yf0CP3jj3OihK+49cFsmY4+bnHPnxrynzmnf2Poqzp+AM4JIADAHwelPH+hpurAyOf+R5qYdAQP3TGTXzFGyfZUXX7kZ0dZvHh64uD9XzBIIbioVllRXzV3X2LgnsOwigvABlyW4C3v7UvLi6uqzV1VW3J41phjzpJ/+vNh50f3vXzY+blkr+tClJwK0JIyMRnbzWO6JFaemlicG0RApOMHM7VJVDmt5ZH7MX9zh+0vvyWXvfnR44AeHS+Zv19XXfPvB8fHbXh7LdCsiWDAIgCZCX7E0Voqrns/GEitK1kWGiOuE8LKCesRZsdjlEZxzRXbV87V46J3RG8bGjNOSEBn+kIHMQGQZShJ6D5XNNe8dPkd2ilCE7FiQmnDW3FdZ+avIU4vO6+lNbUoP/ZjLzO/ny2P9ksN9Ydgt6F8SwgAsGALAhnxm/WA9nGehiCDKzO7sWHCtOC3wv8TMQguRHK9yhee2ZbqJAOv4P2qasQwlCG/szWfvSo8sqU0pz0YuJIKyhsOrdLBs8WzVSTFjGvx4as28jsepIebtyBb6HQNu2qkdT4r4aDYqDdS4A74UApNzRJPSnxJ7wvJTighaEQYKZlt/fxgxf1jPjmukYygiPLxtbPsThYm7arUKjEUYKajGJqvurqnfUkhrOVwqph8dGLp15Zv7O9LlMPpPVYcdgysRkQLAEDwZ/kDEiWLMABGhPGaK1vLHrpOWJ8Nz+/7BNbvK4fZkAKVPMC4nnek6opOrGxvXOjB2ZXKjb41mDn1UKUwGUjZWqM7IMIgmRX7CuSExakyPALky2DXm1cKmGi1pKiH+G4xJMZ6w1t0+PnSxamMhNBsMSy8dmtL1yeSNV7bWXQIAvhTHXUNKAgM4fW7FvE6t4sWCLUHAKSL0htEWsb1YepkAYQTn6nJy1tIg3sUABOhjedE4Rk1Si0JLmPl1fuy65JAXRBMoCS2CQikq/ay+9vmlHdUnl60DAChJkGJyaEkwliEgxOoVTevMzshBCcUMJ4nweqm4XmzKTrz9gTHDPsHLR87dpFJrPSIYnrxjxwuJmPpOBLTMisnZTYl43Gp9//bx3z7Wm7ur3ldBZF3JSRHIrA0fb2/cfdWihvOhBYxlWDc5IstIelo/9t2uR5Zk5MKjuyOnYqQ0Q4ywC/+UyWySBedcJOitKyorbxixNnOi583v9Lz8xlxuq+VJrRLT2h4+FloitKUS6pTWVE3gCXkkHRYHRiPzSjH/6pKKxBlztXdS3rkQkjyZdmZ5ffLaZUtT5zV0BlHNLF/MaY03XH5OzSU/v671mXOP6nMH1xeNjpOKrCvUK+U/MJ6+fmM68zZJIjgAv2lt+eHVlZWr+6MoWytl5ZZ84ZE1o6N3vlYopKd7sNpTNGdWMjm7tqIuiGmvtT7RtGPw6N7n3x0YcG5SQho9rZ/t7NgxW6iTxp0NlSDPljmsigsvdqKGaxSgOEGVGRO7Q2R6rNFJUpFzpXqpgpfD0otX9h66KLKO/xlERYSfNjbeck2qam3GOZcQQjhm7CyVNuzj8it9sLsGHQ/UVQQ1Qcz3daBVQSC36eDQtt0D6aKd0iUx1Zx2Bn7sybaWrXOlXpBldpIgrINxZWcmO+LJIiB94UmfhHMwKSHUlrC88er+w5ceneoL5bF7ZQFsyuXeHHb2mTOC4AIGEiHgTvC9+R2BvoA0JspE4wXHOQZcb6546Ln9R3a9PzoR8r9ltiTCuDFmcz6/blEyvqhZqhMjhpUEJTUp6ZOSvlDSF0pIIscwHpF4upj/xar+ga9lImPFR3TpM8wwwwwzzPB/xD8AGjpDGFrm2d0AAAAASUVORK5CYII=); }
-/* Hex-Rays/IDA — hex-rays.com favicon */
 .dlogo-ida { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAK5UlEQVR42o1Ya6xUVxX+1tr7nJkzM/deLgVuETD31ogFUtOG0KYJplpSqyQKwWhCjKmVFEu0PqLV1safPhLbH2ol2sT+alAwvlDAFkxarj/6kD+VtsSCQdL23hau3BfzOI+1/HH2PrMZoDpkmLnnnNn72996fWsR3uWVJEmt0WiMtZrNm+u12k1s7SgzLyOiEVUVVYWIgJkhIgAAVYW/7i5A4b8qZ1n2TxF5J03T13q93qvdbncqTdPetTDQ1S42Go366lWr7h0ZGbm/Vqt90G8oqhUIqEIcGA/Cg/PvCqAH7X8fXE/T9OTCwsIPZ2dnf5NlWfo/AY6Nja2dmJg4FkfRmkIERVG0VcSCiD0LAKAifuOSK3c9ZBKDwPrs5v5vIooJQK/Xe/nCzMynFhYWTl8BkIigqli9evXmiYmJSagiL4ouEVlVtSjNyQoIVFnKT6gIq6oAYHGfFTARUSJWEXEAWUVE/bPumojkIpIycwMAzp8/f/vs7OzzVzC4dHR0bMOGDdOFSEolW4wSlD+1AOizV7Ll6fKbsqqKOqAhi6ELoA/UMyv+TUQ8PT09sbi4+Ab8hlEU8cT4+CF/UgDWsSFuEyGivumcD7nTsbvCCJ5xzAqIoICEv1H39msO7Gmvu+66g9ZargCuWrXqk0mjsTHP81RVS1P0wQJEDMdGGJXV/RIMPHtEBCrvsZagyt+XYIE+MH8QoDwEq0gaRdEtQ0NDWwCAoyji4eHhe4JNoZ49H22lJUsf9Iv7zfwBABAzE5EMHEIqUB6MswoCE3ufBBFEBEmSfMkYwzZJkuGkXt+a53nORHFlwj47Pi2I80lvdg78h5kIWZ4jyzKOokjIH/TydRgD7uCYFvEsAxaqeRRFW6IoanEURaPGmFhFcu2DqfxIAycPgHu/E1UFM6PdaaPRaOCuuz6KWq0GKQNJBvKYVKYO1gbA1Dc5RCQ1xrSMMaO2FscrtdyJoSrk0oCPZO37RmUmzzKVvimLi4tYt369PPLIdzkvchw//lxp8n50VsxpGGgueNx9gfNfLdMbImvfw2zMiIgA/VzVz1mevRIcB5uxYeZupyMAcM/n78WPf/I4b9x4C9rtNthHc9/Elb+FryAQyzzr1vfRzcassMaYpQHtCBZj73d+AagyiIRUMT8/zzeuX8/37/kyNm/ejDTtodNJYdn6wPBmE+9z6nKp908qrwFB6qo+S5CRZealrqYyBtNH8KmqYozhbrfLIoIdn/4Mdu26DytWrEC7fQnMDBsZqArSLGMmFue5DJd+wkpTpRWXBbyVSBXiDsFEy2xIvw6YwSfV0mTKC/PzWL3mvbjn3i/g7o99HIDi0qVLiKLIuadidOkoxsbGcPr0aW42GmBjRAfzZb9K9ctjwLQPUhBZs2TJktsajcbWoJSpwyYKqDGG0jSVPC/orrs/hm9++2Fs3LgJaa8HBRBZC2MYxjCYCLVaHSuvvx71JMH01DTm5mYpimMvyQgAOUbVsUmODHLV0xca7vV6hy3cg9ovZ+xzFhHJwsK8rFy5infd90V85M4tICK02+0SGDOICERl2WJmFEWOoeFh7Nz5Wdxxx4fxh9//TiYnJ1lE0Gw2URQFNHAfrbJ5P2BCK5rh4eFbm83mVgeUvWlLCpU2bbpNH3zoO7Tx1luR9rpQUVhrwUwwzGAmsDFgYlhj0Ov18NZbU1AVjI+PY/v27TQxMS5TU1P65ptvEhOJjSJ2ck2IiAITk+cVAKdperivTspoEmd79Ho9jI9P4MGHH+F169ajvXgJqgAbAxCBmADHGoPABDB7NgFmgzzL0Wl3sHPnTt63bx/v2bMH9Xqd52Zn4RI8V4rIlzxXNisGl4yM3JYkyVYFhIiMV8rGWvnPzAy9+OLzSJIE4ze8D7U4hkgBNuzYYximkkVmWGvR6XQxPf02ImuRNBIkSQIAGBkZwebNm7FlyxZMT0/L2bNntdfrkTGGgpgk5245EZk0TQ+bkZGRTUm9vlWKIgdggv6BiAgXzp/Hc88+i7enpvD+tWuxYmwMcGraWgM2HmgJsNvrYnp6GlEcIUkSJPU6ms0GrLUQESxfvhzbt2+nNWvW0L/OnMHF2VkEUk7U2ZuIuNfrHWFxmxGRL0MSSvW4VpM4juTIkUP4xtcewP59T4GZ0Wq1nFs4XUdUyV9VgNw/T04/iArkeY4dO3Zg/4EDWLdunXQ6HRCRXCFStK9IygaoRMuiCnKSqCgKVlVOkgRTU1Pyg+9/T77+1Qdw8h8vo9lqwUa29KdSA0JFXREoAZPzS994GWNgrcXRo0exe/dunDp1imu1mhRFwVUGCRzTVlJcRIjZaljFfSrwizPzyMgIJieP45WTJ7Ft+3bcv2cPVixfhjTNSpnnEgcxuWxQ6jsigjEG586dw2OPPYaDBw9Kp9NBI0k43EcDgUxUlhYabAUdo1XfG17L8xxDQ0Nod9p48slfYvfu+zA5+TfEcQQQUOZZgLi/YbPZxOLiIvbu3Svbtm3DgQMHQEDpJqVLiRex6gSu21OtEpFPkhKWnEDziZPtqsoESJ7nzEQYGhqSl158gX/06KPSaA3x+hs/UPmcFoqk0UBST3Dw4J/wxBO/wIkTJziOY7SaTYgqF0UhwT4VSUGnaa0UxaWw0SanAWmwD768HXDIhWtxDZG13G538O9zb8BaA2MYzVYTp19/Hft//SscPXYMRVH4wJK89DcvQkIxDCLioG9esCIyEzYvAwW8EgyXNTauNBoizvIcjSTBzTdtABuL1069hrn5eTx95AgOHzkiMzMXuNFoIIoiKYqir5p8KxqIFN9BBsLlgvWy3aUaOM3X70WcPHeUc3BU9iYhJgwND+HkK6/imaefwaHDf8a5s2climO0Wi1cBqy/eai0Ra8iaEWkbdM0PecekMr/Bk6kXlj2/ROqKkzEhQistXLs2F/5Z3v34sTfXwIzo15GJ4o8r8qXa/grmU+ug9PQlRx4R8gcNZvN5WtWr35HRFIQ2UHR6rt97Tfd1TTBt4hOpcjc3BzX63UfmVXiH9g8/LzaPVHVlJnjmZmZVZxl2UIvTV8HEGtf6nMwHfCM+j6ZpTS/H1VgYWEB7XabkySphkpy5eBIAgD9tf2cJ7gPoJ5l2Zk8z2c5y7JumqZ/BJEURZG6MZvPSxxs5r+LTzned9kJh6IowmdF++kpDLwqO/i/vT50BSRnZuR5vr8oii5r2QA9LiLsU0tQiy+TQtVGZccXdmJVQg/aUg4Y4WDEgYE1w1lOlXra7fbPVRUGANI0navVaqZWq90pRdFWIPYFNciRVE3DtD9Ccv8RObOHaUhLScQiAgIoUErVmiIiVMoZUtUOM9c7nc63FhcX/wKgBAgA3W73eL1e/1AUx2sLNxscGPAQ9VtTv6BWzbaTaEHD5Z8RfzD/PQwWp6hFVXvGmCTLskMXL178iufABDlHu93u/jiOb4ii6BaUZmsroC6K1QNwQC8fWDrJPhDtGphXEc4NgVxVcwAZgMgYY9M0fWp2dvZzRVFk1xwBMzONjo7uarVaPzXW1l3+g4h0rzkZcIl9sNK4AMlRjjIGk3HdC1URudDpdB6am5t7UgceoneZ8C9rNBpb4zj+hLX2dmvMKiKCBEPIACkGZi7X/O7n2HmenymK4oU8z59pt9u/zbJs8f+e8l/WtBjDxpi6YU5AFBljhoPbETMPOYCVj7oDEIBCRC6GAEVkXlUzEWkXRdELm6arvf4LuwP/7Nx4g4cAAAAASUVORK5CYII=); }
-/* Binary Ninja — Vector35/binaryninja-api docs logo (binary.ninja) */
 .dlogo-binja { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAMK0lEQVR42rWZfWzVVZrHP+ec3+93Xwr0DdrLBaQtUxiZdQYs0gGUsQF2dk1mHDNRgytdwFGJFFhcZtSNjOKajSRqUGQh2xVF0Y2yuzExixmXBdNuWqkDNI6KiKWUESi0pZe+3Jffyzn7x72tlWF5cfAk54+b8/b9nec8z/N9vldwBU0IgZSSIAgAiEajzJ07t6impqbqpptuWlBcXDxPCFHpum4xgOM4PVrrI+fOnWvev3//f+/bt+9gU1NTbzqdBkAphTEGrfXlz77cBKXUMLDrr78+tHz58r+cMWPGqq6urkUfffQRBw8e5NixY/T29jI4OAhAXl4ehYWFVFRUMHPmTKqrq4nFYrs//PDDF1999dV9R44ccS/c+6qbEAKlFAATJ0606uvraxsbG/vXrl1r4vG4AQyQATwgyP0e2YPcWAYwsVjMrFmzxjQ2Np7ftm3b30ycOFENgRRCXD24oUX33Xff1NbW1i8efvhhY9u2AVKAh5AGRBaMEEYoZSK2bSKObaSSBpEbQ5jsXDwgpZQya9asMR9//PGntbW1Uy4877ImFkJgjAGgvr6+tqKiYseyZcs4ceJEWoETCCkxmmjIZnb+KH5ckMe0sEOppcgTAgQkteasrzmSdmnpS7I/MUB/2gUhURgdGONOmDAh/Morr9DW1nbPypUr/01r/Y2zLwpw6Cts2+add9556sSJE+tXrFiRBhzbsqTn+8TyIiyJF/HzglGU2QoLg68NgYGA7OYKgRJgCUEgBB1+wH8lBnnt9Dm+6k9iWxae72vA3bx5c7isrOyJO++886lMJgPwDZDiQk/VWrN79+5/bG1tffyxxx5L2paKer4GKbhvcikrSwuIS8GgH5AxJgtJCMSIzYYeIbmDQkKQpxRdxrD1bIJtHWcwgcGxFK7vJzds2BCtqqp68vbbb98AoLUeBjkM0LIsfN/n5ZdfXuZ53vYVK1YkQ7YdzXgehZEQz0+dwG2jwvR5WWAqB+pKmgECY3CAfNtiT8pl7ZGvOJtME3IcMq6bfPHFF6OO49y7YsWKN0Z6txjp7kuXLv3e8uXLj86fPz/p2HbU9TxioyLsmH4dP1SSbj/Augpg/x/QIqX4QhtqP+vgxEAKx7ZxPS+5d+/e6Pbt2yt27tzZPoRJSCkxxhCPx9UHH3zQVlNTM+HUyZNSIOSokMXbN5TzAyXoDTS2+LbQvtl8Y8iXkjYDd35ynJ5UBiGEP3bcOBobGzvmz58/9cyZM1oIgRp6dy+88MKy999/v/a9995zbcuyfaPZPH0yPwnb9FxDcABSCJLGMEkJpubn8c7ZBEpK2dff70opS+6+++62d99992MpZdZalZWV9q5duxKzZ892dBBIPwjk4utK2DRpLF2uj3UNwV14kyWOxT+c6uVf209jKaURQu/fvz991113FbW1tXkS4MEHH/yrt956K+q6rm+MkUVhh4fHF9Hv+ajvCByAEoKE61MXKyCWF0EbI33f9994441R999//0IAmUv8v9mxYwdCCCvQmsXxYiYpSSoXjvR31MnlwVIBtfFicsHaev3115k/f/6vw+Ew1rx584rPnDlz86lTp7QQ0nIsxR1Fo0kFAVEpkd/dBeY8W5AOND8rzGOLY5P0Aqurq0ufPHmyZs6cOYXWggULZu/fvx8hhG8wzo/y86h0LPo8n7Oej74g9VzLJnKhp8hSlIcdqgryaDh7HiGE39TU5CxcuHCWVVVVdevGjRsxxkiA2flR8oB2IfnF58dJZrzhja79G4TAwKYp41kWDTF7TJSGswmMQR44cID169cvtMaNGzf3yy+/BJAA34+E0NrkvCwbWAHkt6FFl2iB72MAbcAIQaAN0yIhEAKMkceOHaO4uHiuZdt2ZSKRyAJUirhj4ZsssxjKrwLQ35ZYXioe5iwjcyEn5lgIpTC+LxOJBFLKSsvzvOJkMpkLoBBVAo34k8S/bt064vE4WhvESM/J2T4IAqSSCCEIfD9LdoXIjg9vZrLjgWbjxmfo6e4efjpaQNgPsHSABwwODpJOp4utS5HDkRZduXIlZWVl1+z26uv/he7u7kt7uDFI27Z7IpFI9hYMpDRIzJ84RSKRIJPJkE6ncV13uKdSKbTW1NfXM2vWLKZPn84jjzxCMpkklUqRyWSG52YymeE9RnI+Y0AayFiKQMrhuiYcDvdYruseLSwsLD1//rwmCGRnxkM5EVSgkcYMPVr6BwYIhUIX/dIDBw7wwAMPDP8+fPgwsdh41q79u4vOT6VS9Pb2DpspEnaQwFkvQAcaQBcUFEit9VGru7u7qaKi4ubjx49rQH6RdjFjIhQoyVjHZsD1QQhWr1rFE088SUVFOZZlAYJUKsXhzw+zYcOGLNlFgNbYtmL9b9cT6ICb581j9OgxCJElot3d3bz00kt0d3cjZfbNxkIWBjiaygyRXF1eXi7PnTvXZLW0tOypqqr6zb59+7Qx0NKXJFmST6GAuYWjaO9P4khBa2srd9zxi+GvFheh5jMLRlERDfEfp3oIvAF+vW7diDpnKDJn19hS4mnN9QWjqXQsBnNng0AI9I033khLS8seuWfPnt/PmTMHY4wlpOBgYoAOXxNozYpYIcXRMK42KCmxlUIJUMYgc6zazpWmRkqerBjPsxXjiY2KogFbKSwpsnMxKGOwc/t4OltG/P3kcYwxho4goCUxMFQ4WXPmzGHPnj2/l83Nzb3xeHxfaWmpxBg/7fm82zuAJRVxATunX0f12Hy0EHhBkCuOct0YPK0pGx3ln6dfx48cReB6vPr9idw0Nh9vqKDi6zWe1nhaUzEmjy3TJ7Mg4qCF4Hfnk/RnPDDaHzt2rJw0adK+5ubmXgHwzDPP/HV3d/fuZ599Ni2lDI+LOPzuhnLCQUBISrSUfOp6HB1M0z/CrCEEkyMON4QdCoD+QIOAiBAEUvJJxqUt5TKg9XBUCAFlkRA3hB3yBQz4Adqy+Okf2jmVzKC1Tq9evTocj8dve/TRR98TAFOmTLHffvvtc9XV1WGMkX4QyF+Vx/ineDGdGQ9bCCJS4EjByIrEYPCNIa0Nnsnm1iF6JowhKiX2JdaktCEWsni6M8HmtlNYSmkDuqmpKX3PPfcUtbW1eUopRU9Pj541a9ZXZWVlv2xubs7YyrIOnR/gh4Wj+YFjMWiyZkppQ0rr4Z7WWbnA5LLQSIcRQuBedI3BAzxjKLIkH7oBjx75I0pI/CDIPPTQQw7wq9dee+2QUurroqm0tFQ2NDR8ccstt0zu7urCGGONjYT497+YTJkQ9Gl9zai/bwyjpeS0gF9+0sGpwTRSCL+ouJjGxsaOW2+9dbhoklprpJR0dnbqp556atGbb75pBVq7lmVxNplmyWcn6DBQqCSeMX827fKMoUBJOgX87edfcXIghWNZBFq7O3futJ5++ulFnZ2deqiYk0OJXinFzp07248ePXrvpk2boq7nJUOOQ8dAirs/66DZDSixLaTJviFzVaw5S90whhLb4pCnueuTExxJDBB2HDKel3zuueei7e3t946sibMyygVa4O7du/+wcuVKKisrF/3P3r1Jx7LsRNrlP7vOEzg2M0dFKZICfxiouKjKOMz1MFhCkG9JXKnY1tPH2iN/pCedwbEsMp6XfPzxx6MzZsx4csmSJZuHbu6S4lEoFGLXrl2/PXbs2IY1a9akAcdSSvpBwPfy81g+vpif5keJKYkwBk9nweoRPM8SAlsKEIIzWrOnL8XLp3r4PDEwpGRowH3++efDlZWVlxePLpTfpJRs2bJlcXl5+ZvLli3j9OnTaSWEE4DEGMZFw8wrHM2PR0eYGnEYaykiKstE0oGmOwg4mnJp6U/xv739dA6mQQgU6MAYNxaLhbdv305HR8cl5bfLCpi1tbVTWltbP121apWRUo4QMMXXAqZSJhpyTFE0bIqiIRMNOQalcuNiSMz0gJQQwtTV1ZnW1tYrEjCvVAJWW7duXdzQ0HC+rq7OlJSUXLUEXFJSYurq6kxDQ8P5rVu3Lr5SCfiqRPRp06Y5S5curamurl598uTJ21paWjh06BDt7cfo7U2QTqUACEciFBYWUF6eFdFnz55NPB7f3dLSctUi+hXd6xBvG9osHA4zd+7cwpqamhurq6sXjRkzZo4QYpoxpjh3+z3GmCN9fX1/9t8Q/wdWxFg+TPRL5wAAAABJRU5ErkJggg==); }
-/* r2dec — radare2 (github.com/radareorg) mark, recoloured to light for the dark UI */
 .dlogo-r2dec { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAF0UlEQVR42u2WX0wURxzHfzOzC/f/EGjZtVgCpparpE0kEMWYRpsIUWo8eOAaUZuLSBqaXKItmNinmvjWpEZIavvkQxNNNJQGEtI+QcWmGiCnctylKijo0RPwDnb3jtudnT54eznxwJKm6ct9k8le5mb299nf/Ob3+wHklFNOOeWUU07/p5DxA2MMCCFgjKUHQggwxsAYe7E4438ASD9fawShDa03eBhjLzYbL1i94F9/PUJACNnQHozxS7bTZBUVFbwgCFZVVenY2NgypRScTieqqqpyqqqqAwDjOI6Ew2F5cXFRs9lsZH5+XltZWckKhjEGSikAAJSWlnI8z6OpqSnVOIW1HKLrOgAAVFZW5sdiMQ1KS0u5S5cufT46OjoUCATuTkxM+Pv7+3vq6uoKtmzZwk1PTz+9d+/e+MTEhD8QCNwdHx///cqVK193dHTUlpWVcZlHuNpjoigSn8+30+/33/L5fDsB4BWPYoxfmnO5XKbz5883BQKBu42NjZs5r9e7v6Gh4av5+fmQoigLGGNeFMWqxsbGfQ8ePPgzEokECCE8ADBKabKgoKAiFotFenp6bmUaIoQApRQopSCKImlpaaltamrqLCkpeY/neWs8Ho9nizHDYy6Xy3T06NEDDQ0Np61Wa7GmaYlkMqlxoiiWLy8vhxljDGNMAEAHALh8+fLA2bNnT9ntdlFRlGcIIYIx5nRdVzNjhTGWBispKcFHjhzZ5Xa7uwRBqJJlOfL8+fOHhYWF7+DUGa4Gq6yszD9+/PjH9fX1p2022xuSJIVjsdgjq9VaghBCXCKRWOZ53ipJUgRjTDiOMwOAPjc3l7xz587I7t27P5MkKUxS54AQwuiFQNM0AAAQBIG0trbWHTp06JQoih9IkhSJRqPTGGNCCMk39mCMQVVVA8zk8/k+ra2t/cRut7+VAntMCOEJIXmGp7lr1679XFdX11pcXPwupTRpMpkc3d3dLbFYjEWj0ViW9IA0TVMppSAIAvF4PLXNzc1dgiC8L8tyJhifWk8RQjiZTKq6rkN1dbXN7XbvP3jw4JcWi6VQluVIBhi/+vJwIyMj0ebm5gNut7va4XA4/X7/xMDAwJNUwKNMOIQQ1nV9xel0vunz+XZ5vd4LJpOpQJblv6LR6EOM8StGEEKYUroiCIJ47ty5imPHjn2vKMq8oijPlpaWnqwFlgZECMHs7Kx28eLFP4xJnudBVVVg2TMrZozRUCg0NTo6enXHjh0tFoulUJKkZ4wxihDKlkCJoihyMBgMbd++/UeXy1VvMpk2KYqyoOs6TcV+9rxoVAxCSHqslfEZYzrGmF9aWlocHByc83q933R0dOwfHh7+wWKxFNlsNlHXdWpcJGMPIYSTZVm6fv36I4/Hc+rMmTP1wWDwV4fD8bbZbN5EKVV1XadZAY0YM26ikVzXESOEECN/jYyMRE+ePPntiRMn9gwNDfWYzeZNdrtdZIzpBmjqwzAhBDRNg76+vlmPx/NFZ2fn3snJyUGn07kmKF6vRCGEMGNMX6++GjX85s2b0fb29u729vYPh4eHvzOZTI6URzUDlFKafreqqtDX1zfj8Xi6urq69k1OTg46HI7SFGiSpjyVFVBVVaCUQjwej2OMOcaYboyUIc3wtq7rwBhLg964cSPa1tZ2oa2tbW/Ko4U2m21zZthkgmqaBr29vY89Hk9XZ2fnR8Fg8Ben01lmNpsLGGNAsnll69at/OHDh101NTV7ysvLayilKiEkH2PMIYSQ2Wy28Dx/PxwOz0uSxDLrq1FTZ2ZmEv39/bf8fv9VURTZzMzM/du3bz/N7I6Mp1GFQqHQUm9v769TU1M/lZeXbx4bG/sNrQZkjEFRURHetm2bXZKkZCKRoBhjZFwmxhgQQpDD4cgLBoPLsViMZWsADBBjvqioCC8sLOjrBbcBCgCQl5cHFosF/ecN50bbttUNB1prUbYeMUva2VDTupGG9Z/YzymnnHLKKafX628VzRN1ScxpEgAAAABJRU5ErkJggg==); }
-/* dewolf — fkie-cad/dewolf assets/logo-dark.svg, rasterised */
 .dlogo-dewolf { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAOAklEQVR42rVYe1AU55Y//ZgXM4zD8BIQ0MXIc1AkZRAFRMUHuMjNloZil1VLS1ajMboxariBBI1CwNqoN+aaorRKLd+57r0+ghYRRFG46O5FRAjKApFhHMEZZqYZenq6++wfoakJvhLv7qnqqunq6e87/fvO+Z3fOQS8wgiCAESE6OhoRW5u7pzi4uIr0jMfHx9ixowZfjNnzpwWExPzTnh4+FRvb+9gAACHw9H3008/tbS2tt5ubGxsbmpqGhgYGBCldymKAlEUARHhdUa86iFFUSAIAqxZsybm22+/bc3Ly/sHq9XKrFu3bn1qauoHPj4++sHBQWdvb2+T2WxuGxoasoiiCBqNRhcYGBgZGhr6jk6n09hsNnttbe2+o0ePfnvhwoVet9sNAAAkSYIoivDGRhA/+19VVbVfFEV0Op3Isiy2tbXVfvHFF1mpqak6X19f8mXv6/V6IiUlRbdz587Mtra2G4iI3d3d/7VmzZoYkiRHQXgjx2QyGQAATJ48WW61Wq0Oh8PNcRx2d3c3BwQEPOcUSZK/uF5k6enp+qqqqgpExMbGxlOJiYlq6V0JjN9su3btykJEdDqdaLVahwYHB8179uzJpmkaZDLZSxcnCAIIggCKop5DKTMzM7Czs7MBEbGgoCD+Nzvp5eUFaWlpPjRNw+LFiwOXLVsWlpycrI2NjVUGBwdTer2ekBb8tRdJkkDT9Kiz3t7exJEjR9YhIu7evTvrVzkpIbJu3bqpiIgxMTEK+H8wTyc++eSTVETEL7/88ncvikna80bKrosXL7a6XK5oi8Xi9vf3Jz2zTaKGX0MRL3OOYRiR4zggCAJ2795dx/P8rLKysnqz2Txz7969DRJ7jNKMxHfJyclaRITbt2/bT5w4sW3evHmrWZYVSJKkCIIg/x7UEFHked6l0WhUBw8efL+4uPgKTf+MD8/z8NVXX+Vu2rTp5Ny5c31ramosEiiEZ4w0Nzdft9lsxlmzZuUZDAbVlStX2srLy3Pr6upaZDIZJYoivgliFEWRbrdbrKio+Lqrq+uvH3/88cH+/n5ROgVp//r6+jMBAQGTp06dmsgwDD53StOnT1fHxMQopfvW1tb69PR0/f9V7P3www9/3LZt22wAAAk9KTkAAAwGgwoRsaSkZPEv4lGhUIC3tzcxtop0dHTcyc/Pn+K5yG9FT6fTEWFhYfTGjRsTWJbFxMREtYTY2P0AAL7++usVDMMMBQUFUSNrEFBaWro0Ly/vS4PBEGW325EkSeB5Hj777LOMjRs3Hl+5cuW069evP/FMDpIkQaPRkP7+/orx48drgoKC9MHBweNDQkLCx48fP8nX13eiXq+fqNFofOVyuRoRXTt27Fh67NixDinmxxI9IkJoaCjd2dnpLikpmbdz585rBADA/Pnz/dLS0mYUFRVdRsRRGiAIAoqKiuZv3LjxKMMwzxCRJEmSRkRREAROoVCMQ0SR47ghhmHMAwMDXWazudNsNnf39vZ29/b2mk0m06DZbHb29PS4hoeH4UXOeTopiiJ89913xQaD4R/j4uLehoiICNnL4swD9n+tqan5Y2pqqk96ero+Ly8vwmKxODIzMwMDAgJIlUr1q478dXWXpmkgCAKWLl0ajIg4e/ZsHZ2fnz+nuLj4akhICN3X1yd4cp5HQacfPnz433V1dVYAgICAgEGGYUzNzc0DT58+FaVyRlHUc5XAkzcR8RfJAQAgiuLofoIgACLCjRs3TDabzb5o0aJkOikpKfPOnTt/7uvrEwiC+IX8QcRRwlQqlSoJAa1WS5EkSavVavrndYXRDf5OrgSCIMBiseCDBw+upKSkLKcNBsPvampqDkiIvWwTRETpmSiKQFEUPTQ0xL/99tvqOXPmxLlcLp6iKPIVx0tJX4KIIIqiQFEU8f3339//8ccfXVJsSj48ePDgWk5Ozhd0YGBgeE9PT7tnjZSKtqR8iRHzCGaCZVlbaGio14kTJ+omTZo07XXoDA0NiWq1mhyLllKpTCstLa2jKAp4nh/1oaen50dfX189SVEUOBwO29i4EAQBXC4XiKIIbrebI0nS00FgWZbZunXrlvDw8GlWq9Vpt9s5m83G2mw2Vvo9PDwMAAAcx0Fpaen8p0+fPhUEAURRBJ7nQRRF3uVyuV70QXa73TEqFjy5DQAgJSVFt379+lVut5vfv3//Ea1Wq3O73W4pCTiOQ71ePzkrK+szp9PJKxQKrzEfKMrlctJoNP7twIEDBXa7nenr63um0+kCbt26deTcuXMHFQqFvKSk5AeZTEa/yEFxJBlIRASlUqn0POLMzMzUuXPnbp4zZ8766upqY15e3n6SJClBEIDneZDJZIRKpfLieV4EAPJFwoAkSbG8vHxlYmJiSlZW1vLh4WF3T0/Pre3bt3+4ePHiZUaj8UlFRcU/6XQ6n5doUjUAAG21WgeDg4PDx/6hurp6v1ar9a+trf1TS0vL/5w9e/bRqVOn5I8ePWpbunTpFoVC4cVxnEi+oAbSNE0zDMM6HI6h3NzcCoqioLGxsbq5uflKV1cXU11dfT44ODggJydn/alTpypeREsTJkwIZxiGIzs6Oq5ERUWlSLEn1T8vLy+tSqXSWiwW+9WrV/tzcnImURRFxsfHz+7q6mp4lR4UBIFXq9Vymqapy5cvlzU2Np7t6OjojoyMnB0XF6cvKCgoXbRo0Qq73W6lxrC35ENsbGzaw4cPq8n6+vpzMTExWVqtlpAE60hgu3ie51iWdQEA1NTUWJYtW1aWnZ29vaWlpV6hUIAgCNwr+Iz88MMPvzp+/Pg3dXV1J/Pz81fHxsZmbNiwYfPnn3+++vTp03+YMGFCLM/z/Ng+XKVSwcSJE2c0NDScJhYuXOhfVVX1dN68eb41NTUWRISysrKcqVOnplMURev1+uCWlpZrcrnca0R1sxkZGf/u6+sb+rIjlpxUq9WjgpSmaWAYRlSr1aTEdwAAH3300cy9e/c20DQNHr5CYGAgSZIkQd68eXPgyZMnPbm5ucukYzOZTMb09PT1CQkJy41GYxvLsk6WZe12u70/NDQ0LiAgIJRlWV7KNinjBEHgeJ7neJ7naJqG+/fvX7979+6fWZYVHQ4Hj4jgdDp5o9HYceHChT39/f2dCoVCPrZXWbBggb9Wq6VNJtPPlWHfvn3/PDg4+MzHx4cgCAI0Gg0RFxenjI6Ofq5p2rJlS5LUhnIchyzLotvtRofDIeCIiaKILMsK586d+31ERITs3r171TzPo8vlQpvNZlu7dm1cYWFhSnNz8/dFRUVzpYaNIAjw8vICm802fOTIkQ2jtSEqKkqBiLhjx460sV0XQRBA0/TodfPmzWMMwwy1trZef/DgQX1PT09bS0vLNUEQ8Pz58yVbt25Nvnz5cgXHcYiIuGHDhumXLl0qR0S02+2OrVu3JhsMBtU333zzLyaT6VFhYeGcsQo7KSnJe9KkSTIAAJqiKGhvb3cdO3Zsy/bt2//z8OHDvv39/aJU5jyvkJAQKiYmJvvZs2fGEydOFD1+/LgvLCwsRKfT+Vmt1u7jx49XFhQUvH/o0KF93t7e+uTk5HylUqkQRVEYQYn28/PzN5lMLoVC4S2TyZRSeIzwMZAkCQ0NDY7RqiXVxMLCwgMURdH79+/fOrbFlBCdNm2av4+Pj9bHxyfk4cOH3a2trX2XLl36q16vD7xz507V8uXL8zMyMj7Ozs5+98aNG38aEbcgJZhCoVAuWrTo/SVLlry1atWqg76+viGCIAiSQDh69Ojva2trv1MoFKPSjRRFEUiShMePH/MffPDBO8uXLy8tKCgwSJk3xsEoQRA4b29vL0EQcObMmZGIiEFBQRHBwcER9fX1V+x2u7mhoaF2woQJk0VR5DmO47q6uv7mcDie8jwvsizrUCqVCpfLxQqCwBEEQUiAXLt27S8nT54s4zhuVD8+p3YrKysLEBGzsrLGe04bAAAuX75cMSK78OLFi+W3bt06ceHChTKz2fwEEbG4uDhjxYoVU3bt2rVEEH7OmZaWlmurVq2Kktbt7u5uPX/+fImUUNu3b08JCgqiJEp6TqaN7QmqqqruJiQkeBUXF5+/e/fuofb2dkZyPjU1NUwmk4kkSfokJCQsCA0NNdA0rTabza1ms7kzPj4+IzIyMjYxMXGJ0Wi8bzQa22iaViQlJS1WqVTeLpeLmzhxYsKUKVPSmpqazrW3t199/Pjxw5MnT9612+3Xmpqa+miafvnMUDpKLy8vuHjxYhki4rp16+I9USZJEhITE9WbNm2avmrVqiitVktI2pEgCJDL5aONuPR/iqIgPj5eVVxcPK+6uvoPVVVV/7F58+Z3Vq5cGRUQEEDu2LFj9pQpU+RjGeSlnRUAgFwuh0OHDq1GRDx9+vS2kJAQ6k1kvDQvTElJ0dlsNofVarU9e/bMhojY0NBw9o0HmJKtXr06hmEYh9PpdBUWFqaNHV5KY7UXXWOr4KeffjoPEdFisQwJgoA5OTkh0uDgNw8wPbv/sLAw+vDhwwWIiAzDuCsrK/8tIyPDf9y4ca9dddy4cURGRoZfZWVlQX9/f78oiiiKIt67d69apVKNzg/faIjuOUgHAIiOjlasXbs2+7333tsTFBQUMTAwMHD//v2/tLe33+zt7e1yOp3DgiAIGo1GHRYWFhEZGTkrLi4u28/Pz89kMnUeP378o5qamttnzpzpKCkpWVxeXn7Lc/03NinQPSewCxcu9K+oqHj39u3bpywWiw3HmNVqdTQ0NJypqKh4d8GCBX6ezf2KFSsi33rrLfnr0AMA+F+FfGKwjUIoRgAAAABJRU5ErkJggg==); }
-/* Kuna — maintainer-supplied mark (kuna.png), black art recoloured to --text for the dark UI */
 .dlogo-kuna { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAJx0lEQVR42u1YXWwc1RX+zr0zO7O72bWd2IYE52/J2k5jwBAhQSOVBCoioYrfriuEWrUSghdUKKrUP1TbpK2ESlshykORUKWqVcsuAlVtA6WQNQ1tiRIoRHESz27sxHFCEstr73pnZ2dn5p4+eBdWKE5sSAsPvdK+zN45853v3HPOdw/wGV90KY0xM33EJhMRf6oeptNpmc1mtTq484Ku/y8X23OhpX0SYKlUShFR0HhWKBRaSqXSSmY2iMiNx+MFIioC8JsAy+Z3LjnAOgui8ZGJiYkbhBB3BkHwhdnZ2U1KqVYAGhF5hUKhOD4+PiGlfAvAn/ft27eHiAJmFkSkLvkZbDacz+dv1nX9+wBuiUQiKJfL8DyPhRDEzCAiSCmh6zpCoRA8z4Pv+++5rvuj7u7uF5hZZDIZGhgYCC4Jg+l0WhJRkM1mV2zYsOFJXdcfFEKgXC6XXdeVRMREBKWUSUSklIJSCp7ncaVSUcwsIpHINS0tLZl8Pv8zIvr2R53+2Aym02k5MDAQHDx4MNHS0vJiOBy+plgslpg5REQEQACgRhLUM1fUf80RCIgI8XhcOo7zarVafay3t3c/M9Ni2U5LDeuhQ4c2RaPR1zRNW1+pVBwhhGBmCUCGw2EyDAMAoJSCEAK2baNWqwVCCFH/DjMzACgi8k3TNIQQXqVSuT+ZTP5mseTRlpAQmJiYaAXwF13X19u2XRJCRJiZotGoZGa4rjtaq9X+rpQ6DKAEoIWIvtfR0bF6ZmYGzKwAkKZpZBiGlFJKx3GwevVqvVKpfAXAb0ZGRmjZDDa8Ghsbez4ejw/Mz8/bAEwiong8LmzbfouZfzI5Ofnyjh07/OZ333nnnY729vZnlFK3h0Ihw/d91Gq1OWY+CmBGShnXNG3W9/0fJhKJ9xY7i3QxcPl8/q5YLPZisVicJyKTiEQkEpGu6z6xf//+HzSy8PTp05t93+/1PG8VEXlCiHwQBIcAmEKINcwcikQixy+//PKzl6LVETNjdHRUD4VC74XD4U3ValUxs4zH43J+fv7xZDI5CADj4+NfE0I8YhjGtS0tLRBCwPd92LaNcrk8J6XMKqV+lUgk/lp3XMtkMjw6OspDQ0NUb4fLy+JsNqvt2LHDtyzrnnA4/EKlUikRUSQWi2nlcvlvyWTy1r1797Z1dXX9fs2aNTtPnjxZUUr9i4iOK6WEEGI9EV3b2traxswIggDVanV/tVp9tLe3983ldJPzJsn09HQj5b+haRqISCci6bquz8yPZLNZbd26da+HQqErp6am7q9Wqy/19fUVmm2cOHFiTbFYvFcI8R0hRIcQ4vpIJPJGLpf7JhE90yBh2SFu1KTJycmVjuPkpJRRZkYsFjOKxeKrPT09O8fGxp6LRCI3zczMfL6/v/8cAEDQh9YUA3UXLcu60jCMNBFd57qu39raqs3MzDza29v7i6UwKRZ7VqvV+k3TbFNKBfUSASHE7yzL6hJC3D41NbWtv7//nPXUbgMEWHr7lSe441tTqvPHk7T63n923RCGpqG7u/vYGdu+NQiCfCgUEqVSqRaLxX5+7NixLxJRkE6n5XIZ1IjIHxsbe6itre3pubm5CgBzxYoVolgs9kop72Jmv6en50nrqd1G98O3uWPisq+boF8ajCjXyXSAg0IF96zlcxNEFBw5cmT7ihUr9lSrVd8wDN113fFisXjV1q1bnabusyQGUX9hteu6ICIlhBCO44CIakS00vO89ODgoOh+5DY3r6/eaoB+XWOOzkJ5RSh/llXNZFxdEfTScSKdmcXmzZtHKpXKP6LRqO44jtva2pqIxWL3ERGPjIzI5YS4ATCs6zqYWTAzlFIgojgzH5+enj49NDxMYEAp9aDJgA/2CNABaASEZqG8OESfkpfdQppUzExSyj/pug4hREP5fBUAtm/frpYNkJmrCzoAzMzKNE0wczsRHdk+MqIySNX3IeEBTE22PlAKDOUx9wDcCGE+CAIwM9u2DQD9R48ebScitZjavhCDp33fR72IBqZpQkq5WdO0f4+mUloKmQUDjDPaAibVfLAVQEwQAJ1qcrqZKV/TtJgQYu2FavL5AHId4OG6+jCJCL7vIwiCOzZu3Dh3+PDhD0uDoN8KWigyvCDtAwZqUZBWgjoXVsaraV/JevlaJ6VsRIU0TQOAOABkMpklA1QAUK1W37Vtu6hpmg5A2ratTNPcns/n+1KplMqk02BAJIMzr8yxeqKFhNYKocUg5EqIEIBZSXTvekzOfm5oSBIRK6VuCoIPfBPMDCGEv6w6SEScTqdlX19fgYhGwuEwL8g8xYZhaEqpnxIRJxIJAWYeBEQPn/tuhWhnDfysD/WCA95lM67bFJzdw4OD2pahIW9sbOwKTdN2lstlRURSCCFc1w0AnAOAVCq19OtpXYjCsqwvvf/++2xZlp/L5diyLP/s2bOcz+cfa+xLp9OSFznLBx54QM9ms1rd1vNnzpxhy7KcXC7n5XK5wLKs45ZlGc3ac0m9mIiCwcFBkUwmXx4bG3s3Fov127YdEJEslUpBNBrdNT4+TkS0CwB4cFBYhZWGXiqQF1/JeqlAGzbAp+FhD88+i1wutysWiw3Mz8+7WChFgWEY0nXdPclk0r1Qy1uKHrw5Eom8btu2D0Cr39iC+r3iZaXUcCKR2Hc+GydOnNjCzI+bpnl3uVx26zVVMrMTiUSijuPc2N3d/VbjzvOxFfXRo0ef7uzsfGh6etoTQuiNC1AsFpOO4wDAm0qpvUqpY0KIAEAXEW0jolvC4bBeKpVcIpJEpCmlnEgkEnYc56Xu7u67LwRuKQAJgHj77bdFS0vLK21tbTcXCoUaEYUaIAHIaDSKUCiEelkCEcHzPJTL5YCZPSIKEZFg5rKUMiyEKGmadnVXV9ephe20/E7S1MDV1q1bfd/37yyVSntWrVoVYuaAmVWdFa5UKsHc3JxXKpXcYrFYnZ2drZTLZafex416pyhrmhaWUqpKpZJau3btVCaTueiEQV4so4eHhwFApFIpd9u2bX9ob2/vjEaj10spqVarBU2drdEXNQA6EWkAFDN7APxwOLxCSlm0bfvuLVu2vMbMsq+vL1i2YL1QuBuSaHx8/A4hxK5wOHyVUgqO48D3fa6DZSJq7PdN0wxpmgbXdXeXy+WH+/r68p9Y8i8WbmamTCYjEonEHw8cOLC7s7Pzy8x8HzPfaJrmylBoYdDAzKjVavB9v6iUeqNarT63cePGV5pHKP/VAeZHGTh16lS753ndSqkrAEQAVIjopJTSWrduXaERgaGhIRoeHlb4XyxmpnpNExeb6zQ606c2Am6EvqOjg5pvhvUB56c7Av7/+qyv/wCH+35xzg0c6AAAAABJRU5ErkJggg==); }
-/* Codex — github.com/openai avatar (openai.com), black blossom recoloured to light art for the dark UI */
 .dlogo-codex { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAM1ElEQVR42u1Ye1BT57b/9s4OCRKeIkp4SSGiYQ60ASrVVuotaBrEV7EO6DlqHW91Ot5Wqh3lWupwJ1R6QGdkWhlbnUJBenvo8IrSYDtGXsFiA44CQgDz4JGyEzYJSYDAzrr/uLmRgu2x58/z/ZWZb2V9v/Xa67cWQv8+f+5gf1gQwxAAIIQQCgwMZCUmJoaIRKKNQqEwxc/PL2JgYODHnp4e5Z07d9o6Ozstc3NziCAIhBBCNE0jAEA4jiMcx5HT6UROp/NfaAX2/3YcPnw4XqVS9ZpMJpiamoLR0VHQarVAURRYrVbQarVQXV19TSQSeT1LJ47jT+l9bg8yStzc3FB+fv4HBw8evDg5OYl++umn/J9//rlOpVJ1T0xMTEdHRweLRKL1EonkfHBwcBBJkta8vLwNPB6Pt379+m1+fn7h/f39jQ8fPrzb3t7e+/DhQztCCLFYLETT9PN7j7H0s88+O2a1WkGlUg1u3bqVv5R8aGgou7W19d7AwMAsRVHgcDjAYrEARVFgt9thZmYGHj9+DIWFhf8ZHh7uxrzxXIfFYiGEEJJIJCEURUFzc3NTTEyMB6OUIAjk5uY2L5+YmOhTXFx8SqvVwsjICJSXl188ffp02v79+/+yd+/ete+///7mwsLCo7/88ovObrdDe3t7V2pqathzgcQwDLHZbITjOPr222+/pCgKNm3atAIhhNhs9jx4hBCKjIzkXLhw4ahOp4OpqSlobGxsycjIEC6lOyIiglNSUiIlSRKGh4dh06ZN/v8USFdBoVDoPjY2RldUVFxmsVhPASMIAr333nuvdnV1Gex2O6jV6qkTJ078h4+PD8bcLzSY+T+LxUKXLl06QVEU1NfX1/J4PAzDsN8vHEaBl5cXtnfv3jVff/31ebPZDEePHn2FuScIAqWlpa2urq6+ZrVaQaPRQGFh4bG4uLj5ymWz2QghhPz9/fHNmzf7cziceaMY4B4eHlhtbe11q9UKhw4dErm+/0zPxcfHe9fX11dZLBYYGRkBg8EAu3fvjmDkXn311eXj4+NgMBigrKzs7/Hx8d4LgSGEUHp6uqClpUVpMBigurr6mw0bNvgxdwzglJQUPkmStFwur3d3d0dLepEBt23btrC+vj6KoihoaGj4sa6u7h9msxl27tz5AiMrFouDSJKcuXXrVgPjDTc3t3nFQqHQvbi4+NTY2BiMjY1BX18fUBQFAwMDtFQqzeDz+QQTdg8PD6y5ublDr9dDREQE55m5GBMT46FWqyfHx8fh6tWr57y9vbGcnJw9DocDtm/fvpqR27JlS6DZbIbKysprTHdACCF3d3f08ccf73r06NGk1WqF7u5uMisra4tIJPKUSqV/0+v1YLfbQalUKtPT0wWMQaWlpRd+/fVXOjEx0XfJMHt5eWEymax6YmICioqKPuRyuQghhPLz8w9PT08vBMg3m81QU1NzHSGEuFwuOnz4cLxcLq8dHh4GjUZD5+fnHwoICHjqpfj4eK9Lly59YDQagSRJqKqqurZjx47w0tLSC0ajEV577TX/JQG+8cYbqwwGA7S0tLR5enpiTAjy8vIOLAbQYrHA999/fy0pKWmFTCb7ZmJiAkiSBK1WC0NDQ1BRUXHhpZde8lwsNyUSSUhra2sbk+M9PT1TfX19dFRUFBfDsKdCjLskfhKPx3NWV1fnTk5OAofDmScHi+QrNj09jSIiIiRlZWVjSUlJ+7u6utqPHTsWlZWVJdDpdB1paWkn6urqLAUFBe8GBQURs7Oz81V88+ZN/bZt2zacO3cuhaIovZeXFxcA5nAcx5Z6E929e7dHq9WCUCh0Z75ZCKFFPSgWi4NGRkbg8ePH0NjY2JSZmSlcvnz5vLG+vr74vn37hCqVqt9oNIJKperLyclJ9/HxwReGMCQkhCguLj5NkiQ0NjY2hYaGshetYo1GA52dnQbmIaY6GYA7d+58gfnj1q1b+SaTCRQKRZMrsIUf8qCgIOL27dt39Ho9kCQJCoWiIT09XbAw7BwOB12/fv3SzMwM5OXlvfNUtJgfT/gaZ2GJA4ATAJx2u30aAOYBsNlsZDQa1SaTyUkQBMIwDNE0jWiaRhiGIYIg0PDw8BxFUUMIIefg4OCj6OjolCtXrvSVlpbmCQQCzuzsLCIIAs3MzKDs7OyTarVa+/bbb38eGxvr8RuA/f39P61YscJHIBD4uCYqh8Ph0TSNi8Xi3atWrWLRNI1mZ2fpJx7jMMBccwcA5oGyWCzk6emJS6XSN0+ePPmiWq3ukEgkZ+RyuWHPnj1r5ubmkJubG9JoNI6amprcwMBAbnJy8sbfAJTJZFJPT0+0Y8eO3a6PKRSKGwaDYfzAgQNF9fX16uPHjyf5+Ph4Op1OhOM49qzeyYDHMAzZbLapkpKS+2KxOP6LL77IXLlypU9SUtJ2V9m6uroqs9mMUlNT//s3ABUKRbvRaERpaWnnIiMjOQ6HA7HZbCSTyXRpaWnBP/zwQ2FwcHB4bm6uIjs7+0eLxeKkaRqeAH2qPTEReELtZ56EnMVisRBFUc7m5uY7OI477Xb7JEIIOZ1OBABoYGDAbDQax1evXr3pNwC7urqsDQ0N58LCwoLy8/O/8PLywmZnZxGbzUY9PT1T+/btO3nkyJEXlEplBZ/PD8NxHPf19V0dEhLCZkLMFAkT4oiICI6/v7+A+cQw3ly2bBkXwzAcX5DwTwyaWzIqfn5+uFwuv2E0GqGuru76mjVruAtZDo7j6J133hF1dHT0kiQJDx480J09e3aHv7///GP+/v54bm7uXrVabevv74fR0VEQi8VBzP327dtXT09PQ0FBwTGm4DAMQzExMR46nQ6am5tVS5IFgUDA6e3tnRoaGoLu7u5fz549u9P108MAXblyJUsqlf51aGgIbDYb3Lt3r+vgwYMvZmZmRre1tXVYrVZ49OjRVGdn58jY2NgzATLM5tSpUxKr1Up/8skne5ecPaKiorhqtZru6emx6fV6sNlscPv27YbU1NRQV6LKnISEBO/y8vJ8vV4PWq0WxsfHgaIo+O677y4JhUL3ysrKaxaLBbZs2cJfDCATTm9vb6y1tbVtZGRkvic/lYPM3BsQEMDz8fHBVSrVV++++25YbW3t50KhMKW0tFR75cqVnI0bN/rNzc3NAyRJ0j46OjoIAIggCNTS0vK/x48f/0tGRsZ/dXd3T7HZbO5S7YvFYhEAgJYtW4akUumHMTEx66uqqs4olUrjkkz65Zdf9jEYDHRpaekF5u6tt94SKJVKpc1mg9HRUbh48eLxhIQE79OnT2/XaDRgt9vh/v37uqysrGSmOzBerqysvDYxMUGnpKQEunrQ4XDAp59+esjX1xf/8ssvz1EUBT09PSaBQMB5JpsODw930+l00NTUpGIYLkIIBQQEsHJycnb19vZSFosFNBoNmM1m0Ov1UFBQcDgsLIztOu0xFO7WrVsNFEWBRCIJZt7atWvXCxMTEyCXy+sVCkXb5OQkdHd3G1JSUvhLElaGanO5XFRbW/sdSZK0RCIJZdgyc6Kjo5cVFRW9/+DBA7K8vPzC5s2bVzJ3jByO4+jNN98Mkslk/yBJEjQaDR0XF+fFGLtr164Ig8EwP06UlJRIY2Njeb872TFhzsjIEFqtVpDL5TIPDw9sYQUjhJArSXDleomJib4VFRWfkyQJFEVBVVVV8SuvvOLnGvYjR468bDaboaSk5H9ef/31FYtNk0u2JhzHEY/Hw2pqar6lKAqKioo+dB0V2Ww2cs0zRmlAQAArOzs7dXBwkLZarXDv3r2+zMxMIXPP9GWG4o+NjdHMd9ZVzx/eJiQmJvrqdDowmUxw9erVc5GRkYsmL0EQ6NChQy/evXv3/vT0NAwODkJeXt7+0NBQtqtOxqgNGzYspygKKioqLjOs559eHjF9NDk5OTA3N7cuJiYmbmBgYKypqem8TqfrMxgMQwRBsPl8fmhCQkL6+vXrM6xWq+PGjRsflpWVfdPe3m5mcpJZtTmdThQbG8u7fPlyfUhISPyePXv4bW1t1HMvjxiX8/l84uLFi8e0Wi3Y7XaYnp4Gs9kMNpsNHA4HmEwm6O/vn1EqlT9HRUVxl9InFouDOzo6NFNTU3DmzJmdvzuk/5H1m6t169atc4+Li4tcu3ZtTGhoaNz4+PhgZ2dnC47j+EcffaRYtWoVb3R01CGTyd7r6OhQqtXqIT8/P55QKFwrEom2paSkfMDlctFXX3117OzZs8Wzs7PzLOZPLy9/b1+ybt069/Pnzx9Qq9U2q9UKk5OTMDIyAiaTCex2O1AUBTdv3vw+NTU1ZLGl6L9kBcwM6ACAnE7nfMUz1IoBmpycHL9mzRpRUFBQ/MTEhGZwcFDV0dHRrlAohm02GzDA/rTn/n3+4Pk/Qzen6kK0xQwAAAAASUVORK5CYII=); }
-/* Claude Code — github.com/anthropics avatar (anthropic.com), logomark recoloured to light art for the dark UI */
 .dlogo-claude-code { background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAGJUlEQVR42u2XXWwTVxbH7z0zcz3jrxk7X42oCVGy6cqEDWAQIqjZECvIJnKLtPuwbVe7LeKhWq2IKtQ+tm+LeIEKNS9VpZIKpIoSqVohKwoiEojmwaAGR21ThUg4IhAZLDuxxzOTmbn37guu+gEkLoXtQ87Tna87P517/uf+L0Ib8XSBa4O2tjbp9wS2sLDgIIQQ/N4zuAG4Afj/DvGpWgDGP7nmnD/y2Y/vPzdAjDGilHLGGMIYI4wxAgBcA3Jdl2OMEecciaKInzsgpRR5vV6REAI1IMMwXIwxkiQJq6pKGGMcAJCu6y6llP88488EEGOMXNflmqZ5RkZGLodCoRcZY8iyrNLRo0dfXlhYqDQ0NJDTp0+Ph8PhdlmW4dy5c8MjIyNjqqqKlFL+TEUCANgwDNbX17cjGo3uURRlk8/n29TZ2dk9MDDwMqWUP3jwYHV6evrz1tbWTbIstyYSiffD4bDkOE7dWawbkDHGZVmGRCJx1DRN5rquQSm1dF1ng4ODx4LBoIgxxul0eqxcLtvVatXesmVLd29v7x8Nw6C1On0mgLXsbdu2raW7u/svhmEgWZa9hBDZNE3W1dX15x07drRxzvns7GxhZmbmgs/nEymlKJFIvC2KIq5X0fBrlJtKpV6TZRkIIWhubm58fn5+wuPxAACgVCp1RBAEbNs2u3jx4klJkqBarbq7d+9+MxqNNtabRagHbnV1lUUiEW9fX9+7lUrF9fv9cP78+ffHxsY+CAQCUKlU7L179/67o6NDBQA8NTX1bS6X+0YURfD5fHIymXy13jqEepbXNE22f//+PU1NTc0IIcjn84VMJvNdJpP55v79+8sIIVBV1RuPx+OMMV4sFu3r169/4vP5QNd11t/ff6ylpcVj2zZbLyTU0fe4z+eDAwcOvGNZFvP7/ZDJZD4uFApWPp+3bty48UkwGBSr1SqLx+PHNE2TGGNocnLyv47jINd17Ugk0rVv375tpmmy9S4z1CEOun379k3RaHTIsiyXc47S6fSn5XKZVSoVeuHChY8cx2Grq6tuR0fHnl27dnUghFA2m12cnZ0dVxRFdl0XJZPJfxFCMGPst8sgxhgxxlAikfgbIQQBAJRKpWVN07SDBw/+IZlMdqmqGiwUCnclSRIxxiiZTB6WJAnruk4nJiZOyrKMdF23e3p63ohGo42maa5LLGtafowxchyHNzU1yaOjo3OBQKDVtm2Xc84URSG1WuKcI8uybIwxAABQSo3Dhw+33bp1a3nz5s3+M2fO3CKEhFVVFUdHR4+cOHHiU03THruzrNvy18TR39+/u6WlpdWyLJsQIgaDQSIIAgIABABIEAQUCASIJEmi4zhuKBTyx+Pxfs45WlxcrF67du10IBAQH4rlvebmZs96FC3UBpqmCY96oeZGhoeHP2xsbHyJc86Xl5fvZLPZL5aWlmYWFxdv3r179+a9e/du3r59O+PxeIJ+vz9MKUXhcLh9YmLiM9M0qeM4i4lEYtiyrNXm5uaW+fn5L2dmZu4piiI8qnmvrKywNc0CAGBd193e3t62rVu3Dum6boVCIfnUqVN/P3v27FfBYFCoFTsAoHK5TA8dOvSn48eP31xZWTE6Ozv3xGKx9suXL89NT0/fyWazX3Z3d79i2zYbGhp6J51O/5Mxxp9KJJxzlEql3pJlGWRZlpeWlu5cuXLla1VVBUmSgBCCCSFYkiTQNE2cmpr6PpfLzSiK4hUEAQ0MDPwVAHC1WqXj4+MnFUUBy7JYLBZ7vaen54W1dhZYa+dob28P7Ny58x+FQmFZEARjcnLyRD6ftyRJAsYY55wjzjlijHFRFHGpVHIuXbr0HwAwSqVSORaLvRmJRHyCIOCrV69+ncvlvuecGwghfXBwMLVWu3miihljyOv1CuFwWKGUcgBAxWLRsiyLAsAjrTznHBFCoLGxUWGMIQDAxWLRtCyLcs5RQ0ODR5Zl8aHJZYVCwXySitdsM4wx5LouwxjjmmAAYM2yqCmUc85FUQQA+KFl1bJWc99PAhTX0WaQx+OBxx2OHlceHo+n9uMfLBbn/BdAa821Lsv/a05lj/vmmfrBjYP7BuAG4AbgRjz/+B9CoyRKNwvZjAAAAABJRU5ErkJggg==); }
 
 
 /* ==========================================================================
-   Mobile: stack the wide results tables into per-row cards  (<= 700px)
-
-   On desktop the leaderboard / metrics / distance / compiles tables are wide
-   grids — one decompiler per row, ASCII-bar cells across. On a phone that runs
-   hundreds of px off the right edge, so below this breakpoint each row becomes
-   a self-contained dashed CARD:
-
-     - thead is hidden (column-sort is a header-click, so sorting is unavailable
-       on phones — accepted; rows keep their current sort order);
-     - the rank (leaderboard) + decompiler name form the card's header line;
-     - every other cell becomes a "label ....... value" row, the label taken from
-       the <td data-label> app.js stamps with the column's header text.
-
-   Only these four #ids are affected — the desktop rendering above and the 820px
-   sidebar-collapse block are untouched. The About page's two plain tables get a
-   lighter horizontal-scroll treatment further down. */
+   Mobile (<= 700px): stack the wide results tables into per-row cards.
+   ========================================================================== */
 @media (max-width: 700px) {
-  /* table / tbody / rows / cells all go block-level for the four bar tables. */
   #leaderboard-table, #leaderboard-table > tbody,
   #metrics-perfect-table, #metrics-perfect-table > tbody,
   #distance-table, #distance-table > tbody,
   #compile-table, #compile-table > tbody { display: block; width: 100%; }
 
-  /* Hide the header row (labels move onto each cell via data-label). Visually
-     hidden rather than display:none so the markup/contract is unchanged. */
   #leaderboard-table > thead, #metrics-perfect-table > thead,
   #distance-table > thead, #compile-table > thead {
     position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
     overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
   }
 
-  /* Each data row -> a dashed card. */
   #leaderboard-table > tbody > tr, #metrics-perfect-table > tbody > tr,
   #distance-table > tbody > tr, #compile-table > tbody > tr {
     display: block;
@@ -696,7 +604,6 @@ pre.viz-code code {
     margin: 0.7rem 0;
     padding: 0.45rem 0.7rem 0.55rem;
   }
-  /* Kill the desktop last-row border rule; the card border owns the frame now. */
   #leaderboard-table > tbody > tr:last-child > td,
   #metrics-perfect-table > tbody > tr:last-child > td,
   #distance-table > tbody > tr:last-child > td,
@@ -721,10 +628,8 @@ pre.viz-code code {
     column-gap: 0.45rem; row-gap: 0.05rem;
     padding: 0.3rem 0; white-space: normal;
     border-top: dashed 1px rgba(var(--line-rgb), 0.16);
-    border-bottom: none; border-left: none;   /* neutralize col-overall's left rule */
+    border-bottom: none; border-left: none;
   }
-  /* The label column: a fixed-width muted stub so every value (and its ASCII
-     bar) starts at the same x down the card. */
   #leaderboard-table td[data-label]::before, #metrics-perfect-table td[data-label]::before,
   #distance-table td[data-label]::before, #compile-table td[data-label]::before {
     content: attr(data-label);
@@ -732,31 +637,21 @@ pre.viz-code code {
     color: var(--text-muted); font-size: 0.82em; letter-spacing: 0.01em;
     white-space: nowrap;
   }
-  /* Distance labels are longer ("Recompile dist") — widen their stub to keep the
-     numbers aligned. */
   #distance-table td[data-label]::before { min-width: 8.9em; }
 
-  /* Nothing inside a card may force the page wider than the phone: counts wrap
-     under their bar, long tokens break, and any residual pixel is clipped at the
-     body rather than shifting the whole layout sideways. */
   #leaderboard-table td[data-label] .cell-count, #metrics-perfect-table td[data-label] .cell-count,
   #distance-table td[data-label] .cell-count, #compile-table td[data-label] .cell-count {
     white-space: normal; overflow-wrap: anywhere;
   }
   html, body { overflow-x: hidden; }
 
-  /* The counts hug the right edge (so the column reads as "label  bar %  count"),
-     and drop to their own line rather than overflow on a very narrow card. */
   #leaderboard-table td[data-label] .cell-count,
   #metrics-perfect-table td[data-label] .cell-count,
   #distance-table td[data-label] .cell-count,
   #compile-table td[data-label] .cell-count { margin-left: auto; white-space: nowrap; }
-  /* Keep the ASCII bar unbroken. */
   #leaderboard-table td[data-label] .bar-ascii, #metrics-perfect-table td[data-label] .bar-ascii,
   #compile-table td[data-label] .bar-ascii { white-space: pre; }
 
-  /* (The desktop leaderboard's top-align padding shims — lines ~240 — are
-     overridden by the td[data-label] and td.lb-rank padding rules above.) */
 
   /* ---- About page: two plain tables -> horizontal scroll, no page overflow -- */
   #dataset-projects, #joern-output-table {
@@ -764,40 +659,26 @@ pre.viz-code code {
     -webkit-overflow-scrolling: touch;
   }
 
-  /* ---- About page: metric-viz SVGs.  Their inline style is max-width:100% only
-     (no `width`), and a percentage max-width is ignored while the browser sizes
-     the flex column by min-content — so the 360/720-unit viewBoxes propagate a
-     ~500px min-content up and widen the whole page. Pin an explicit width:100%
-     (mobile only; desktop keeps its natural sizing) to kill that. ------------- */
+  /* ---- About page: metric-viz SVGs. A percentage max-width is ignored while the
+     browser sizes the flex column by min-content, so the viewBox propagates a
+     ~500px min-content up and widens the page; pin width:100% to kill that. ---- */
   .metric-viz svg { width: 100%; height: auto; }
-  /* Legend entries are white-space:nowrap; one ("≈ matches after normalizing a
-     link-time-dependent operand") is wider than a phone — let them wrap. */
   .viz-legend .pass { white-space: normal; }
 
   /* ---- View page: the form controls. The function <select> is as wide as its
-     longest option ("proj/opt/bin :: fn"), which drags the layout off-screen;
-     let the controls shrink (min-width:0) and give the two wide ones their own
-     full-width row. ----------------------------------------------------------- */
+     longest option, so let the controls shrink and give the wide ones a row. ---- */
   .controls { gap: 0.5rem 0.6rem; }
   .controls select, .controls input[type=text] { min-width: 0; max-width: 100%; }
   #view-select { flex: 1 1 100%; }
   #view-filter { flex: 1 1 12rem; }
 
-  /* ---- View page: stack source / decompiler code panels (inline style forces
-     2 cols; !important is the minimal way to override it on a phone). ---------- */
+  /* ---- View page: stack the code panels. !important is the minimal way to
+     override the inline 2-column style on a phone. ---- */
   .cmp-grid { grid-template-columns: 1fr !important; }
 }
 
 /* ==========================================================================
    Tablet / small-laptop band: horizontal-scroll the wide results tables.
-
-   Between the stacked-card phone layout (<=700px, above) and the width where
-   the ~1230px-wide desktop tables actually fit their column (roughly a >=1500px
-   viewport, sidebar included), the tables are wider than .main and — because
-   .main is width:100% with visible overflow — they push the whole PAGE sideways.
-   Let each scroll INSIDE its own box instead (display:block + overflow-x:auto),
-   so the body never scrolls horizontally at any width. Bounded to <=1499px so the
-   >=1500px desktop keeps its untouched display:table rendering (pixel-identical).
    ========================================================================== */
 @media (min-width: 701px) and (max-width: 1499px) {
   #leaderboard-table, #distance-table, #compile-table,

--- a/site/app.js
+++ b/site/app.js
@@ -28,22 +28,15 @@
 /* ============================================================================
  * Self-contained syntax highlighter — no third-party code, no CDN.
  *
- * An IIFE that exposes three globals on `window` (this file is a classic
- * script, so they are reachable as bare names below):
+ * An IIFE exposing three globals on `window` (this is a classic script, so they
+ * are reachable as bare names below):
  *   hlC(code)                    -> HTML string  (C / decompiler pseudo-C)
  *   hlAsm(text)                  -> HTML string  (x86-64 Intel + basic ARM)
  *   applyStaticHighlights(root)  -> highlight every <pre data-lang="c|asm">
- *                                   under `root` by reading its textContent.
  *
- * Token span classes (styled in app.css): tok-kw tok-type tok-str tok-num
- * tok-com tok-pp tok-call tok-mn tok-reg tok-imm tok-lbl.
- *
- * The tokenizers escape every token's text and clamp unterminated strings /
- * comments to EOL/EOF, so output is always well-formed even on adversarial
- * input (< > & " '). init() drives applyStaticHighlights(document) (there is no
- * DOMContentLoaded auto-init here — see the source viz/hl.js), so the about
- * page's server-rendered <pre data-lang> blocks are highlighted in both the
- * split and inline delivery modes.
+ * Token span classes are styled in app.css (tok-kw, tok-type, ...). The
+ * tokenizers escape every token and clamp unterminated strings/comments to
+ * EOL/EOF, so the output is well-formed on adversarial input.
  * ==========================================================================*/
 (function (global) {
   "use strict";
@@ -58,7 +51,6 @@
     return '<span class="' + cls + '">' + esc(text) + "</span>";
   }
 
-  // ---- C keyword / type vocabularies -------------------------------------
   var C_KEYWORDS = new Set([
     "if", "else", "for", "while", "do", "switch", "case", "default", "break",
     "continue", "return", "goto", "sizeof", "typedef", "struct", "union",
@@ -69,13 +61,11 @@
     "__volatile__", "__extension__", "true", "false", "NULL"
   ]);
   var C_TYPES = new Set([
-    // real C types
     "void", "char", "short", "int", "long", "float", "double", "bool",
     "size_t", "ssize_t", "ptrdiff_t", "wchar_t", "va_list", "FILE", "off_t",
     "int8_t", "int16_t", "int32_t", "int64_t",
     "uint8_t", "uint16_t", "uint32_t", "uint64_t",
     "intptr_t", "uintptr_t",
-    // decompiler pseudo-types (Ghidra / IDA / angr / binja flavours)
     "undefined", "undefined1", "undefined2", "undefined4", "undefined8",
     "uint", "ulong", "ushort", "uchar", "byte", "word", "dword", "qword",
     "code", "__int8", "__int16", "__int32", "__int64", "__uint64",
@@ -96,19 +86,15 @@
   }
   function isSpaceNoNL(c) { return c === " " || c === "\t" || c === "\r"; }
 
-  // -------------------------------------------------------------------------
-  //  C / pseudo-C
-  // -------------------------------------------------------------------------
   function hlC(code) {
     code = String(code == null ? "" : code);
     var out = "", plain = "", i = 0, n = code.length;
-    var atLineStart = true;            // only whitespace seen since last '\n'
+    var atLineStart = true;
     function flush() { if (plain) { out += esc(plain); plain = ""; } }
 
     while (i < n) {
       var c = code[i];
 
-      // preprocessor line: '#' as the first non-space token on a line
       if (c === "#" && atLineStart) {
         flush();
         var j = i;
@@ -119,21 +105,18 @@
         out += span("tok-pp", code.slice(i, j));
         i = j; atLineStart = true; continue;
       }
-      // line comment
       if (c === "/" && code[i + 1] === "/") {
         flush();
         var k = code.indexOf("\n", i); if (k < 0) k = n;
         out += span("tok-com", code.slice(i, k));
         i = k; continue;
       }
-      // block comment
       if (c === "/" && code[i + 1] === "*") {
         flush();
         var e = code.indexOf("*/", i + 2); e = (e < 0) ? n : e + 2;
         out += span("tok-com", code.slice(i, e));
         i = e; atLineStart = false; continue;
       }
-      // string / char literal
       if (c === '"' || c === "'") {
         flush();
         var q = c, p = i + 1;
@@ -142,11 +125,10 @@
           if (code[p] === q || code[p] === "\n") break;
           p++;
         }
-        if (code[p] === q) p++;        // include closing quote when present
+        if (code[p] === q) p++;
         out += span("tok-str", code.slice(i, p));
         i = p; atLineStart = false; continue;
       }
-      // number (hex / decimal / float, with suffixes)
       if (isDigit(c) || (c === "." && isDigit(code[i + 1]))) {
         flush();
         var s = i;
@@ -164,7 +146,6 @@
         out += span("tok-num", code.slice(s, i));
         atLineStart = false; continue;
       }
-      // identifier / keyword / type / call
       if (isIdentStart(c)) {
         flush();
         var a = i; i++;
@@ -179,7 +160,6 @@
         }
         atLineStart = false; continue;
       }
-      // plain char (operators, punctuation, whitespace)
       if (c === "\n") { plain += c; atLineStart = true; i++; continue; }
       if (!isSpaceNoNL(c)) atLineStart = false;
       plain += c; i++;
@@ -188,28 +168,25 @@
     return out;
   }
 
-  // -------------------------------------------------------------------------
-  //  Assembly (x86-64 Intel-syntax + basic ARM)
-  // -------------------------------------------------------------------------
   var X86_REGS = new Set([
     "rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rbp", "rsp", "rip",
     "eax", "ebx", "ecx", "edx", "esi", "edi", "ebp", "esp",
     "ax", "bx", "cx", "dx", "si", "di", "bp", "sp",
     "al", "bl", "cl", "dl", "ah", "bh", "ch", "dh",
     "sil", "dil", "bpl", "spl",
-    "lr", "pc", "fp", "ip", "sb", "sl", "xzr", "wzr"   // ARM aliases
+    "lr", "pc", "fp", "ip", "sb", "sl", "xzr", "wzr"
   ]);
   function isReg(w) {
     var r = w.toLowerCase();
     if (X86_REGS.has(r)) return true;
-    if (/^r\d{1,2}[dwb]?$/.test(r)) return true;         // r0..r15, r8d/r9w/..
-    if (/^[xw]([0-9]|[12][0-9]|3[01])$/.test(r)) return true; // ARM x0..x31/w0..
-    if (/^(xmm|ymm|zmm)\d{1,2}$/.test(r)) return true;   // SIMD
-    if (/^[dsq]([0-9]|[12][0-9]|3[01])$/.test(r)) return true; // ARM d/s/q regs
+    if (/^r\d{1,2}[dwb]?$/.test(r)) return true;
+    if (/^[xw]([0-9]|[12][0-9]|3[01])$/.test(r)) return true;
+    if (/^(xmm|ymm|zmm)\d{1,2}$/.test(r)) return true;
+    if (/^[dsq]([0-9]|[12][0-9]|3[01])$/.test(r)) return true;
     return false;
   }
 
-  function readNumTail(line, s) {          // s points just past the # / $ prefix
+  function readNumTail(line, s) {
     var n = line.length;
     if (line[s] === "+" || line[s] === "-") s++;
     if (line[s] === "0" && (line[s + 1] === "x" || line[s + 1] === "X")) {
@@ -222,11 +199,9 @@
 
   function hlAsmLine(line) {
     var n = line.length, i = 0, out = "";
-    // leading whitespace
     var ws = 0; while (ws < n && (line[ws] === " " || line[ws] === "\t")) ws++;
     if (ws) { out += esc(line.slice(0, ws)); i = ws; }
 
-    // leading label:  name:  /  .Lxx:  /  hexaddr:
     var lm = /^([.\w$@]+):/.exec(line.slice(i));
     if (lm) {
       out += span("tok-lbl", lm[0]);
@@ -239,28 +214,24 @@
     var mnemSeen = false;
     while (i < n) {
       var c = line[i];
-      // comments
       if (c === ";" || c === "@") { out += span("tok-com", line.slice(i)); break; }
       if (c === "/" && line[i + 1] === "/") { out += span("tok-com", line.slice(i)); break; }
       if (c === "#") {
         var d = line[i + 1];
-        if (d === "-" || d === "+" || (d >= "0" && d <= "9")) {   // #imm
+        if (d === "-" || d === "+" || (d >= "0" && d <= "9")) {
           var s = readNumTail(line, i + 1);
           out += span("tok-imm", line.slice(i, s)); i = s; continue;
         }
-        out += span("tok-com", line.slice(i)); break;            // '# comment'
+        out += span("tok-com", line.slice(i)); break;
       }
-      // whitespace
       if (c === " " || c === "\t") {
         var a = i; while (i < n && (line[i] === " " || line[i] === "\t")) i++;
         out += esc(line.slice(a, i)); continue;
       }
-      // AT&T immediate  $imm
       if (c === "$") {
         var s2 = readNumTail(line, i + 1);
         out += span("tok-imm", line.slice(i, s2)); i = s2; continue;
       }
-      // bare number / hex
       if (isDigit(c)) {
         var s3 = i;
         if (c === "0" && (line[i + 1] === "x" || line[i + 1] === "X")) {
@@ -270,7 +241,6 @@
         }
         out += span("tok-imm", line.slice(s3, i)); continue;
       }
-      // word: mnemonic / directive / register / symbol
       if ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c === ".") {
         var wstart = i; i++;
         while (i < n && /[\w.$]/.test(line[i])) i++;
@@ -285,7 +255,6 @@
         }
         continue;
       }
-      // any other char (brackets, commas, +, -, *, :, !, etc.)
       out += esc(c); i++;
     }
     return out;
@@ -296,16 +265,13 @@
     return text.split("\n").map(hlAsmLine).join("\n");
   }
 
-  // -------------------------------------------------------------------------
-  //  Static application to <pre data-lang="c|asm"> blocks
-  // -------------------------------------------------------------------------
   function applyStaticHighlights(root) {
     root = root || (typeof document !== "undefined" ? document : null);
     if (!root) return;
     var pres = root.querySelectorAll("pre[data-lang]");
     for (var i = 0; i < pres.length; i++) {
       var pre = pres[i];
-      if (pre.getAttribute("data-hl") === "1") continue;   // idempotent
+      if (pre.getAttribute("data-hl") === "1") continue;
       var lang = (pre.getAttribute("data-lang") || "").toLowerCase();
       var target = pre.querySelector("code") || pre;
       var text = target.textContent;
@@ -320,24 +286,17 @@
 })(typeof window !== "undefined" ? window
   : (typeof globalThis !== "undefined" ? globalThis : this));
 
-// The inline payload, or null in split mode. Set before this script runs.
 const INLINE = (typeof window !== "undefined" && window.__DECBENCH_INLINE__) || null;
 
-// Split-mode routing root: the relative hop from THIS page to the site root,
-// stamped by the renderer (html.py::linked_assets) before this script — "" on the
-// root index, "../" on a `<view>/index.html` subpage. It is a string only in split
-// mode; null in the single-file/inline report, which keeps pure hash routing.
 const ROOT = (typeof window !== "undefined" && typeof window.__DECBENCH_ROOT__ === "string")
     ? window.__DECBENCH_ROOT__ : null;
 
-// Query params from the URL the page FIRST loaded with, read once before any
-// replaceState rewrites location: dataset/norm, and on the view page tier/dec/
-// metric/fn. Unknown values are ignored where they are applied, never here.
 const INIT_PARAMS = (function () {
     try { return new URLSearchParams(location.search); } catch (e) { return new URLSearchParams(); }
 })();
 
-// The directory of the SITE ROOT (e.g. "/decbench/"), resolved once from the page
+// Cached deliberately: pushState later moves location without moving the root,
+// so recomputing from a post-navigation URL would lie.
 // that first loaded plus the stamped hop. Cached deliberately: pushState later moves
 // location without moving the root, so recomputing from a post-navigation URL lies.
 let _basePath = null;
@@ -348,7 +307,7 @@ function basePath() {
     }
     return _basePath;
 }
-// Resolve NOW, before any pushState moves location: a later first call would
+// Resolve NOW, before any pushState moves location.
 // compute the root from wherever the user has since navigated.
 if (ROOT !== null) basePath();
 
@@ -361,9 +320,6 @@ const state = {
     normalize: false
 };
 
-// ---- Data loading ----
-// One promise per payload, cached: a view is never fetched twice, and a failure
-// stays failed rather than re-storming the network on every navigation.
 const _payloads = {};
 function loadData(name) {
     if (_payloads[name]) return _payloads[name];
@@ -374,6 +330,7 @@ function loadData(name) {
             : Promise.reject(new Error("inline payload '" + name + "' is missing"));
     } else {
         // Anchored to the site root, not the document: a relative "data/..." would
+// re-resolve after pushState, and the first cached rejection would then stick.
         // re-resolve against whatever path pushState/replaceState moved us to, and
         // the first cached rejection would stick for the whole session.
         const prefix = ROOT !== null ? basePath() : "";
@@ -386,9 +343,6 @@ function loadData(name) {
     return p;
 }
 
-// ---- Metric presentation (from the registry in aggregates.json) ----
-// Names and column order used to be hardcoded here AND in html.py; both now read
-// decbench/rendering/content/metrics.toml, which ships into aggregates.json.
 let _metricSpecs = null;
 function metricSpecs() {
     if (_metricSpecs) return _metricSpecs;
@@ -404,8 +358,6 @@ function metricSpecs() {
 function metricList() { return (AGG && AGG.metrics) || []; }
 function metricShort(m) { const s = metricSpecs()[m]; return (s && s.short_name) || m; }
 function metricName(m) { const s = metricSpecs()[m]; return (s && s.display_name) || m; }
-// Registry order (structure -> types -> recompile); unregistered metrics keep
-// their given order and are appended. Mirrors Content.ordered_metrics().
 function orderedMetrics() {
     const specs = metricSpecs(), ms = metricList();
     const known = ms.filter(m => m in specs).sort((a, b) => specs[a].order - specs[b].order);
@@ -414,6 +366,8 @@ function orderedMetrics() {
 }
 
 // ---- Decompiler presentation (from the registry in aggregates.json) ----
+// SHOW_LOGOS is the single switch for the leaderboard logos; flip it to false to
+// disable them everywhere with no other edit.
 // Official names / links / prettified versions replace raw ids on screen. Tolerant
 // the same way metricSpecs is: a missing registry (older payload) or an unknown id
 // (r2dec/dewolf data landing before its entry) falls back to the raw id, unlinked.
@@ -430,8 +384,6 @@ function decRegistry() { return (AGG && AGG.decompiler_registry) || {}; }
 function decRegEntry(id) {
     const reg = decRegistry();
     if (reg[id]) return reg[id];
-    // Base-name fallback: a versioned id ("ghidra@12.1") resolves to its base
-    // ("ghidra") entry when the registry has no exact match for it.
     const base = baseName(id);
     if (reg[base]) return reg[base];
     for (const k in reg) if (baseName(k) === base) return reg[k];
@@ -445,21 +397,10 @@ function decVersion(id) {
     if (e && e.version) return e.version;
     return (AGG && AGG.decompiler_versions && AGG.decompiler_versions[id]) || null;
 }
-// Tooltip: pretty name + pretty version (was the raw id + raw version).
 function decTip(id) {
     const v = decVersion(id);
     return v ? (decName(id) + " — version " + v) : decName(id);
 }
-// A decompiler as a table cell: linked when the registry carries a url (opens in a
-// new tab; styled to keep the terminal look — see .lb-name a).
-//
-// Two forms, one source of truth (name/url/version/logo):
-//   compact (default)  `[logo] name <span.ver>vX</span>` on one line — the metrics
-//                      table, the distance table and the compile table.
-//   stacked ({stacked:true})  a two-line block for the LEADERBOARD: logo-prefixed
-//                      name, then the version on its own line.
-// The version keeps the same rule in both: a "v" prefix only in front of a digit
-// ("v9.2" reads right, "vr2 6.0.8" does not).
 function decNameHtml(id, options) {
     options = options || {};
     const name = escapeHtml(decName(id)), url = decUrl(id), v = decVersion(id);
@@ -479,7 +420,10 @@ function decNameHtml(id, options) {
     return html + '</span>';
 }
 
-// ---- Combo lookup (replaces the old client-side recompute) ----
+// ---- Combo lookup ----
+// A run with no dataset presets has none to select, so the builder emits one
+// synthetic all-functions combo under this reserved name (aggregate.py's
+// ALL_PRESET). Without the fallback every view here shows an error banner.
 // A run with no dataset presets has no preset to select, so state.dataset stays null.
 // The builder emits one synthetic all-functions combo under this reserved name for
 // exactly that case (aggregate.py's ALL_PRESET); selecting it renders the full corpus
@@ -493,12 +437,12 @@ function currentCombo() {
 }
 function totalFunctions() { return (AGG && AGG.totals && AGG.totals.functions) || 0; }
 
-// Aggregates ship [numerator, denominator] pairs rather than percentages: the UI
-// shows the raw counts next to the bar, so the pair is what it needs.
 function pairOf(map, key) { const c = map && map[key]; return c || [0, 0]; }
 function metricCell(result, d, m) { return pairOf((result.per_metric || {})[d], m); }
 
-// Decompilers to render as rows for the CURRENT preset. Backends in
+// Decompilers to render as rows for the CURRENT preset. AGG.sample_set_only
+// backends ran on the sample-set slice only, so they render there and, on the
+// data page, below a partial-coverage break (splitDecs) — never elsewhere.
 // AGG.sample_set_only (the LLM/coding-agent ones — codex/claude-code) ran on the
 // sample-set slice only, so their rows are shown ONLY when the sample-set preset is
 // selected; on every other view they are omitted (their data still ships, it is
@@ -514,11 +458,6 @@ function visibleDecs() {
     if (preset === SAMPLE_SET_PRESET) return all;
     return all.filter(d => sso.indexOf(d) < 0);
 }
-// The same rows split into {main, subset} for the data page's tables: off the
-// sample-set preset the sample-set-only backends are NOT hidden there (unlike the
-// leaderboard) — they render below a dashed break, muted, because their numbers
-// cover only the part of the selected dataset that overlaps the sample-set slice.
-// On the sample-set preset itself they are first-class rows (subset is empty).
 function splitDecs() {
     const all = ((AGG && AGG.decompilers) || []).slice();
     const sso = (AGG && AGG.sample_set_only) || [];
@@ -529,9 +468,6 @@ function splitDecs() {
         subset: all.filter(d => sso.indexOf(d) >= 0),
     };
 }
-// The dashed break labeling the sample-set-only rows, and the note shown with it
-// (the note's text lives in content/data.md; it ships hidden and is revealed
-// only when subset rows are actually rendered).
 function subsetBreakRow(colspan) {
     return '<tr class="subset-break"><td colspan="' + colspan +
         '">&mdash; sample-set only &mdash;</td></tr>';
@@ -542,13 +478,8 @@ function toggleSubsetNote(id, on) {
 }
 function overallCell(result, d) { return pairOf(result.overall, d); }
 function errorCell(result, d) { return pairOf(result.errors, d); }
-// Compiles: share of a decompiler's byte_match-measured functions whose output
-// actually recompiled (the compilability-fixup pass built it). Denominator is
-// per-decompiler (functions where byte_match was measurable), so ARM/PE
-// abstentions never enter it — see aggregate.py `compile`.
 function compileCell(result, d) { return pairOf(result.compile, d); }
 
-// ---- Formatting ----
 function pctClass(p) { return p >= 50 ? "high" : (p >= 20 ? "mid" : "low"); }
 function asciiBar(pct, width) {
     width = width || 12;
@@ -563,15 +494,12 @@ function escapeHtml(s) {
 }
 function pct(cell) { return cell && cell[1] > 0 ? (cell[0] / cell[1]) * 100 : 0; }
 
-// Read a theme color from CSS (app.css :root owns the palette).
 function cssVar(name, fallback) {
     const v = getComputedStyle(document.documentElement).getPropertyValue(name);
     return (v && v.trim()) || fallback;
 }
 
-// ---- Loading / error states ----
 function setLoading(el) { if (el) el.innerHTML = '<p class="view-desc">Loading&hellip;</p>'; }
-// A failed payload must say so where the reader is looking — never a blank view.
 function showBanner(viewId, msg) {
     const sec = document.getElementById("view-" + viewId);
     if (!sec) return;
@@ -584,18 +512,13 @@ function showBanner(viewId, msg) {
     b.textContent = "[ error ] " + msg;
 }
 
-// ---- Leaderboard (swebench-style sortable table) ----
 function cellPctHtml(cell) {
     const p = pct(cell);
     return '<span class="bar-ascii">' + asciiBar(p, 8) + '</span> ' +
         '<span class="cell-pct pct-' + pctClass(p) + '">' + p.toFixed(1) + '%</span> ' +
         '<span class="cell-count">(' + cell[0] + '/' + cell[1] + ')</span>';
 }
-// Errors: lower is better, so the color scale is inverted vs metrics.
 function errPctClass(p) { return p < 2 ? "high" : (p < 10 ? "mid" : "low"); }
-// Same arithmetic as pct() now that errors ship as an [errored, scope] pair (the
-// old pair read .errored/.scope vs .perfect/.total). Kept as its own name so the
-// call sites say which rate they mean.
 function errRate(cell) { return cell && cell[1] > 0 ? (cell[0] / cell[1]) * 100 : 0; }
 function errorCellHtml(cell) {
     const p = errRate(cell);
@@ -612,9 +535,6 @@ function buildLeaderboard(result) {
     const tbl = document.getElementById("leaderboard-table");
     if (!tbl) return;
     const decs = visibleDecs(), metrics = orderedMetrics();
-    // Header. "Errors" = how often the decompiler failed/timed out on a
-    // function it was asked to decompile (lower is better). The Compiles rate
-    // used to sit here; it moved to its own table on the distance page.
     const cols = [["__name__", "decompiler"], ["__overall__", "Union"]];
     for (const m of metrics) cols.push([m, metricShort(m)]);
     cols.push(["__errors__", "Errors"]);
@@ -626,20 +546,16 @@ function buildLeaderboard(result) {
             escapeHtml(label) + '<span class="arrow">' + arrow + '</span></th>';
     }
     tbl.querySelector("thead tr").innerHTML = head;
-    // Sort.
     decs.sort((a, b) => {
         let va = sortValue(a, state.sortKey, result), vb = sortValue(b, state.sortKey, result);
         if (typeof va === "string") return state.sortDir * va.localeCompare(vb);
         return state.sortDir * (va - vb);
     });
-    // Rows.
     let body = "";
     decs.forEach((d, i) => {
         let row = '<tr class="binrow"><td class="lb-rank">#' + (i + 1) + '</td>' +
             '<td class="lb-name lb-name-stacked" title="' + escapeHtml(decTip(d)) + '">' +
             decNameHtml(d, {stacked: true}) + '</td>';
-        // data-label lets the stacked (mobile) card show each cell's column name
-        // (see the max-width:700px block in app.css); ignored on the desktop table.
         row += '<td class="metric-cell col-overall" data-label="Union">' + cellPctHtml(overallCell(result, d)) + '</td>';
         for (const m of metrics) row += '<td class="metric-cell" data-label="' + escapeHtml(metricShort(m)) + '">' + cellPctHtml(metricCell(result, d, m)) + '</td>';
         row += '<td class="metric-cell" data-label="Errors">' + errorCellHtml(errorCell(result, d)) + '</td>';
@@ -657,7 +573,6 @@ function buildLeaderboard(result) {
     });
 }
 
-// ---- Metrics perfect-rate table ----
 function buildMetricsTable(result) {
     const tbl = document.getElementById("metrics-perfect-table");
     if (!tbl) return;
@@ -678,9 +593,6 @@ function buildMetricsTable(result) {
     tbl.querySelector("tbody").innerHTML = body;
 }
 
-// ---- Distance table (the data page's #distance section; lower is better) ----
-// mean/median/n/at0 are precomputed per combo; see docs/site.md. A null
-// cell means no function under this combo had a finite distance for that metric.
 function buildDistance(result) {
     const tbl = document.getElementById("distance-table");
     if (!tbl) return;
@@ -696,9 +608,6 @@ function buildDistance(result) {
             return av - bv;
         });
     const rows = mkRows(groups.main), subRows = mkRows(groups.subset);
-    // Best (lowest) mean per metric -> highlight. Full-coverage rows only: a
-    // sample-set-only backend's mean covers a fraction of this dataset, so it
-    // neither takes nor sets the highlight.
     const best = {};
     metrics.forEach((m, i) => {
         best[m] = Math.min.apply(null, rows.map(r => r.cells[i] ? r.cells[i].mean : Infinity));
@@ -729,13 +638,6 @@ function buildDistance(result) {
     toggleSubsetNote("distance-subset-note", subRows.length > 0);
 }
 
-// ---- Compile-rate table (lives on the data page's #compiles section) ----
-// The per-decompiler Compiles rate — the share of a decompiler's
-// byte_match-measured functions whose output actually recompiled — moved off the
-// leaderboard to here. It is one number per decompiler (see aggregate.py's
-// `compile`), so unlike the metrics it gets its own small table rather than a
-// column. Sorted highest-first; the sample-set-only backends render below a
-// dashed break off their preset, exactly like the distance table (splitDecs()).
 function buildCompile(result) {
     const tbl = document.getElementById("compile-table");
     if (!tbl) return;
@@ -760,16 +662,6 @@ function buildCompile(result) {
     toggleSubsetNote("compile-subset-note", subRows.length > 0);
 }
 
-// ---- Cost table (the data page's #cost section) ----
-// Reads AGG.cost — a GLOBAL, combo-independent block (decompile time and $ do
-// not vary with the dataset preset or the normalize toggle), so buildCost runs
-// ONCE from init() after the aggregates land, never from refresh(). Shape per
-// decompiler: {time: {mean_s, median_s, n_functions, [n_binaries,] basis},
-// dollars: {total, per_function, model, estimated} | null}. `basis` is "batch"
-// (binary wall-time / functions) for traditional decompilers and "per-function"
-// (agent call incl. tool use) for the LLM backends — the data.md prose warns the
-// two are not directly comparable, which is also why the rows split main vs
-// sample-set (the same static split the other tables draw with subsetBreakRow).
 function fmtSecs(s) {
     return s >= 100 ? Math.round(s) + " s" : s.toFixed(1) + " s";
 }
@@ -779,8 +671,6 @@ function buildCost() {
     const cost = (AGG && AGG.cost) || {};
     tbl.querySelector("thead tr").innerHTML =
         "<th>decompiler</th><th>median time / fn</th><th>mean time / fn</th><th>est. cost</th>";
-    // Static split: LLM/sample-set-only backends below the break, always (cost is
-    // preset-independent, so unlike splitDecs() this does not consult the preset).
     const all = ((AGG && AGG.decompilers) || []).filter(d => cost[d]);
     const sso = (AGG && AGG.sample_set_only) || [];
     const median = d => {
@@ -791,8 +681,6 @@ function buildCost() {
     const timeCell = v => (v == null) ? "&mdash;" : fmtSecs(v);
     const rowHtml = (d, isSubset) => {
         const t = cost[d].time || {}, dol = cost[d].dollars;
-        // No dollars: em-dash for the batch rows (not applicable — no per-token
-        // cost), "n/a" for an LLM row (applicable but unpriced/no token data).
         const dolCell = dol
             ? '$' + dol.total.toFixed(2) + ' <span class="cell-count">($' +
               dol.per_function.toFixed(2) + '/fn, est.)</span>'
@@ -841,19 +729,12 @@ function refresh() {
     buildDistance(lastResult);
     buildCompile(lastResult);
     updateStats(lastResult);
-    // The About page's projects table is preset-aware; re-render it if it has been
-    // loaded (no-op before the About view is first opened, or if not in the DOM).
     renderDatasetProjects();
 }
 
-// ---- About page's dataset section (corpus-wide; independent of the selectors) ----
-// The corpus stats are selector-independent, but the projects table is preset-aware
-// (the sample-set preset lists only its sampled projects), so the loaded payload is
-// cached here and the table is re-rendered from it on preset change (refresh()).
 let _lastDataset = null;
 function buildDataset(ds) {
     const cats = ds.categories || [], summary = ds.summary || {};
-    // Category highlight buttons.
     const cc = document.getElementById("category-controls");
     if (cc) {
         cc.innerHTML = cats.map(c =>
@@ -873,7 +754,6 @@ function buildDataset(ds) {
             }
         }));
     }
-    // Summary.
     const sum = document.getElementById("dataset-summary");
     if (sum) {
         sum.innerHTML = '<div class="goal-body">' +
@@ -886,22 +766,12 @@ function buildDataset(ds) {
             '</strong> total source lines of code (project .c files)</div>' +
             '</div>';
     }
-    // Projects table: cache the payload, then render it preset-aware. refresh()
-    // calls renderDatasetProjects() again on preset change (no refetch).
     _lastDataset = ds;
     renderDatasetProjects();
 }
 
-// ---- Data page's pipeline-health section (corpus-wide; from data/dataset.json) ----
-// Split out of buildDataset when the joern scaffolds moved from the about page to
-// the data page (2026-07-23). Same lazy dataset.json payload — the fetch promise
-// is cached per file (loadData), so opening both pages fetches it once.
 function buildPipelineHealth(ds) {
     const joern = ds.joern || {};
-    // Pipeline health: source-side GED loss. A benchmark function has NO source
-    // CFG iff no decompiler ever got a GED value for it (source CFGs are
-    // decompiler-independent), so this is the share of functions GED cannot score
-    // because OUR source front-end (Joern) failed or was too slow on the source.
     const src = joern.source || {}, spot = joern.spot_check || {};
     const srcTotal = src.total || 0, srcLost = src.lost || 0;
     const srcPct = srcTotal ? (100 * srcLost / srcTotal) : 0;
@@ -920,7 +790,6 @@ function buildPipelineHealth(ds) {
                 '.</div>') : '') +
             '</div>';
     }
-    // Pipeline health: Joern failures on each decompiler's OUTPUT (corpus-wide).
     const out = joern.output || {};
     const jt = document.getElementById("joern-output-table");
     if (jt) {
@@ -938,12 +807,6 @@ function buildPipelineHealth(ds) {
     }
 }
 
-// The About page's projects table, filtered by the selected preset. Only the
-// sample-set preset narrows the list — to the projects it sampled (>=1 function
-// tagged sample-set, per the row's `presets`); every other preset shows the full
-// corpus (which those presets essentially are, and the user asked to filter only
-// the sample-set). Reads the cached payload so refresh() can re-render on a preset
-// change without refetching.
 function renderDatasetProjects() {
     const tbl = document.getElementById("dataset-projects");
     if (!tbl || !_lastDataset) return;
@@ -969,22 +832,11 @@ function renderDatasetProjects() {
     }
 }
 
-// ---- View page (source vs one decompiler, by difficulty tier) ----
-// Replaced the old Compare and Hardest views. samples.json entries carry a
-// `difficulty` tag (easy/medium/hard, assigned server-side from cross-decompiler
-// GED agreement); the three dropdowns pick the tier, the decompiler whose output
-// is shown, and the metric whose score is highlighted.
 let VIEW_SAMPLES = [];
-// Tier order for the view-page dropdown. `sample-set` is the dataset-selector's
-// curated slice (materialized at build time, difficulty="sample-set"); it lists
-// after the three GED-agreement tiers, and the decompiler dropdown gains codex
-// only because those entries carry codex output. A tier appears only when the
-// data has entries for it (initView filters this against VIEW_SAMPLES).
 const DIFFICULTIES = ["easy", "medium", "hard", "sample-set"];
 function sampleLabel(s) {
     return s.project + "/" + s.opt_level + "/" + s.binary + " :: " + s.function;
 }
-// The stable id used in the `fn` URL param: the label with no spaces around "::".
 function sampleKey(s) {
     return s.project + "/" + s.opt_level + "/" + s.binary + "::" + s.function;
 }
@@ -999,9 +851,6 @@ function viewControls() {
         body: document.getElementById("view-body")
     };
 }
-// Human explanation for a missing view-page source, keyed by the `source_status`
-// code the sample carries (stamped by scoring/report_extras.py). Any unknown or
-// null code falls back to a generic line rather than showing an empty panel.
 function sourceUnavailableReason(status) {
     switch (status) {
         case "binary_not_found":
@@ -1030,7 +879,6 @@ function renderViewEntry() {
         (s.difficulty ? (' &middot; <span class="tag score-bad">' +
             escapeHtml(s.difficulty) + '</span>') : '') +
         '</div>';
-    // Scores strip: the chosen decompiler's per-metric values, chosen metric first.
     const vals = (s.values && s.values[dec]) || {};
     const perf = (s.perfects && s.perfects[dec]) || {};
     let scores = "";
@@ -1046,9 +894,6 @@ function renderViewEntry() {
     }
     html += '<div class="cmp-scores">' + escapeHtml(dec) + ': ' + (scores || '&mdash;') + '</div>';
     const code = (s.decompiled || {})[dec];
-    // Always a two-column grid: source on the left (or, when it is missing, a
-    // short explanation of why), the chosen decompiler's output on the right.
-    // Both code panels are syntax-highlighted — hlC escapes its input for us.
     html += '<div class="cmp-grid" style="grid-template-columns:repeat(2,minmax(0,1fr));">';
     if (s.source_code) {
         const badge = s.source_status === "preprocessed"
@@ -1093,7 +938,6 @@ function initView(samples) {
     VIEW_SAMPLES = samples || [];
     const c = viewControls();
     if (!c.fn) return;
-    // Difficulty tiers present in the data; legacy payloads (no tags) get "all".
     const tiers = DIFFICULTIES.filter(t => VIEW_SAMPLES.some(s => s.difficulty === t));
     if (c.tier) {
         (tiers.length ? tiers : ["__all__"]).forEach(t => {
@@ -1102,7 +946,6 @@ function initView(samples) {
             c.tier.appendChild(o);
         });
     }
-    // Decompilers: union over the entries (covers versioned ids), sorted.
     const decs = [];
     for (const s of VIEW_SAMPLES) {
         for (const d in (s.decompiled || {})) if (decs.indexOf(d) < 0) decs.push(d);
@@ -1111,7 +954,7 @@ function initView(samples) {
     if (c.dec) {
         decs.forEach(d => {
             const o = document.createElement("option");
-            o.value = d; o.textContent = decName(d);  // value stays the raw id
+            o.value = d; o.textContent = decName(d);
             c.dec.appendChild(o);
         });
     }
@@ -1122,8 +965,6 @@ function initView(samples) {
             c.metric.appendChild(o);
         });
     }
-    // Deep-link the tier/dec/metric selects from the initial URL; the function is
-    // selected after fillViewFunctions lists it.
     const fnIdx = applyViewParams(c);
     if (c.tier) c.tier.addEventListener("change", () => { fillViewFunctions(); syncUrl(); });
     if (c.dec) c.dec.addEventListener("change", () => { renderViewEntry(); syncUrl(); });
@@ -1135,14 +976,8 @@ function initView(samples) {
         c.fn.value = String(fnIdx);
         renderViewEntry();
     }
-    // Reflect the resolved view state in the URL (idempotent; keeps a deep link
-    // canonical and drops any unknown params the reader arrived with).
     if (state.view === "view") syncUrl();
 }
-// Apply the view page's URL params (once, from the initial load). Returns the
-// VIEW_SAMPLES index the `fn` param names, or -1. Unknown values are ignored: a
-// param only takes effect when it matches a real option, and a named function
-// additionally forces its own difficulty tier so its option is actually listed.
 function applyViewParams(c) {
     const optOf = sel => Array.from(sel.options).map(o => o.value);
     let fnIdx = -1;
@@ -1164,24 +999,14 @@ function applyViewParams(c) {
     return fnIdx;
 }
 
-// baseName strips a versioned id's "@version" suffix. It outlived the removed
-// Historical view (whose legend keyed by base name): the decompiler registry
-// still uses it to resolve a versioned id ("ghidra@12.1") to its "ghidra" entry.
 function baseName(dec) { const a = dec.indexOf("@"); return a >= 0 ? dec.substring(0, a) : dec; }
 
-// ---- Theme toggle ----
-// Dark is the default; light is an explicit opt-in, persisted in localStorage.
-// The FOUC-free <head> script (html.py) already applied the stored/URL theme
-// before first paint, and the button LABEL is CSS-driven off data-theme — so all
-// that is left for the client is the click. The whole page is pure CSS and
-// re-tints for free (the removed historical charts, which baked colors at render
-// time, were the only thing that had to be redrawn on a live flip).
 function currentTheme() {
     return document.documentElement.dataset.theme === "light" ? "light" : "dark";
 }
 function applyTheme(theme) {
     document.documentElement.dataset.theme = theme;
-    try { localStorage.setItem("decbench-theme", theme); } catch (e) { /* private mode */ }
+    try { localStorage.setItem("decbench-theme", theme); } catch (e) { }
 }
 function initThemeToggle() {
     const btn = document.getElementById("theme-toggle");
@@ -1191,14 +1016,8 @@ function initThemeToggle() {
     });
 }
 
-// ---- Lazy views ----
-// Fetched on FIRST navigation, once. Each also waits on aggregates, which carry
-// the metric registry these views label their columns and scores with.
 const LAZY_VIEWS = {
     about: {file: "dataset", body: "dataset-summary", render: buildDataset},
-    // The data page's pipeline-health section reads the SAME dataset.json as the
-    // about page — loadData caches the fetch promise per file, so whichever view
-    // opens first pays for it and the other reuses the promise.
     data: {file: "dataset", body: "joern-source", render: buildPipelineHealth},
     view: {file: "samples", body: "view-body", render: initView}
 };
@@ -1207,7 +1026,7 @@ function ensureViewData(name) {
     const spec = LAZY_VIEWS[name];
     if (!spec || lazyStarted[name]) return;
     const body = document.getElementById(spec.body);
-    if (!body) return;  // the view rendered its empty state: nothing to fill.
+    if (!body) return;
     lazyStarted[name] = true;
     setLoading(body);
     Promise.all([loadData("aggregates"), loadData(spec.file)])
@@ -1218,11 +1037,6 @@ function ensureViewData(name) {
         });
 }
 
-// ---- View routing ----
-// Two modes, one DOM update. Split mode reflects the view in the URL PATH
-// (site/<view>/) so it is linkable and the back button works; the single-file /
-// inline report keeps its pure #hash behavior. showView only touches the DOM; the
-// URL is written by navigate()/syncUrl().
 function showView(name) {
     state.view = name;
     document.querySelectorAll(".view").forEach(v => {
@@ -1236,20 +1050,15 @@ function showView(name) {
 function validViews() {
     return Array.from(document.querySelectorAll(".view")).map(v => v.getAttribute("data-view"));
 }
-// Renamed views: an old `#<hash>` deep link routes to the view's new id (e.g. the
-// distance page became the data page, 2026-07-23). Only consulted when the hash
-// is not itself a valid view id, so an in-page section anchor (#cost, #compiles)
-// that is NOT a view id still falls through to native scrolling untouched.
 const LEGACY_HASH_VIEWS = {distance: "data"};
-// The view a `#hash` names: the hash itself when it is a valid view id, its
-// legacy mapping when that resolves to one, else null (not a view hash).
 function resolveViewHash(hash) {
     const views = validViews();
     if (views.indexOf(hash) >= 0) return hash;
     const mapped = LEGACY_HASH_VIEWS[hash];
     return (mapped && views.indexOf(mapped) >= 0) ? mapped : null;
 }
-// The view a fresh load opens on when the URL names none. It is config —
+// The default view is config (views.toml's `default = true`) and reaches us
+// through the DOM: routing runs before aggregates.json lands.
 // views.toml's `default = true` — and reaches us through the DOM: the renderer
 // marks that section `active` (on a subpage, the subpage's own view), and routing
 // runs before aggregates.json lands, so we cannot wait to read it from there.
@@ -1257,7 +1066,8 @@ function defaultView() {
     const el = document.querySelector(".view.active") || document.querySelector(".view");
     return el ? el.getAttribute("data-view") : null;
 }
-// Split mode: the view named by the path segment just under the site root, or null
+// The source of truth AFTER a browser navigation, when the DOM's `.active` is
+// stale.
 // (the root, or an unknown segment). The source of truth AFTER a browser navigation,
 // when the DOM's `.active` is stale.
 function pathView() {
@@ -1269,16 +1079,10 @@ function pathView() {
     const seg = rest.split("/")[0];
     return validViews().indexOf(seg) >= 0 ? seg : null;
 }
-// Where a fresh load lands: a valid legacy `#hash` (so old site/#about links keep
-// working, and a renamed view's old hash — #distance — still routes) wins;
-// otherwise the renderer already marked the right section active (a path
-// subpage, or the inline default), so the DOM fallback covers it.
 function routeTarget() {
     const hash = (location.hash || "").replace("#", "");
     return resolveViewHash(hash) || defaultView();
 }
-// The canonical URL for the current state. Split mode carries the view in the path;
-// inline mode leaves the path+hash alone and only attaches the query.
 function viewUrl(view) {
     const qs = currentQuery();
     if (ROOT !== null) return basePath() + (view ? view + "/" : "") + (qs ? "?" + qs : "");
@@ -1289,35 +1093,27 @@ function writeUrl(push) {
     try {
         if (push) history.pushState({view: state.view}, "", url);
         else history.replaceState(history.state, "", url);
-    } catch (e) { /* file:// and sandboxed frames forbid the history API */ }
+    } catch (e) { }
 }
-// A state change (dataset / normalize / view select) replaces — no new history
-// entry. A nav pushes a new entry in split mode, replaces in inline (hash left as is).
 function syncUrl() { writeUrl(false); }
 function navigate(view) {
     showView(view);
     writeUrl(ROOT !== null);
 }
 function onPopState() {
-    // The URL is the source of truth after Back/Forward; do not push again. A
-    // legacy `#hash` entry (the URL a pre-subpage deep link loaded with) names
-    // its view in the hash, not the path — honor it exactly as routeTarget() did.
     const hash = (location.hash || "").replace("#", "");
     const name = resolveViewHash(hash)
         || pathView() || (AGG && AGG.default_view) || defaultView();
     if (name) showView(name);
 }
-// In-page `#view` links in the prose (e.g. about.md's "see the data page") change
-// the hash without a popstate; route them in both delivery modes. A hash that is
-// neither a view id nor a legacy view alias (e.g. the data page's own #cost /
-// #compiles section anchors) is left to the browser's native anchor scrolling.
 function onHashChange() {
     const hash = (location.hash || "").replace("#", "");
     const name = resolveViewHash(hash);
     if (name) showView(name);
     maybeScrollToHash();
 }
-// A section-anchor deep link (the data page's #distance / #compiles / #cost, incl.
+// The browser's native on-load scroll fires while these sections are still
+// empty, so re-scroll once the async tables have rendered.
 // the old /distance/ URL that now redirects to /data/#distance) must scroll to its
 // heading AFTER the async tables render: the browser's native on-load scroll fires
 // while those sections are still empty, so the heading has moved by the time the
@@ -1332,10 +1128,10 @@ function initNav() {
     document.querySelectorAll(".nav-item").forEach(a => {
         const id = a.getAttribute("data-view");
         // Rewrite the href to the real subpage URL so middle-click / copy-link work
+// (the renderer ships "#id" for the no-JS and single-file forms).
         // (the renderer ships "#id" for the no-JS and single-file forms).
         if (ROOT !== null) { try { a.setAttribute("href", basePath() + id + "/"); } catch (e) {} }
         a.addEventListener("click", e => {
-            // Leave modified clicks (new tab, download, non-primary button) to the href.
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || (e.button && e.button !== 0)) return;
             e.preventDefault();
             navigate(id);
@@ -1347,14 +1143,11 @@ function initNav() {
     if (target) showView(target);
 }
 
-// ---- URL <-> state (query params, both modes) ----
 function defaultPresetName() {
     const presets = (AGG && AGG.presets) || [];
     const def = presets.filter(p => p.default)[0] || presets[0];
     return def ? def.name : null;
 }
-// Minimal, clean query for the current state: dataset only when NOT the default
-// preset, norm only when on, and the view-page selectors only while on that page.
 function currentQuery() {
     const params = new URLSearchParams();
     if (state.dataset && state.dataset !== defaultPresetName()) params.set("dataset", state.dataset);
@@ -1374,7 +1167,8 @@ function setDatasetDesc() {
     const p = (AGG.presets || []).filter(x => x.name === state.dataset)[0];
     const el = document.getElementById("dataset-desc");
     if (el) el.textContent = p ? p.description : "";
-    // The leaderboard's per-dataset explainer paragraph. `long_description` is
+    // `long_description` is packaged, maintainer-authored inline HTML from
+// content/datasets.toml — not run data — so innerHTML is safe here.
     // final inline HTML from content/datasets.toml (packaged, maintainer-authored
     // — not run data), so innerHTML is safe; empty (older aggregates.json or an
     // unregistered preset) renders nothing.
@@ -1386,14 +1180,10 @@ function setDatasetDesc() {
 }
 function initDatasetSelector() {
     const presets = AGG.presets || [];
-    // The opening preset is explicit (`default = true` in datasets.toml), never
-    // positional; a valid `dataset` URL param overrides it (deep link), and an
-    // unknown one is ignored. Sync the buttons so state and UI cannot disagree.
     const def = presets.filter(p => p.default)[0] || presets[0];
     const wanted = INIT_PARAMS.get("dataset");
     state.dataset = presets.some(p => p.name === wanted) ? wanted : (def ? def.name : null);
     state.normalize = INIT_PARAMS.get("norm") === "1";
-    // Only the preset buttons carry data-dataset (the normalize toggle does not).
     const btns = document.querySelectorAll(".ds-btn[data-dataset]");
     btns.forEach(b => {
         b.classList.toggle("active", b.getAttribute("data-dataset") === state.dataset);
@@ -1407,7 +1197,6 @@ function initDatasetSelector() {
         });
     });
     setDatasetDesc();
-    // "normalize failures": restrict to functions every decompiler decompiled.
     const nb = document.getElementById("normalize-btn");
     if (nb) {
         nb.classList.toggle("active", state.normalize);
@@ -1423,19 +1212,12 @@ function initDatasetSelector() {
 function init() {
     initNav();
     initThemeToggle();
-    // Color the about page's server-rendered <pre data-lang> blocks. They are in
-    // the DOM from page load in both modes (all view sections ship in every page),
-    // so this runs once here rather than via a DOMContentLoaded auto-init.
     if (typeof applyStaticHighlights === "function") applyStaticHighlights(document);
     loadData("aggregates").then(agg => {
         AGG = agg;
         initDatasetSelector();
         refresh();
-        // Cost is combo-independent (AGG.cost is global, not per-combo), so it is
-        // built once here rather than on every refresh().
         buildCost();
-        // Section anchors (e.g. a /distance/ -> /data/#distance redirect) scroll
-        // only now that the tables they point at have rendered.
         maybeScrollToHash();
     }).catch(err => {
         ["leaderboard", "about", "data"].forEach(v => showBanner(v,

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -81,9 +81,6 @@ def _build(function_data: FunctionData) -> dict:
     return build_aggregates(function_data, Scoreboard())
 
 
-# -- the shared-denominator rule -------------------------------------------
-
-
 def test_metric_unmeasurable_for_everyone_leaves_every_denominator() -> None:
     """A metric no decompiler could be scored on is our failure, not theirs.
 
@@ -107,8 +104,6 @@ def test_metric_unmeasurable_for_everyone_leaves_every_denominator() -> None:
         assert combo["per_metric"][dec]["byte_match"] == [0, 1], "abstained function must drop out"
         assert combo["per_metric"][dec]["ged"] == [0, 2]
         assert combo["per_metric"][dec]["type_match"] == [2, 2]
-    # `overall` is the Union column: a function counts once ANY metric is measurable,
-    # and both functions are type_match-perfect, so both land in the numerator.
     assert combo["overall"]["alpha"] == [2, 2]
 
 
@@ -128,8 +123,6 @@ def test_source_parse_failure_drops_ged_for_everyone() -> None:
     for dec in DECS:
         assert combo["per_metric"][dec]["ged"] == [0, 0], "GED denominator must be empty"
         assert combo["per_metric"][dec]["byte_match"] == [1, 1]
-        # Union: byte_match/type_match are still measurable (and perfect), so the
-        # function stays in and scores despite GED being unmeasurable for everyone.
         assert combo["overall"][dec] == [1, 1]
 
 
@@ -144,7 +137,7 @@ def test_joern_failing_on_one_decompilers_output_is_that_decompilers_miss() -> N
         "half",
         values={
             "alpha": {"byte_match": 1.0, "ged": 0.0, "type_match": 1.0},
-            "beta": {"byte_match": 1.0, "type_match": 1.0},  # Joern choked on beta's C
+            "beta": {"byte_match": 1.0, "type_match": 1.0},
         },
         perfects={
             "alpha": {"byte_match": True, "ged": True, "type_match": True},
@@ -157,10 +150,8 @@ def test_joern_failing_on_one_decompilers_output_is_that_decompilers_miss() -> N
     assert combo["per_metric"]["alpha"]["ged"] == [1, 1]
     assert combo["per_metric"]["beta"]["ged"] == [0, 1], "same denominator, counted as a miss"
     assert combo["overall"]["alpha"] == [1, 1]
-    # Union: beta misses GED but is byte_match/type_match-perfect, so it scores.
     assert combo["overall"]["beta"] == [1, 1]
 
-    # ...and it is reported as a tooling stat on the Dataset page.
     dataset = build_dataset_page(_data([func]))
     assert dataset["joern"]["source"] == {"lost": 0, "total": 1}
     assert dataset["joern"]["output"] == {"alpha": [0, 1], "beta": [1, 1]}
@@ -199,9 +190,6 @@ def test_errors_scope_counts_only_attempts() -> None:
     combo = _build(_data([func]))["combos"][combo_key("full", False)]
     assert combo["errors"]["alpha"] == [0, 1]
     assert combo["errors"]["beta"] == [0, 0], "not attempted => not in scope"
-
-
-# -- normalize -------------------------------------------------------------
 
 
 def test_normalize_restricts_to_functions_every_decompiler_decompiled() -> None:
@@ -286,7 +274,6 @@ def test_sample_set_only_decompiler_does_not_gate_normalize_off_its_preset() -> 
     assert normalized["functions"] == 1, "codex's cost-gate skip must not gate normalize"
     assert normalized["per_metric"]["alpha"]["ged"] == [1, 1]
 
-    # A conventional decompiler failing still gates: like-with-like is preserved.
     func_beta_failed = _func(
         "beta_failed",
         values={"alpha": {"byte_match": 1.0, "ged": 0.0, "type_match": 1.0}},
@@ -318,9 +305,6 @@ def test_sample_set_only_decompiler_still_gates_the_sample_set_preset() -> None:
     assert aggregates["combos"][combo_key("sample-set", False)]["functions"] == 2
     normalized = aggregates["combos"][combo_key("sample-set", True)]
     assert normalized["functions"] == 1, "codex's real failure gates where its row renders"
-
-
-# -- presets ---------------------------------------------------------------
 
 
 def test_presets_are_non_exclusive_membership_tags() -> None:
@@ -364,10 +348,7 @@ def test_dataset_projects_omit_a_preset_no_function_carries() -> None:
     dataset = build_dataset_page(_data([only_full]))
 
     row = next(p for p in dataset["projects"] if p["name"] == "proj")
-    assert row["presets"] == ["full"]  # "tiny" is registered but unused here
-
-
-# -- the no-presets fallback -----------------------------------------------
+    assert row["presets"] == ["full"]
 
 
 def _presetless(functions: list[FunctionRecord]) -> FunctionData:
@@ -395,8 +376,6 @@ def test_no_presets_still_aggregates_every_function() -> None:
     client rendered everything here (`isActive()` opened `if (!state.dataset) return
     true;`), so this is a fallback, not a new feature.
     """
-    # Values on every metric, so `overall` (Union: perfect on >=1 metric) is a real
-    # count over both functions.
     everywhere = dict.fromkeys(METRICS, 1.0)
     funcs = [
         _func(
@@ -421,8 +400,6 @@ def test_no_presets_still_aggregates_every_function() -> None:
     assert set(aggregates["combos"]) == {combo_key(ALL_PRESET, False), combo_key(ALL_PRESET, True)}
 
     combo = aggregates["combos"][combo_key(ALL_PRESET, False)]
-    # The leaderboard's real counts: every function present, [perfect, total] pairs
-    # populated — not an empty table and not zeros.
     assert combo["functions"] == 2, "every function is active under the fallback"
     assert combo["binaries"] == 1
     assert combo["per_metric"]["alpha"]["ged"] == [1, 2]
@@ -452,9 +429,6 @@ def test_client_fallback_preset_matches_the_builder() -> None:
     match = re.search(r'const FALLBACK_PRESET = "([^"]+)"', js)
     assert match, "app.js must define FALLBACK_PRESET"
     assert match.group(1) == ALL_PRESET
-
-
-# -- distance --------------------------------------------------------------
 
 
 def test_median_is_the_upper_middle_element_not_a_true_median() -> None:
@@ -490,7 +464,6 @@ def test_distance_has_no_shared_denominator_and_at0_is_independent() -> None:
     func = _func(
         "f",
         values={d: {"ged": 0.0} for d in DECS},
-        # alpha is flagged perfect but carries a non-zero distance: two sources of truth.
         perfects={"alpha": {"ged": True}, "beta": {"ged": False}},
         distances={"alpha": {"ged": 2.0}},
     )
@@ -590,9 +563,6 @@ def test_non_finite_ged_is_unmeasurable_not_a_miss() -> None:
         assert combo["per_metric"][dec]["ged"] == [0, 0]
 
 
-# -- decompiledBy back-compat ----------------------------------------------
-
-
 def test_decompiled_by_falls_back_to_perfects_presence() -> None:
     """Datasets predating `FunctionRecord.decompiled` infer attempts from `perfects`.
 
@@ -606,11 +576,10 @@ def test_decompiled_by_falls_back_to_perfects_presence() -> None:
         "legacy",
         values={d: {"byte_match": 1.0, "ged": 0.0, "type_match": 1.0} for d in DECS},
         perfects={"alpha": {"byte_match": True, "ged": True, "type_match": True}, "beta": {}},
-        decompiled={},  # legacy record: no decompiled map at all
+        decompiled={},
     )
     aggregates = _build(_data([func]))
 
-    # An EMPTY perfects map still means "beta decompiled it", so normalize keeps it.
     assert aggregates["combos"][combo_key("full", True)]["functions"] == 1
     assert build_dataset_page(_data([func]))["joern"]["output"]["beta"] == [0, 1]
 
@@ -626,9 +595,6 @@ def test_decompiled_by_fallback_excludes_a_decompiler_with_no_perfects_entry() -
     aggregates = _build(_data([func]))
     assert aggregates["combos"][combo_key("full", False)]["functions"] == 1
     assert aggregates["combos"][combo_key("full", True)]["functions"] == 0
-
-
-# -- decompiler registry ---------------------------------------------------
 
 
 def _registry_data(decompilers: list[str], versions: dict[str, str] | None = None) -> FunctionData:
@@ -673,7 +639,6 @@ def test_registry_carries_names_links_and_prettified_versions() -> None:
     }
     assert registry["ida"]["display_name"] == "Hex-Rays"
     assert registry["ida"]["version"] == "9.2", "raw '920' prettified server-side"
-    # The raw versions map is kept untouched for back-compat.
     assert _build(data)["decompiler_versions"]["ida"] == "920"
 
 
@@ -689,7 +654,6 @@ def test_registry_carries_license_and_logo_flags() -> None:
     assert registry["angr"]["logo"] is True
     assert registry["ida"]["license"] == "closed-source"
     assert registry["ida"]["logo"] is True
-    # RetDec ships no logo asset, so the flag is omitted rather than False.
     assert registry["retdec"]["license"] == "open-source"
     assert "logo" not in registry["retdec"]
 
@@ -714,9 +678,6 @@ def test_registry_resolves_versioned_ids_by_base_name() -> None:
     assert registry["ghidra@12.1"]["display_name"] == "Ghidra"
     assert registry["ghidra@12.1"]["url"] == "https://ghidra-sre.org"
     assert registry["ghidra@12.1"]["version"] == "12.1"
-
-
-# -- dataset page ----------------------------------------------------------
 
 
 def test_dataset_page_is_selector_independent() -> None:
@@ -770,9 +731,6 @@ def test_dataset_joern_source_loss_is_scoped_to_decompiled_functions() -> None:
     assert dataset["joern"]["source"] == {"lost": 1, "total": 1}
 
 
-# -- the cost block (global, not per-combo) ---------------------------------
-
-
 def _priced_content(models: dict[str, dict]):
     """A Content whose pricing registry is replaced with the given price cards."""
     from dataclasses import replace
@@ -815,7 +773,6 @@ def test_cost_block_batch_time_passthrough_and_no_dollars() -> None:
                 "per_fn_median_s": 0.4,
                 "basis": "batch",
             },
-            # Not in function_data.decompilers => never shipped (hidden backends).
             "ghost": {
                 "total_s": 1.0,
                 "functions": 1,
@@ -873,9 +830,8 @@ def test_cost_block_claude_dollar_formula() -> None:
     info = {"decompile_time": {}, "llm": {"alpha": _llm_entry("model-c", tokens)}}
     cost = _cost_block(content, _cost_data(info))
     dollars = cost["alpha"]["dollars"]
-    # 10 + 2 + 0.4*12.5 + 0.1*40 = 21.0
     assert dollars["total"] == pytest.approx(21.0)
-    assert dollars["per_function"] == pytest.approx(2.1)  # / 10 functions
+    assert dollars["per_function"] == pytest.approx(2.1)
     assert dollars["model"] == "model-c"
     assert dollars["estimated"] is True
     assert cost["alpha"]["time"] == {
@@ -896,7 +852,7 @@ def test_cost_block_codex_dollar_formula() -> None:
             "model-x": dict(
                 input_per_mtok=2.0,
                 cached_input_per_mtok=0.5,
-                cache_write_per_mtok=99.0,  # must not matter: cache_write is 0
+                cache_write_per_mtok=99.0,
                 output_per_mtok=8.0,
             )
         }
@@ -910,7 +866,6 @@ def test_cost_block_codex_dollar_formula() -> None:
     }
     info = {"decompile_time": {}, "llm": {"alpha": _llm_entry("model-x", tokens)}}
     dollars = _cost_block(content, _cost_data(info))["alpha"]["dollars"]
-    # 0.5*2 + 4*0.5 + 0.25*8 = 5.0
     assert dollars["total"] == pytest.approx(5.0)
     assert dollars["per_function"] == pytest.approx(0.5)
 
@@ -920,7 +875,7 @@ def test_cost_block_unpriced_or_unknown_model_has_null_dollars() -> None:
     block must emit null, never a bogus $0.00."""
     from decbench.rendering.aggregate import _cost_block
 
-    content = _priced_content({"placeholder": {}})  # all-zero => not is_priced
+    content = _priced_content({"placeholder": {}})
     tokens = {"input": 1, "cached_input": 1, "cache_write": 1, "output": 1, "sessions": 1}
     info = {
         "decompile_time": {},
@@ -932,7 +887,6 @@ def test_cost_block_unpriced_or_unknown_model_has_null_dollars() -> None:
     cost = _cost_block(content, _cost_data(info))
     assert cost["alpha"]["dollars"] is None
     assert cost["beta"]["dollars"] is None
-    # No token data at all is also null (time still ships).
     info = {"decompile_time": {}, "llm": {"alpha": _llm_entry("placeholder", None)}}
     assert _cost_block(content, _cost_data(info))["alpha"]["dollars"] is None
 

--- a/tests/test_byte_match_fixup.py
+++ b/tests/test_byte_match_fixup.py
@@ -15,7 +15,6 @@ needs_gcc = pytest.mark.skipif(not gcc_available, reason="gcc not installed")
 
 class TestSanitizeTokens:
     def test_strips_symbol_version_qualifier(self) -> None:
-        # angr emits illegal `GLIBC_2.2.5::stderr`; the bare identifier remains.
         out = sanitize_tokens("fprintf(GLIBC_2.2.5::stderr, msg);")
         assert "::" not in out
         assert "stderr" in out
@@ -25,8 +24,6 @@ class TestSanitizeTokens:
         assert sanitize_tokens(code) == code
 
     def test_strips_decompiler_annotations(self) -> None:
-        # Binary Ninja / IDA / Ghidra emit annotations that aren't valid C where
-        # they appear; stripping them lets the body still compile.
         assert "__noreturn" not in sanitize_tokens("int main() __noreturn {")
         assert "__convention" not in sanitize_tokens('void f() __convention("regparm") {')
         out = sanitize_tokens("int __cdecl g(int a)")
@@ -35,7 +32,6 @@ class TestSanitizeTokens:
 
 class TestNormalizeOperands:
     def test_branch_target_blanked(self) -> None:
-        # Two calls to different (link-dependent) targets normalize equal.
         a = _normalize_operands("call", "0x1234")
         b = _normalize_operands("call", "0x9abc")
         assert a == b == "X"
@@ -47,20 +43,16 @@ class TestNormalizeOperands:
         assert "0x2e04" not in a
 
     def test_non_branch_immediate_preserved(self) -> None:
-        # A real constant in a non-branch instruction must NOT be blanked.
         out = _normalize_operands("add", "rax, 0x10")
         assert "0x10" in out
 
     def test_indirect_branch_displacement_preserved(self) -> None:
-        # An indirect call's memory displacement is a (base-independent) struct
-        # offset — a real difference that must be kept, not blanked.
         a = _normalize_operands("call", "qword ptr [rax + 0x20]")
         b = _normalize_operands("call", "qword ptr [rax + 0x40]")
         assert a != b
         assert "0x20" in a
 
     def test_arm_adrp_immediate_blanked(self) -> None:
-        # AArch64 adrp immediate is a PC-relative page address (link-dependent).
         a = _normalize_operands("adrp", "x0, #0x400000")
         b = _normalize_operands("adrp", "x0, #0x10000")
         assert a == b
@@ -82,14 +74,12 @@ class TestCompileWithFixup:
         shutil.rmtree(res.obj_path.parent, ignore_errors=True)
 
     def test_ghidra_pseudotypes_get_defined(self) -> None:
-        # `undefined4`/`uint`/`code` are undefined in C; the fixup must typedef
-        # them via gcc-error-driven self-repair so the function builds.
         code = (
             "uint compute(undefined4 x) {\n" "    uint r = (uint)x;\n" "    return r + 1;\n" "}\n"
         )
         res = compile_with_fixup(code, "compute")
         assert res.compilable, res.error
-        assert res.iterations >= 2  # needed at least one repair pass
+        assert res.iterations >= 2
         shutil.rmtree(res.obj_path.parent, ignore_errors=True)
 
     def test_undeclared_symbol_stubbed(self) -> None:
@@ -99,15 +89,11 @@ class TestCompileWithFixup:
         shutil.rmtree(res.obj_path.parent, ignore_errors=True)
 
     def test_unrepairable_returns_no_object(self) -> None:
-        # A hard syntax error cannot be repaired by declaration injection.
         res = compile_with_fixup("int bad(void) { return", "bad")
         assert not res.compilable
         assert res.obj_path is None
 
     def test_abstains_when_toolchain_missing(self, tmp_path) -> None:
-        # When the matching recompile toolchain is unavailable (e.g. ARM/PE on an
-        # x86 host), byte_match must ABSTAIN (no per-function results), not score
-        # 0 — so cps/malware aren't unfairly penalized.
         import subprocess
 
         from decbench.metrics.byte_match import ByteMatchMetric
@@ -137,18 +123,15 @@ class TestCompileWithFixup:
         )
         metric = ByteMatchMetric()
         orig = binfmt.tool_available
-        binfmt.tool_available = lambda name: False  # force "toolchain missing"
+        binfmt.tool_available = lambda name: False
         try:
             result = metric.compute_for_binary(dr)
         finally:
             binfmt.tool_available = orig
-        assert result.function_results == {}  # abstained, not scored 0
+        assert result.function_results == {}
         assert any("abstain" in e for e in result.errors)
 
     def test_failure_paths_do_not_leak_temp_dirs(self, tmp_path) -> None:
-        # Every non-success path must clean up its mkdtemp dir. Isolate the temp
-        # root to tmp_path so a concurrent benchmark run's decbench_bm_* dirs
-        # don't race this assertion.
         import glob
         import tempfile
 
@@ -159,4 +142,4 @@ class TestCompileWithFixup:
                 compile_with_fixup("int bad(void) { return", "bad")
         finally:
             tempfile.tempdir = old
-        assert glob.glob(f"{tmp_path}/decbench_bm_*") == []  # no leaked dirs
+        assert glob.glob(f"{tmp_path}/decbench_bm_*") == []

--- a/tests/test_caching_dataset_subset.py
+++ b/tests/test_caching_dataset_subset.py
@@ -49,11 +49,6 @@ def cache_dir(tmp_path, monkeypatch):
     caching._CACHES.clear()
 
 
-# --------------------------------------------------------------------------- #
-# Metric caching
-# --------------------------------------------------------------------------- #
-
-
 def test_metric_value_json_round_trip():
     mv = MetricValue(value=0.5, raw_value=0.5, metadata={"a": 1})
     again = MetricValue(**mv.model_dump(mode="json"))
@@ -98,7 +93,7 @@ def test_ged_cache_hit_across_fresh_instance(cache_dir):
 
     GEDMetric().compute_for_function(fd, source_cfg=g1, decompiled_cfg=g2)
 
-    caching._CACHES.clear()  # drop in-memory layer; force on-disk lookup
+    caching._CACHES.clear()
     metric2 = GEDMetric()
     calls = {"n": 0}
     orig = metric2._compute_uncached
@@ -201,11 +196,6 @@ def test_byte_match_caches_with_real_binary(cache_dir, tmp_path):
     assert calls["n"] == 1
 
 
-# --------------------------------------------------------------------------- #
-# Binary dataset store
-# --------------------------------------------------------------------------- #
-
-
 def _fake_elf(path: Path, body: bytes) -> None:
     """Write a minimal ELF header (ET_EXEC) plus a payload body."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -282,11 +272,6 @@ def test_load_missing_dataset_raises(tmp_path):
         load_dataset("nope", store_root=tmp_path / "store")
 
 
-# --------------------------------------------------------------------------- #
-# Large-function subset
-# --------------------------------------------------------------------------- #
-
-
 def _make_function_data() -> FunctionData:
     sizes = {"a": 5, "b": 7, "c": 6, "d": 8, "e": 4, "big1": 200, "big2": 150}
     group = BinaryGroup(
@@ -316,7 +301,7 @@ def _make_function_data() -> FunctionData:
 def test_size_distribution_ignores_none():
     fd = _make_function_data()
     dist = size_distribution(fd)
-    assert dist["count"] == 8  # the None-size record is excluded
+    assert dist["count"] == 8
     assert dist["min"] == 4
     assert dist["max"] == 200
     assert dist["p90"] >= dist["p50"]
@@ -358,9 +343,7 @@ def test_filter_function_data_shrinks_and_drops_empty():
 
     remaining = [(g.binary, r.function) for g in filtered.groups for r in g.functions]
     assert all(name in {"big1", "big2"} for _, name in remaining)
-    # bin2 had no large functions -> its group is dropped.
     assert all(g.binary == "bin" for g in filtered.groups)
-    # Top-level metadata is preserved.
     assert filtered.decompilers == ["angr"]
     assert filtered.perfect_values == {"ged": 0.0}
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -20,9 +20,6 @@ def content() -> Content:
     return load_content()
 
 
-# -- views -----------------------------------------------------------------
-
-
 def test_every_registered_view_has_content(content: Content) -> None:
     """views.toml is the registry; each id must have a parsed <id>.md."""
     for spec in content.view_specs:
@@ -49,8 +46,6 @@ def test_view_registry_covers_the_report(content: Content) -> None:
 def test_visible_views_drop_data_backed_views_without_data(content: Content) -> None:
     without = [v.id for v in content.visible_views(has_function_data=False)]
     with_data = [v.id for v in content.visible_views(has_function_data=True)]
-    # data/view need per-function data; leaderboard, about, and the prose
-    # changelog do not.
     assert without == ["leaderboard", "about", "changelog"]
     assert with_data == [v.id for v in content.view_specs]
 
@@ -83,10 +78,9 @@ def test_default_view_is_the_leaderboard(content: Content) -> None:
 
 def test_empty_states_are_parsed(content: Content) -> None:
     view = content.view("view")
-    assert view.has_empty_state
+    assert view.empty_html
     assert view.title == "view"
     assert "No sample functions were attached" in view.empty_html
-    # The three dropdowns are the contract with app.js's initView.
     for control in ("view-difficulty", "view-dec", "view-metric", "view-select"):
         assert f'id="{control}"' in view.body_html
 
@@ -95,14 +89,8 @@ def test_inline_html_passes_through_unescaped(content: Content) -> None:
     """Prose is markdown now, but the scaffolds and hand-authored viz islands are
     still final markup: their raw tags and entities must survive rendering
     byte-for-byte (the renderer's verbatim text() must not re-escape them)."""
-    # A scaffold element (JS fills it) passes through verbatim — the view page's
-    # selector controls.
     assert '<div class="controls">' in content.view("view").body_html
-    # The about page's .recovered callout is a raw-HTML styling hook, so its
-    # <strong> is passed through untouched (markdown is not parsed inside a
-    # raw-HTML block, so the tag is the only way to bold there).
     assert "<strong>at least one</strong>" in content.view("about").outro_html
-    # The metric-viz islands keep their hand-authored entities — not double-escaped.
     ged = next(g for g in content.view("about").goals if g.metric_key == "ged")
     assert "&mdash;" in ged.body_html
     assert "&amp;mdash;" not in ged.body_html
@@ -115,20 +103,14 @@ def test_prose_renders_markdown_constructs(content: Content) -> None:
     Guards the markdown-first rule — the literal `**`/`*`/`[..]` must be gone, and
     a bold run in a view body must become <strong>."""
     lb = content.view("leaderboard").body_html
-    # *italic* -> <em>, and the literal markdown is consumed.
     assert "<em>at least one</em>" in lb
     assert "*at least one*" not in lb
-    # [text](url) -> <a href>.
     assert '<a href="https://mahaloz.re/dec-history-pt1">the last 30 years</a>' in lb
-    # Literal unicode punctuation survives; it does NOT come back as an entity.
     assert "—" in lb
     assert "&mdash;" not in lb
-    # **bold** -> <strong> in a view body (the data page's distance section).
     di = content.view("data").body_html
     assert "<strong>GED</strong>" in di
     assert "**GED**" not in di
-    # Inline `code` -> <code> (also the changelog injection path, which renders
-    # markdown bullets as lists).
     injected = content.with_view("changelog", "# changelog\n\n- run `foo()` and **bar**.")
     body = injected.view("changelog").body_html
     assert "<code>foo()</code>" in body
@@ -159,12 +141,9 @@ def test_with_view_reparses_only_the_named_view(content: Content) -> None:
     injected = content.with_view("changelog", "# changelog\n\n- an injected bullet.")
     body = injected.view("changelog").body_html
     assert injected.view("changelog").title == "changelog"
-    assert "<li>an injected bullet.</li>" in body  # markdown lists render as lists
-    # Only the changelog view changed; every other view is the same object, and
-    # the original Content is untouched.
+    assert "<li>an injected bullet.</li>" in body
     assert injected.view("about") is content.view("about")
     assert "an injected bullet." not in content.view("changelog").body_html
-    # An unregistered id is a no-op (returns self, not a copy).
     assert content.with_view("does-not-exist", "# x") is content
 
 
@@ -175,13 +154,10 @@ def test_data_view_has_four_section_anchors(content: Content) -> None:
     body = content.view("data").body_html
     for anchor in ("distance", "compiles", "pipeline-health", "cost"):
         assert f'<h3 class="sub" id="{anchor}">' in body, anchor
-    # The section scaffolds app.js's builders target.
     for scaffold in ("cost-table", "joern-source", "joern-output-table"):
         assert f'id="{scaffold}"' in body, scaffold
-    # The pre-rename element ids are unchanged (the app.js contract).
     for kept in ("distance-table", "distance-subset-note", "compile-table", "compile-subset-note"):
         assert f'id="{kept}"' in body, kept
-    # ...and about.md no longer carries the joern scaffolds it used to.
     about = content.view("about")
     assert "joern-" not in about.body_html + about.outro_html + about.empty_html
 
@@ -197,12 +173,8 @@ def test_pricing_registry_loads(content: Content) -> None:
     assert "gpt-5.6-sol" in names
     assert content.model_pricing("claude-opus-4-8") is not None
     assert content.model_pricing("no-such-model") is None
-    # The is_priced gate: any non-zero axis is priced; all-zero is unpriced.
     assert ModelPricing(name="x", output_per_mtok=15.0).is_priced
     assert not ModelPricing(name="x").is_priced
-
-
-# -- metrics ---------------------------------------------------------------
 
 
 def test_metrics_registry_covers_the_three_metrics(content: Content) -> None:
@@ -213,7 +185,6 @@ def test_metric_lookup_and_fallbacks(content: Content) -> None:
     assert content.short_name("ged") == "Structure"
     assert content.display_name("ged") == "Structural Correctness (GED)"
     assert content.metric("nope") is None
-    # Unknown metrics fall back to their raw name rather than blowing up.
     assert content.short_name("nope") == "nope"
 
 
@@ -221,9 +192,6 @@ def test_ordered_metrics_sorts_known_and_appends_unknown(content: Content) -> No
     assert content.ordered_metrics(["byte_match", "ged", "type_match"]) == BENCHMARK_METRICS
     assert content.ordered_metrics(["byte_match", "ged"]) == ["ged", "byte_match"]
     assert content.ordered_metrics(["zzz", "ged"]) == ["ged", "zzz"]
-
-
-# -- goal cards (on the about page) -----------------------------------------
 
 
 def test_goal_card_parse_yields_three_cards(content: Content) -> None:
@@ -238,10 +206,7 @@ def test_goal_cards_are_fully_populated(content: Content) -> None:
         assert card.title
         assert card.metric_display_name
         assert card.body_html
-        # Every metric card carries its collapsible how-it-works visualization.
         assert 'class="metric-viz"' in card.body_html
-        # GED and type_match draw inline SVG; byte_match visualizes with an HTML
-        # assembly line-diff (.viz-diff) instead, so accept either.
         assert "<svg" in card.body_html or 'class="viz-diff"' in card.body_html
         assert card.perfect.startswith("perfect = ")
 
@@ -257,15 +222,10 @@ def test_goal_card_perfect_lines_match_the_metric_registry(content: Content) -> 
 def test_about_view_keeps_intro_and_outro_around_the_cards(content: Content) -> None:
     view = content.view("about")
     assert "three separable goals" in view.body_html
-    assert "[1]" not in view.body_html  # cards were lifted out of the body
+    assert "[1]" not in view.body_html
     assert 'class="recovered"' in view.outro_html
-    # The dataset section (scaffolds app.js fills from data/dataset.json)
-    # merged into this page's outro.
     assert 'id="dataset-summary"' in view.outro_html
     assert 'id="dataset-projects"' in view.outro_html
-
-
-# -- datasets --------------------------------------------------------------
 
 
 def test_exactly_one_default_dataset(content: Content) -> None:
@@ -290,13 +250,8 @@ def test_dataset_presets_cover_the_selector(content: Content) -> None:
     ]
     for preset in content.dataset_presets:
         assert preset.label and preset.description
-        # The leaderboard's per-dataset explainer paragraph: every shipped preset
-        # names itself (LARGE, SAMPLE-SET, ...) at the start of its paragraph.
         assert preset.long_description
         assert preset.name.upper() in preset.long_description
-
-
-# -- decompilers -----------------------------------------------------------
 
 
 def test_decompiler_registry_loads_with_names_links_and_overrides(content: Content) -> None:
@@ -309,9 +264,8 @@ def test_decompiler_registry_loads_with_names_links_and_overrides(content: Conte
     ida = content.decompiler("ida")
     assert ida is not None
     assert ida.display_name == "Hex-Rays"
-    # A raw version string is prettified through the entry's overrides.
     assert ida.pretty_version("920") == "9.2"
-    assert ida.pretty_version("unknown") == "unknown"  # unmapped passes through
+    assert ida.pretty_version("unknown") == "unknown"
     assert ida.pretty_version(None) is None
 
 
@@ -323,10 +277,8 @@ def test_decompiler_license_and_logo_are_parsed(content: Content) -> None:
     ida = content.decompiler("ida")
     assert ida is not None and ida.license == "closed-source" and ida.logo is True
 
-    # Every registered backend declares a license; only some ship a logo asset.
     for spec in content.decompilers:
         assert spec.license in {"open-source", "closed-source"}, spec.id
-    # RetDec/Reko carry no logo (no .dlogo-<id> in app.css yet).
     assert content.decompiler("retdec").logo is False
     assert content.decompiler("reko").logo is False
 
@@ -348,9 +300,6 @@ def test_decompiler_url_is_optional(content: Content) -> None:
     """Kuna has no homepage yet, so it renders unlinked."""
     kuna = content.decompiler("kuna")
     assert kuna is not None and kuna.url == ""
-
-
-# -- categories / site -----------------------------------------------------
 
 
 def test_categories_carry_labels_in_display_order(content: Content) -> None:
@@ -375,7 +324,6 @@ def test_site_chrome(content: Content) -> None:
     assert site.brand.title == "DecBench"
     assert site.brand.subtitle == "decompiler benchmark"
     assert "function_results.json" in site.no_function_data_banner
-    # The leading space separates the label from the <span> holding the number.
     assert site.side_stats["functions"] == " functions"
 
 
@@ -389,9 +337,6 @@ def test_footer_renders_projects_and_falls_back_when_empty(content: Content) -> 
 
 def test_load_content_is_cached(content: Content) -> None:
     assert load_content() is content
-
-
-# -- raw-HTML islands --------------------------------------------------------
 
 
 def test_metric_viz_islands_pass_through_verbatim() -> None:
@@ -444,6 +389,5 @@ def test_metric_viz_blocks_open_by_default_and_carry_a_visualization(content: Co
     assert "<svg" in goals["ged"]
     assert "<svg" in goals["type_match"]
     assert 'class="viz-diff"' in goals["byte_match"]
-    # The byte_match score strip's arithmetic is exact: 7 / 8 = 0.88.
     assert "0.88" in goals["byte_match"]
     assert "0.87" not in goals["byte_match"]

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -23,8 +23,6 @@ from decbench.scoring.cost import (
     scan_structured_costs,
 )
 
-# -- fixtures ---------------------------------------------------------------
-
 
 def _write_decompiled_toml(
     tree: Path,
@@ -133,9 +131,6 @@ def _codex_session(path: Path) -> None:
     path.write_text("\n".join(json.dumps(r) for r in records))
 
 
-# -- batch decompile-time scan ----------------------------------------------
-
-
 def test_scan_reads_only_the_toml_header(tmp_path: Path) -> None:
     """The per-function tables after the header must never be parsed: a broken
     table body (invalid TOML) cannot fail the scan, because the parse stops at
@@ -174,7 +169,6 @@ def test_scan_keys_by_header_decompiler_not_filename(tmp_path: Path) -> None:
 def test_scan_mean_median_and_zero_skip(tmp_path: Path) -> None:
     """Mean is amortized (sum/sum); median is over per-binary rates; a binary
     with zero time or zero functions contributes nothing."""
-    # Three real binaries: rates 1.0, 2.0 and 6.0 s/fn.
     _write_decompiled_toml(
         tmp_path, "O0", "p1", "angr_a", decompiler="angr", total_time=10.0, function_count=10
     )
@@ -184,7 +178,6 @@ def test_scan_mean_median_and_zero_skip(tmp_path: Path) -> None:
     _write_decompiled_toml(
         tmp_path, "O2", "p3", "angr_c", decompiler="angr", total_time=60.0, function_count=10
     )
-    # Skipped: no functions / no recorded time.
     _write_decompiled_toml(
         tmp_path, "O0", "p4", "angr_d", decompiler="angr", total_time=99.0, function_count=0
     )
@@ -195,8 +188,8 @@ def test_scan_mean_median_and_zero_skip(tmp_path: Path) -> None:
     assert times["total_s"] == pytest.approx(90.0)
     assert times["functions"] == 30
     assert times["binaries"] == 3
-    assert times["per_fn_mean_s"] == pytest.approx(3.0)  # 90 / 30
-    assert times["per_fn_median_s"] == pytest.approx(2.0)  # median of [1, 2, 6]
+    assert times["per_fn_mean_s"] == pytest.approx(3.0)
+    assert times["per_fn_median_s"] == pytest.approx(2.0)
     assert times["basis"] == "batch"
 
 
@@ -210,18 +203,15 @@ def test_scan_respects_the_given_opt_levels(tmp_path: Path) -> None:
     assert scan_decompile_times(tmp_path, ["O0"])["ida"]["total_s"] == pytest.approx(1.0)
 
 
-# -- session token parsing --------------------------------------------------
-
-
 def test_parse_claude_session_tokens(tmp_path: Path) -> None:
     path = tmp_path / "s.jsonl"
     _claude_session(path)
     tokens = parse_session_tokens(path)
     assert tokens == {
-        "input": 5,  # 2 + 3
-        "cached_input": 20000,  # 14000 + 6000
-        "cache_write": 5200,  # 5000 + 200 (no double count with the breakdown)
-        "output": 150,  # 100 + 50
+        "input": 5,
+        "cached_input": 20000,
+        "cache_write": 5200,
+        "output": 150,
     }
 
 
@@ -233,10 +223,10 @@ def test_parse_codex_session_tokens_normalizes_cached_input(tmp_path: Path) -> N
     _codex_session(path)
     tokens = parse_session_tokens(path)
     assert tokens == {
-        "input": 66000,  # 553000 - 487000
+        "input": 66000,
         "cached_input": 487000,
         "cache_write": 0,
-        "output": 6500,  # already includes reasoning
+        "output": 6500,
     }
 
 
@@ -248,16 +238,12 @@ def test_parse_unknown_session_format_returns_none(tmp_path: Path) -> None:
     assert parse_session_tokens(tmp_path / "missing.jsonl") is None
 
 
-# -- trace scan -------------------------------------------------------------
-
-
 def test_scan_llm_traces(tmp_path: Path) -> None:
     traces = tmp_path / "traces"
     _trace_md(traces, "claude-code", "O0__p__b__f1_0x1", status="ok", elapsed=100)
     _trace_md(traces, "claude-code", "O0__p__b__f2_0x2", status="FAILED", elapsed=300)
     _trace_md(traces, "claude-code", "O0__p__b__f3_0x3", status="TIMEOUT", elapsed=200)
     _claude_session(traces / "claude-code" / "O0__p__b__f1_0x1.session.jsonl")
-    # A dir with no .md files is not a backend.
     (traces / "not-a-backend").mkdir()
 
     scanned = scan_llm_traces(traces)
@@ -265,8 +251,6 @@ def test_scan_llm_traces(tmp_path: Path) -> None:
     entry = scanned["claude-code"]
     assert entry["model"] == "test-model"
     assert entry["functions"] == 3
-    # FAILED and TIMEOUT both count as failed AND still contribute wall time —
-    # that time (and those tokens) were genuinely spent.
     assert entry["failed"] == 2
     assert entry["elapsed"]["total_s"] == pytest.approx(600.0)
     assert entry["elapsed"]["mean_s"] == pytest.approx(200.0)
@@ -285,9 +269,6 @@ def test_scan_llm_traces_without_parseable_sessions_has_none_tokens(tmp_path: Pa
     assert scan_llm_traces(tmp_path / "nope") == {}
 
 
-# -- structured fields (FunctionDecompilation -> TOML -> scan) ---------------
-
-
 def test_function_decompilation_round_trips_cost_fields(tmp_path: Path) -> None:
     """The two structured fields survive pydantic serialization AND the
     DecompilationResult TOML artifact; records without them still load (None)."""
@@ -304,15 +285,12 @@ def test_function_decompilation_round_trips_cost_fields(tmp_path: Path) -> None:
         time_seconds=12.5,
         llm_tokens={"input": 10, "cached_input": 5, "cache_write": 2, "output": 3},
     )
-    # Pydantic round trip.
     back = FunctionDecompilation.model_validate(json.loads(func.model_dump_json()))
     assert back.time_seconds == 12.5
     assert back.llm_tokens == {"input": 10, "cached_input": 5, "cache_write": 2, "output": 3}
-    # Pre-field artifacts still load, defaulting to None.
     legacy = FunctionDecompilation(name="g", address=1, decompiled_code="")
     assert legacy.time_seconds is None and legacy.llm_tokens is None
 
-    # TOML artifact round trip (the structured scan's input).
     import toml
 
     result = DecompilationResult(
@@ -326,7 +304,6 @@ def test_function_decompilation_round_trips_cost_fields(tmp_path: Path) -> None:
     data = toml.load(out)
     assert data["functions.f"]["time_seconds"] == 12.5
     assert data["functions.f"]["llm_tokens"]["cached_input"] == 5
-    # None fields are omitted, keeping batch backends' artifacts unchanged.
     assert "time_seconds" not in data["functions.g"]
     assert "llm_tokens" not in data["functions.g"]
 
@@ -362,7 +339,6 @@ def test_scan_structured_costs_prefers_new_run_artifacts(tmp_path: Path) -> None
     dest = tmp_path / "O0" / "proj" / "decompiled" / "claude-code_b.toml"
     dest.parent.mkdir(parents=True)
     result.to_toml(dest)
-    # A batch artifact without the fields is skipped by the substring sniff.
     _write_decompiled_toml(
         tmp_path, "O0", "proj", "angr_b", decompiler="angr", total_time=5.0, function_count=5
     )
@@ -370,7 +346,7 @@ def test_scan_structured_costs_prefers_new_run_artifacts(tmp_path: Path) -> None
     scanned = scan_structured_costs(tmp_path, ["O0"])
     assert set(scanned) == {"claude-code"}
     entry = scanned["claude-code"]
-    assert entry["model"] == "claude-opus-4-8"  # from the header version
+    assert entry["model"] == "claude-opus-4-8"
     assert entry["functions"] == 2
     assert entry["failed"] == 1
     assert entry["elapsed"]["mean_s"] == pytest.approx(200.0)
@@ -398,7 +374,6 @@ def test_build_cost_info_merges_scans_structured_first(tmp_path: Path) -> None:
     traces = tmp_path / "traces"
     _trace_md(traces, "codex", "O0__p__b__f_0x1", status="ok", elapsed=400)
     _trace_md(traces, "claude-code", "O0__p__b__f_0x1", status="ok", elapsed=999)
-    # claude-code ALSO has structured artifacts — they must win over its traces.
     result = DecompilationResult(
         binary_path=tmp_path / "b",
         binary_name="b",
@@ -412,10 +387,9 @@ def test_build_cost_info_merges_scans_structured_first(tmp_path: Path) -> None:
 
     info = build_cost_info(tmp_path, traces, ["O0"])
     assert info["decompile_time"]["ghidra"]["per_fn_mean_s"] == pytest.approx(0.5)
-    assert info["llm"]["codex"]["elapsed"]["mean_s"] == pytest.approx(400.0)  # trace path
-    assert info["llm"]["claude-code"]["elapsed"]["mean_s"] == pytest.approx(50.0)  # structured
-    json.dumps(info, allow_nan=False)  # the whole blob must be strict-JSON-safe
+    assert info["llm"]["codex"]["elapsed"]["mean_s"] == pytest.approx(400.0)
+    assert info["llm"]["claude-code"]["elapsed"]["mean_s"] == pytest.approx(50.0)
+    json.dumps(info, allow_nan=False)
 
-    # Without a traces dir the llm block still carries the structured backends.
     info = build_cost_info(tmp_path, None, ["O0"])
     assert set(info["llm"]) == {"claude-code"}

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,8 +11,6 @@ def _make_data() -> FunctionData:
     for proj in ("alpha", "beta", "gamma"):
         for opt in ("O0", "O2", "O2-noinline"):
             funcs = [
-                # A recorded metric value makes the record scoreable — the
-                # sample-set draw skips value-less phantom rows.
                 FunctionRecord(
                     function=f"{proj}_{opt}_f{i}", size=sz, values={"angr": {"ged": 1.0}}
                 )
@@ -78,7 +76,6 @@ def test_large_rules() -> None:
         for f in g.functions:
             if "large" in f.datasets:
                 assert g.opt_level == "O2-noinline" and f.size >= thr
-    # there IS at least one large function per opt level here (size 220)
     assert any("large" in f.datasets for g in fd.groups for f in g.functions)
 
 
@@ -91,8 +88,7 @@ def test_sample_set_is_bounded_and_spread() -> None:
         for f in g.functions
         if "sample-set" in f.datasets
     ]
-    assert 0 < len(picked) <= 25  # ~sample_total, bounded (5 buckets x quota)
-    # spread across all opt levels and all projects
+    assert 0 < len(picked) <= 25
     assert {opt for opt, _ in picked} == {"O0", "O2", "O2-noinline"}
     assert {proj for _, proj in picked} == {"alpha", "beta", "gamma"}
 
@@ -129,7 +125,6 @@ def _sample_keys(fd: FunctionData) -> set[str]:
 
 
 def test_sample_set_is_seeded_and_reproducible() -> None:
-    # Same seed -> identical sample-set selection, every time.
     fd1 = _make_data()
     assign_datasets(fd1, sample_total=20, seed=42)
     fd2 = _make_data()
@@ -139,7 +134,6 @@ def test_sample_set_is_seeded_and_reproducible() -> None:
 
 
 def test_sample_set_changes_with_seed() -> None:
-    # A different seed should (with this much data) pick a different sample.
     fd_a = _make_data()
     assign_datasets(fd_a, sample_total=20, seed=1)
     fd_b = _make_data()
@@ -176,16 +170,14 @@ def _sample_binkeys(fd: FunctionData) -> list[tuple[str, str, str]]:
 
 
 def test_sample_set_one_function_per_binary_when_enough() -> None:
-    # With many distinct binaries, no binary contributes more than one function.
     fd = _make_many_binaries(n_bins=40)
     assign_datasets(fd, sample_total=100)
     keys = _sample_binkeys(fd)
     assert len(keys) == len(set(keys)), "each binary should appear at most once"
-    assert len(keys) >= 20  # plenty selected (only the O0 bucket has candidates)
+    assert len(keys) >= 20
 
 
 def test_sample_set_relaxes_when_few_binaries() -> None:
-    # Only 9 binary-groups but we want ~20 -> must reuse some binaries.
     fd = _make_data()
     assign_datasets(fd, sample_total=50)
     keys = _sample_binkeys(fd)
@@ -212,7 +204,7 @@ def test_sample_set_skips_valueless_phantom_rows() -> None:
     for g in poisoned.groups:
         for f in g.functions:
             if f"{g.project}/{g.opt_level}/{f.function}" == victim:
-                f.values = {}  # now a phantom: no metric value from anyone
+                f.values = {}
     assign_datasets(poisoned, sample_total=100, seed=42)
     repicked = _sample_keys(poisoned)
 
@@ -224,9 +216,9 @@ def test_sample_set_skips_valueless_phantom_rows() -> None:
 def test_env_var_seed(monkeypatch) -> None:
     monkeypatch.setenv("DECBENCH_SAMPLE_SEED", "777")
     fd_env = _make_data()
-    assign_datasets(fd_env, sample_total=20)  # seed from env
+    assign_datasets(fd_env, sample_total=20)
     fd_explicit = _make_data()
-    assign_datasets(fd_explicit, sample_total=20, seed=777)  # same, explicit
+    assign_datasets(fd_explicit, sample_total=20, seed=777)
     assert _sample_keys(fd_env) == _sample_keys(fd_explicit)
 
 
@@ -254,7 +246,6 @@ def test_assign_datasets_honors_manifest() -> None:
         if "sample-set" in f.datasets
     }
     assert tagged == members
-    # Different seed, same manifest -> identical membership (seed is ignored).
     fd2 = _make_many_binaries(n_bins=10)
     assign_datasets(fd2, sample_total=100, seed=999, sample_members=members)
     tagged2 = {
@@ -280,7 +271,7 @@ def _make_multibucket(n_bins: int = 30) -> FunctionData:
                     FunctionRecord(
                         function=f"{proj}_{opt}_b{b}_f{i}", size=sz, values={"angr": {"ged": 1.0}}
                     )
-                    for i, sz in enumerate([10, 30, 400])  # 400 -> large
+                    for i, sz in enumerate([10, 30, 400])
                 ]
                 groups.append(
                     BinaryGroup(
@@ -311,13 +302,8 @@ def test_sample_set_topup_preserves_picks_across_all_buckets() -> None:
     base_fd = _make_multibucket()
     assign_datasets(base_fd, sample_total=50, seed=1337)
     base_members = _members_of(base_fd)
-    # Exclude a NON-ARM project (like the real mirai-win): its picks land in the
-    # unoptimized/inlined/optimized/large buckets — all refillable from p2 — while
-    # the arm-only bucket (p3) is untouched, so the total is fully replenished.
     excluded_project = "p1"
     base_excluded = {m for m in base_members if m[0] == excluded_project}
-    # p1 must have picks in the overlapping large/optimized buckets to make the
-    # preservation test meaningful.
     assert any(m[1] == "O2-noinline" for m in base_excluded), "need optimized/large picks"
 
     fd = _make_multibucket()
@@ -326,8 +312,6 @@ def test_sample_set_topup_preserves_picks_across_all_buckets() -> None:
     )
 
     assert not {m for m in topped if m[0] == excluded_project}, "excluded project never appears"
-    # EVERY non-excluded base pick is preserved verbatim — the invariant the
-    # review found violated by the old exclude-in-draw approach.
     assert (base_members - base_excluded) <= topped
     assert len(topped) == len(base_members), "total size preserved"
     assert (topped - base_members) and all(
@@ -356,7 +340,7 @@ def test_topup_refills_a_dropped_arm_pick_from_the_arm_bucket() -> None:
     base_fd = _make_multibucket()
     assign_datasets(base_fd, sample_total=50, seed=1337)
     base_members = _members_of(base_fd)
-    arm_picks = {m for m in base_members if m[0] == "p3"}  # p3 is the ARM project
+    arm_picks = {m for m in base_members if m[0] == "p3"}
     assert arm_picks, "fixture must sample the ARM project"
     victim = sorted(m for m in arm_picks if m[1] == "O0")[0]
 
@@ -364,7 +348,7 @@ def test_topup_refills_a_dropped_arm_pick_from_the_arm_bucket() -> None:
     for g in fd.groups:
         for f in g.functions:
             if (g.project, g.opt_level, g.binary, f.function) == victim:
-                f.values = {}  # unscoreable, so the refill cannot re-pick it
+                f.values = {}
 
     topped = topup_sample_members(
         fd, base_members, frozenset(), seed=1337, exclude_members=frozenset({victim})
@@ -406,8 +390,6 @@ def test_sample_set_topup_drops_excluded_members_and_refills() -> None:
     base_members = _members_of(base_fd)
     victims = frozenset(sorted(base_members)[:3])
 
-    # Simulate the phantoms: the victims' rows lose every metric value, so the
-    # refill (which skips unscoreable rows) can never re-pick them.
     fd = _make_multibucket()
     for g in fd.groups:
         for f in g.functions:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -70,7 +70,6 @@ class TestRegistry:
         for name in ALL_DECOMPILERS:
             dec = DecompilerRegistry.get(name)
             assert dec.name == name
-            # is_available must never raise
             assert isinstance(dec.is_available(), bool)
 
     def test_binja_registered_even_if_unavailable(self) -> None:
@@ -99,12 +98,9 @@ class TestSmokeDecompile:
         func = result.functions["add_nums"]
         assert func.decompiled_code.strip()
         assert func.line_count > 0
-        # Structured variables must be populated (stack vars and/or args)
         assert func.variables, f"{name} produced no variables for add_nums"
         kinds = {v.kind for v in func.variables}
         assert kinds <= {"stack", "arg"}
-        # At -O0 every backend recovers at least one stack variable w/ offset
         assert any(v.stack_offset is not None for v in func.variables)
 
-        # Output files were written
         assert (tmp_path / f"{name}_{tiny_binary.stem}.c").exists()

--- a/tests/test_dewolf_backend.py
+++ b/tests/test_dewolf_backend.py
@@ -27,7 +27,6 @@ def test_unavailable_without_python(monkeypatch) -> None:
     monkeypatch.delenv("DECBENCH_DEWOLF_PYTHON", raising=False)
     monkeypatch.delenv("DECBENCH_DEWOLF_REPO", raising=False)
     dec = RawDewolfDecompiler()
-    # No configured interpreter (and the test env has no versions config for it):
     monkeypatch.setattr(dec, "_python", lambda: None)
     assert dec.is_available() is False
 
@@ -44,8 +43,6 @@ def test_child_env_prepends_repo_and_astyle(monkeypatch, tmp_path: Path) -> None
     assert env["PATH"].split(":")[0] == "/opt/astyle/bin"
 
 
-# A stand-in driver: emits the JSON protocol and exits, so decompile_binary can
-# be exercised without Binary Ninja or the dewolf venv.
 _FAKE_DRIVER = """\
 import json, sys
 def e(o): sys.stdout.write(json.dumps(o) + "\\n")
@@ -69,8 +66,6 @@ def test_decompile_binary_parses_driver_stream(monkeypatch, tmp_path: Path) -> N
     monkeypatch.setattr(dec, "_python", lambda: sys.executable)
     monkeypatch.setattr(dec, "_child_env", dict)
     monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw._DRIVER", driver)
-    # elf_min_vaddr on our stub bytes → 0; the driver's addrs are already
-    # ELF-file-space, so they pass straight through.
     monkeypatch.setattr("decbench.decompilers.raw.dewolf_raw.common.elf_min_vaddr", lambda p: 0)
 
     out = tmp_path / "out"

--- a/tests/test_dockerized_decompilers.py
+++ b/tests/test_dockerized_decompilers.py
@@ -26,18 +26,11 @@ from decbench.decompilers.dockerized import (
 )
 from decbench.decompilers.registry import DecompilerRegistry
 
-# A tiny real binary used for the (skippable) native/ELF tests. Also probe the
-# main checkout so these run even from an isolated worktree without results/.
 _GZIP_CANDIDATES = [
     Path("results/sailr_full/O0/gzip/compiled/gzip"),
     Path("/home/mahaloz/github/decbench/results/sailr_full/O0/gzip/compiled/gzip"),
 ]
 _GZIP = next((p for p in _GZIP_CANDIDATES if p.is_file()), _GZIP_CANDIDATES[0])
-
-
-# --------------------------------------------------------------------------- #
-# Registration
-# --------------------------------------------------------------------------- #
 
 
 def test_backends_register() -> None:
@@ -58,11 +51,6 @@ def test_registry_get_returns_correct_class(spec: str, cls: type) -> None:
     dec = DecompilerRegistry.get(spec)
     assert isinstance(dec, cls)
     assert dec.id == spec
-
-
-# --------------------------------------------------------------------------- #
-# is_available() semantics
-# --------------------------------------------------------------------------- #
 
 
 def test_docker_backends_unavailable_without_image() -> None:
@@ -87,7 +75,6 @@ def test_r2dec_available_when_native_present() -> None:
     if native:
         assert dec.is_available() is True
     else:
-        # Falls back to image presence.
         assert dec.is_available() == DockerizedDecompiler._image_present(dec.image)
 
 
@@ -95,10 +82,6 @@ def test_get_version_proxies_image_tag() -> None:
     assert RetDecDecompiler().get_version() == "latest"
     assert RekoDecompiler().get_version() == "latest"
 
-
-# --------------------------------------------------------------------------- #
-# C-function splitting (pure, always runs)
-# --------------------------------------------------------------------------- #
 
 _FAKE_C = """
 #include <stdint.h>
@@ -130,10 +113,8 @@ def test_split_c_functions_finds_all() -> None:
 
 def test_split_c_functions_balances_braces_with_literals() -> None:
     parts = split_c_functions(_FAKE_C)
-    # The literal '}' must not prematurely end add(); both returns must be in it.
     assert "return a + b;" in parts["add"]
     assert "return a - b;" in parts["add"]
-    # entrypoint body should not leak into add.
     assert "entrypoint" not in parts["add"]
     assert "return (uint64_t)x;" in parts["entrypoint"]
 
@@ -148,11 +129,6 @@ def test_split_keeps_first_definition_of_duplicate_name() -> None:
     parts = split_c_functions(src)
     assert "return 1;" in parts["f"]
     assert "return 2;" not in parts["f"]
-
-
-# --------------------------------------------------------------------------- #
-# r2dec pure helpers: discovery, address filter, naming (no binary/tool needed)
-# --------------------------------------------------------------------------- #
 
 
 class _FakeR2:
@@ -172,7 +148,6 @@ class _FakeR2:
     def cmd(self, cmd: str) -> str:
         if cmd.startswith(("pdd", "pdc")) and "@" in cmd:
             addr = int(cmd.rsplit("@", 1)[1].strip(), 0)
-            # Emit r2dec-style C (banner + include) so name extraction is exercised.
             return (
                 "/* r2dec pseudo code output (r2 6.0.8) */\n"
                 "#include <stdint.h>\n\n"
@@ -196,7 +171,6 @@ def test_r2_is_import_and_bare_name() -> None:
 
 
 def test_func_ident_in_code_strips_banner_and_macros() -> None:
-    # r2dec's block-comment banner + #include must not be mistaken for the name.
     code = (
         "/* r2dec pseudo code output (r2 6.0.8) */\n"
         "/* /in/bin @ 0x2e2b */\n"
@@ -207,20 +181,18 @@ def test_func_ident_in_code_strips_banner_and_macros() -> None:
         "    return a;\n}\n"
     )
     assert _func_ident_in_code(code) == "acl_create_entry"
-    # pdc emits a dotted pseudo-name verbatim; it must round-trip.
     assert _func_ident_in_code("void fcn.00003bed (int64_t a) {\n    return;\n}") == "fcn.00003bed"
-    # A snippet with no definition (just a control-flow block) yields None.
     assert _func_ident_in_code("if (x) {\n    y();\n}\n") is None
 
 
 def test_r2_discover_normalizes_and_filters() -> None:
     aflj = [
-        {"name": "sym.imp.free", "addr": 0x500},  # import -> skip
-        {"name": "reloc.foo", "addr": 0x600},  # reloc -> skip
-        {"name": "entry0", "addr": 0x1500},  # entry alias -> skip
-        {"name": "fcn.00002000", "addr": 0x2000},  # keep
-        {"name": "sym.main", "addr": 0x3000},  # keep
-        {"name": "sym.outside", "addr": 0x9500},  # outside .text -> skip
+        {"name": "sym.imp.free", "addr": 0x500},
+        {"name": "reloc.foo", "addr": 0x600},
+        {"name": "entry0", "addr": 0x1500},
+        {"name": "fcn.00002000", "addr": 0x2000},
+        {"name": "sym.main", "addr": 0x3000},
+        {"name": "sym.outside", "addr": 0x9500},
     ]
     r = _FakeR2(aflj, baddr=0)
     out = R2DecDecompiler._discover(r, elf_base=0, text_range=(0x1000, 0x9000), baddr=0)
@@ -228,7 +200,6 @@ def test_r2_discover_normalizes_and_filters() -> None:
 
 
 def test_r2_discover_rebases_when_baddr_differs() -> None:
-    # ARM firmware: r2 loads at baddr; file_addr = raw - baddr + elf_base.
     aflj = [{"name": "fcn.08002000", "addr": 0x8002000}]
     r = _FakeR2(aflj, baddr=0x8000000)
     out = R2DecDecompiler._discover(
@@ -241,12 +212,10 @@ def test_r2_narrow_by_int_address() -> None:
     discovered = [("fcn.a", 0x1000, 0x1000), ("fcn.b", 0x2000, 0x2000), ("fcn.c", 0x3000, 0x3000)]
     out = R2DecDecompiler._narrow(discovered, {0x1000, 0x3000}, "bin")
     assert {t[1] for t in out} == {0x1000, 0x3000}
-    # int labels are None (the code identifier becomes the key).
     assert all(t[0] is None for t in out)
 
 
 def test_r2_narrow_int_thumb_tolerant() -> None:
-    # DWARF low_pc is even; a Thumb function may be reported odd (addr|1).
     discovered = [("fcn.a", 0x8001, 0x8001)]
     out = R2DecDecompiler._narrow(discovered, {0x8000}, "bin")
     assert [t[1] for t in out] == [0x8001]
@@ -256,21 +225,17 @@ def test_r2_narrow_by_str_name_and_fallback() -> None:
     discovered = [("sym.foo", 0x1000, 0x1000), ("fcn.00002000", 0x2000, 0x2000)]
     out = R2DecDecompiler._narrow(discovered, {"foo"}, "bin")
     assert len(out) == 1 and out[0][0] == "foo" and out[0][1] == 0x1000
-    # No address matches -> fall back to everything (never an empty result).
     out2 = R2DecDecompiler._narrow(discovered, {0xDEAD}, "bin")
     assert {t[1] for t in out2} == {0x1000, 0x2000}
 
 
 def test_r2_make_function_names_from_code_and_relabels() -> None:
     code = "int foo(int a) {\n    return a;\n}\n"
-    # No label: name == the code identifier so an address-relabel rewrites both.
     fd = R2DecDecompiler._make_function("fcn.00001000", 0x1000, code, None)
     assert fd is not None and fd.name == "foo" and fd.address == 0x1000
-    # With a label (legacy str path): the code is rewritten to the label.
     fd2 = R2DecDecompiler._make_function("sym.foo", 0x1000, code, "realname")
     assert fd2 is not None and fd2.name == "realname"
     assert "realname" in fd2.decompiled_code and "foo(" not in fd2.decompiled_code
-    # Empty code -> no function.
     assert R2DecDecompiler._make_function("fcn.x", 0x1, "   ", None) is None
 
 
@@ -286,18 +251,12 @@ def test_r2_decompile_native_int_filter_mocked(monkeypatch: pytest.MonkeyPatch) 
     ]
     monkeypatch.setattr(r2pipe, "open", lambda *a, **k: _FakeR2(aflj, baddr=0))
     dec = R2DecDecompiler()
-    # binary_path need not exist: elf_min_vaddr -> 0, elf_text_range -> None.
     result = dec._decompile_native(Path("/nonexistent/bin"), None, None, {0x1000, 0x2000}, None)
     got = {fd.address for fd in result.functions.values()}
-    assert got == {0x1000, 0x2000}  # the import + 0x3000 are excluded
+    assert got == {0x1000, 0x2000}
     for fd in result.functions.values():
         assert _func_ident_in_code(fd.decompiled_code) == fd.name
     assert result.decompiler.extra.get("via") == "native"
-
-
-# --------------------------------------------------------------------------- #
-# ELF symbol enumeration (needs the sample binary)
-# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.skipif(not _GZIP.is_file(), reason="sample gzip binary not present")
@@ -305,26 +264,17 @@ def test_elf_function_symbols_elf_space() -> None:
     syms = elf_function_symbols(_GZIP)
     assert syms, "expected function symbols from gzip"
     names = {n for n, _ in syms}
-    # A known user function in gzip's deflate.c.
     assert "rsync_roll" in names
-    # Addresses are sorted and look like ELF .text addresses (non-zero).
     addrs = [a for _, a in syms]
     assert all(a > 0 for a in addrs)
     assert addrs == sorted(addrs)
-    # CRT helpers are filtered out.
     assert "_start" not in names
     assert "frame_dummy" not in names
-
-
-# --------------------------------------------------------------------------- #
-# _build_result mapping (no container; fake combined C)
-# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.skipif(not _GZIP.is_file(), reason="sample gzip binary not present")
 def test_build_result_maps_snippets_to_elf_addresses() -> None:
     dec = RetDecDecompiler()
-    # Pretend the container emitted C for one real gzip function.
     combined = "void rsync_roll(unsigned int a, unsigned int b) {\n    return;\n}\n"
     result = dec._build_result(
         binary_path=_GZIP,
@@ -338,17 +288,11 @@ def test_build_result_maps_snippets_to_elf_addresses() -> None:
     )
     assert "rsync_roll" in result.functions
     fn = result.functions["rsync_roll"]
-    # Address comes from the ELF symbol table (ELF file space).
     assert fn.address == 0x4567
     assert "rsync_roll" in fn.decompiled_code
     assert fn.variables == []
     assert fn.line_mappings == []
     assert result.decompiler.decompiler_name == "retdec"
-
-
-# --------------------------------------------------------------------------- #
-# r2dec native smoke (skips if radare2/r2pipe missing)
-# --------------------------------------------------------------------------- #
 
 
 def _native_r2dec_ready() -> bool:
@@ -365,21 +309,14 @@ def _native_r2dec_ready() -> bool:
     not _native_r2dec_ready(), reason="native radare2/r2pipe or sample binary absent"
 )
 def test_r2dec_native_decompiles_one_function() -> None:
-    # Drive the native path directly: the public decompile_binary now prefers
-    # the real r2dec via the docker image when it is built, so exercising the
-    # native fallback (pdd-if-installed, else pdc) means calling it explicitly.
-    # Discovery is from radare2's own analysis; a str name filter is the legacy
-    # interface (the benchmark driver uses int addresses instead).
     dec = R2DecDecompiler()
     result = dec._decompile_native(_GZIP, None, None, {"rsync_roll"}, None)
     assert result.decompiler.extra.get("via") == "native"
     assert "rsync_roll" in result.functions
     fn = result.functions["rsync_roll"]
-    # r2's normalized address must equal the ELF symbol-table address (ELF file
-    # space), so it lines up with DWARF and the driver's address relabel.
     want = dict(elf_function_symbols(_GZIP)).get("rsync_roll")
     assert want is not None and fn.address == want
-    assert fn.decompiled_code.strip()  # non-empty pseudo-C
+    assert fn.decompiled_code.strip()
     assert result.decompiler.decompiler_name == "r2dec"
 
 
@@ -390,7 +327,6 @@ def test_r2dec_native_int_address_filter() -> None:
         pytest.skip("native radare2/r2pipe or sample binary absent")
     dec = R2DecDecompiler()
     syms = dict(elf_function_symbols(_GZIP))
-    # Pick a few known ELF-file-space addresses (what the driver would pass).
     wanted = {syms[n] for n in ("rsync_roll", "bi_reverse") if n in syms}
     assert wanted, "expected known gzip functions"
     import tempfile
@@ -398,22 +334,13 @@ def test_r2dec_native_int_address_filter() -> None:
     with tempfile.TemporaryDirectory() as td:
         prog = Path(td) / "prog.pkl"
         result = dec._decompile_native(_GZIP, None, Path(td), wanted, prog)
-        # Every returned function's address is one we asked for.
         got = {fd.address for fd in result.functions.values()}
         assert got, "expected at least one decompiled function"
         assert got <= wanted
-        # Each function's name equals the identifier in its code (so a later
-        # address-relabel rewrites the code too) and the code is non-empty.
         for fd in result.functions.values():
             assert fd.decompiled_code.strip()
             assert _func_ident_in_code(fd.decompiled_code) == fd.name
-        # progress_path was checkpointed during the run.
         assert prog.exists()
-
-
-# --------------------------------------------------------------------------- #
-# Docker-image decompile smoke (skips when image absent)
-# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.parametrize("cls", [RetDecDecompiler, RekoDecompiler])
@@ -424,5 +351,4 @@ def test_docker_decompile_skips_when_image_absent(cls: type) -> None:
     if not _GZIP.is_file():
         pytest.skip("sample binary absent")
     result = dec.decompile_binary(_GZIP, function_names={"rsync_roll"})
-    # When the image is present, we at least get a well-formed result.
     assert result.decompiler.decompiler_name == cls.name

--- a/tests/test_e2e_pipeline.py
+++ b/tests/test_e2e_pipeline.py
@@ -103,7 +103,6 @@ class TestScoringPipeline:
         from decbench.scoring.aggregator import aggregate_results
         from decbench.scoring.scoreboard import build_scoreboard
 
-        # Create synthetic evaluation results
         eval_results = {
             "test_project": {
                 OptimizationLevel.O2: {
@@ -145,7 +144,6 @@ class TestScoringPipeline:
             },
         }
 
-        # Compute aggregates for each metric result
         for proj_results in eval_results.values():
             for opt_results in proj_results.values():
                 for bin_results in opt_results.values():
@@ -161,12 +159,10 @@ class TestScoringPipeline:
         assert "angr" in aggregated.decompilers
         assert aggregated.total_binaries == 1
 
-        # Check per-metric aggregates
         angr_ged = aggregated.by_decompiler["angr"]["ged"]
-        assert angr_ged.perfect_count == 2  # func1 and func3 have GED=0
+        assert angr_ged.perfect_count == 2
         assert angr_ged.total_count == 3
 
-        # Build scoreboard
         scoreboard = build_scoreboard(
             aggregated,
             projects=["test_project"],
@@ -176,14 +172,10 @@ class TestScoringPipeline:
         assert len(scoreboard.decompilers) == 1
         assert scoreboard.decompiler_scores["angr"].metric_scores["ged"].perfect_count == 2
 
-        # Union: func1 and func3 are perfect on all 3 (so certainly on >=1);
-        # func2 fails every metric — ged (2.0 != 0.0), type_match (0.5 != 1.0),
-        # byte_match (0.0 != 1.0) — so it is counted but never perfect.
         ds = scoreboard.decompiler_scores["angr"]
-        assert ds.overall_perfect_count == 2  # func1 and func3
+        assert ds.overall_perfect_count == 2
         assert ds.overall_total_count == 3
 
-        # Render text
         text = scoreboard.render_text()
         assert "angr" in text
 
@@ -272,7 +264,6 @@ class TestScoringPipeline:
             assert "Type Correctness" in content
             assert "Recompilation Bytematch" in content
             assert "Union" in content
-            # No function data -> banner present, no embedded data.
             assert "interactive views unavailable" in content.lower()
             assert "__DECBENCH_INLINE__" not in content
 
@@ -356,15 +347,11 @@ class TestScoringPipeline:
             assert output_path.exists()
             content = output_path.read_text()
 
-            # Embedded (precomputed) data + interactive sections present.
             assert "window.__DECBENCH_INLINE__" in content
-            # Sidebar layout: nav + JS-driven leaderboard + view routing.
             assert 'class="sidebar"' in content
             assert 'id="leaderboard-table"' in content
-            assert 'data-view="about"' in content  # absorbed the old metrics view
-            # The precomputed combos the client looks up instead of recomputing.
+            assert 'data-view="about"' in content
             assert '"combos"' in content
-            # `</script>` escaping in the inline payload: see tests/test_site.py.
 
 
 class TestLabels:
@@ -390,11 +377,9 @@ class TestLabels:
         labels = binary_labels_for(config, "O2", "bin1")
         assert labels == ["O2", "optimized", "firmware", "big"]
 
-        # A binary without per-binary additions still inherits project labels.
         labels2 = binary_labels_for(config, "O0", "bin2")
         assert labels2 == ["O0", "unoptimized", "firmware"]
 
-        # Duplicates across sources are removed, order-stable.
         config2 = ProjectConfig(
             name="proj2",
             labels=["O2", "firmware"],
@@ -408,13 +393,9 @@ class TestLabels:
 
         base = ["O2", "optimized"]
 
-        # Below threshold -> no "large".
         assert function_labels_for(base, 50, large_threshold=100) == base
-        # At threshold -> "large" appended.
         assert function_labels_for(base, 100, large_threshold=100) == ["O2", "optimized", "large"]
-        # Above threshold -> "large" appended.
         assert function_labels_for(base, 250, large_threshold=100) == ["O2", "optimized", "large"]
-        # Unknown line count -> no "large".
         assert function_labels_for(base, None, large_threshold=100) == base
 
 
@@ -527,7 +508,6 @@ class TestFullPipelineIntegration:
         binary_file = EXAMPLE_PROJECT_DIR / "example"
         source_file = EXAMPLE_PROJECT_DIR / "example.c"
 
-        # Extract source CFGs
         source_parsed = parse_source(str(source_file))
         source_cfgs = {}
         for func_name, func in source_parsed.items():
@@ -536,7 +516,6 @@ class TestFullPipelineIntegration:
 
         assert len(source_cfgs) > 0
 
-        # Decompile with angr
         project = angr.Project(str(binary_file), auto_load_libs=False)
         cfg = project.analyses.CFGFast(normalize=True)
 
@@ -553,7 +532,6 @@ class TestFullPipelineIntegration:
 
         assert len(decompiled_code) > 0
 
-        # Parse decompiled code to get CFGs
         decompiled_cfgs = {}
         with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
             for name, code in decompiled_code.items():
@@ -570,7 +548,6 @@ class TestFullPipelineIntegration:
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
-        # Compute GED
         total = 0
         perfect = 0
         for dec_name in decompiled_cfgs:

--- a/tests/test_evalkit.py
+++ b/tests/test_evalkit.py
@@ -34,9 +34,6 @@ pytestmark = pytest.mark.skipif(
     reason="host gcc + strip are required to build the synthetic eval-kit tree",
 )
 
-# --------------------------------------------------------------------------- #
-# Synthetic tree fixture: 2 tiny PIE programs at O0, a manifest, empty .i files
-# --------------------------------------------------------------------------- #
 _PROG1_C = """\
 int add_nums(int a, int b) { return a + b; }
 int mul_nums(int a, int b) { return a * b; }
@@ -49,8 +46,6 @@ int helper_two(int x) { return x * 2; }
 int main(void) { return helper_one(5) + helper_two(6); }
 """
 
-# main is deliberately NOT in the manifest so its address is an "extra"
-# (off-manifest) address for the ingest drop tests.
 _MANIFEST_FUNCS = [
     {"project": "proj1", "opt": "O0", "binary": "prog1", "function": "add_nums"},
     {"project": "proj1", "opt": "O0", "binary": "prog1", "function": "mul_nums"},
@@ -90,8 +85,6 @@ def tree(tmp_path_factory: pytest.TempPathFactory) -> Path:
             check=True,
             capture_output=True,
         )
-        # Empty .i named after the TU: source_stems() only needs the stem for
-        # the DWARF decl_file filter (no Joern parse happens at evaluate=False).
         (compiled / f"{prog}.i").write_text("")
     manifest = {"method": "std", "k": 1.0, "threshold": 10.0, "functions": _MANIFEST_FUNCS}
     (root / "sample_set_manifest.json").write_text(json.dumps(manifest, indent=2))
@@ -178,14 +171,10 @@ def packaged_zip(kit: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
     return zip_path
 
 
-# --------------------------------------------------------------------------- #
-# Export
-# --------------------------------------------------------------------------- #
 def test_export_layout_and_zip(kit: Path) -> None:
     assert (kit / "README.md").is_file()
     assert (kit / "functions.json").is_file()
     assert (kit / "results" / "README.md").is_file()
-    # package.py is the kit_package module source VERBATIM (standalone contract).
     assert (kit / "package.py").read_text() == Path(kit_package.__file__).read_text()
 
     fj = _functions_json(kit)
@@ -195,13 +184,11 @@ def test_export_layout_and_zip(kit: Path) -> None:
     assert shipped == set(fj["public"]) == set(fj["private"])
     assert len(shipped) == 2
 
-    # results.example.json is valid JSON built from the kit's own first binary.
     example = json.loads((kit / "results" / "results.example.json").read_text())
     (entry,) = example["results"].values()
     assert entry["binary"] == sorted(fj["public"])[0]
     assert set(entry["functions"].values()) <= set(fj["public"][entry["binary"]])
 
-    # The zip wraps the kit dir as its single top-level folder.
     zip_path = kit.parent / f"{kit.name}.zip"
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
@@ -215,14 +202,12 @@ def test_export_functions_json_matches_dwarf_truth(kit: Path, tree: Path) -> Non
 
     fj = _functions_json(kit)
     for anon, ident in fj["private"].items():
-        # Private identity round-trips to the real file on disk.
         original = tree / ident["opt"] / ident["project"] / "compiled" / ident["file"]
         assert original.is_file()
         assert Path(ident["file"]).stem == ident["binary"]
         assert ident["format"] == "ELF64-x86-64"
         shipped = kit / "binaries" / anon
         assert ident["sha256_stripped"] == hashlib.sha256(shipped.read_bytes()).hexdigest()
-        # Public addresses are exactly the manifest functions' nm/DWARF truth.
         truth = _nm_addrs(original)
         expected = sorted(truth[fn] for fn in _MANIFEST_BY_BINARY[ident["binary"]])
         assert fj["public"][anon] == [f"0x{a:x}" for a in expected]
@@ -243,8 +228,6 @@ def test_export_strip_verification(kit: Path, tree: Path) -> None:
         assert not any(name.startswith(".debug") for name in stripped)
         assert ".symtab" not in stripped
         assert stripped[".text"] == sections(original)[".text"]
-        # Never ship the executable bit: some real-corpus kit binaries are
-        # malware and the README says never to run them.
         assert not shipped.stat().st_mode & 0o111
 
 
@@ -271,7 +254,6 @@ def test_export_anon_assignment_deterministic(tree: Path, kit: Path, tmp_path: P
     assert fj_a["public"] == fj_b["public"]
     assert fj_a["private"] == fj_b["private"]
 
-    # The pinned assignment: sort by (project, opt, file), Random(seed).shuffle.
     idents = sorted(
         [(v["project"], v["opt"], v["file"]) for v in fj_a["private"].values()],
     )
@@ -304,7 +286,7 @@ def test_export_strict_vs_allow_unresolved(tree: Path, tmp_path: Path) -> None:
         tree, tmp_path / "lenient", manifest=manifest, make_zip=False, allow_unresolved=True
     )
     assert summary.n_binaries == 2
-    assert summary.n_functions == 4  # the resolvable manifest entries all survive
+    assert summary.n_functions == 4
     assert len(summary.skipped) == 2
     assert summary.zip_path is None
 
@@ -314,9 +296,6 @@ def test_export_rejects_non_sample_set_dataset(tree: Path, tmp_path: Path) -> No
         export_kit(tree, tmp_path / "kit", dataset="large")
 
 
-# --------------------------------------------------------------------------- #
-# package.py (always exercised as a real subprocess)
-# --------------------------------------------------------------------------- #
 def test_package_happy_path(kit_copy: Path) -> None:
     submitted = _full_submission(kit_copy)
     proc = _run_package(kit_copy)
@@ -336,7 +315,6 @@ def test_package_happy_path(kit_copy: Path) -> None:
     for c_name, entry in packaged["results"].items():
         anon = entry["anon_binary"]
         ident = fj["private"][anon]
-        # De-anonymized identity, straight from the kit's private mapping.
         assert entry["binary"] == {k: ident[k] for k in ("project", "opt", "binary", "file")}
         assert entry["functions"] == submitted["results"][c_name]["functions"]
 
@@ -414,7 +392,6 @@ def test_package_duplicate_function_names(kit_copy: Path) -> None:
     c_name = sorted(submitted["results"])[0]
     entry = submitted["results"][c_name]
     addrs = sorted(entry["functions"].values())
-    # JSON with a literal duplicate key (json.dumps of a dict can't emit one).
     entry_text = json.dumps(entry["functions"])[:-1] + f', "dup_fn": "{addrs[0]}", '
     entry_text += f'"dup_fn": "{addrs[1]}"}}'
     raw = json.dumps(submitted).replace(json.dumps(entry["functions"]), entry_text)
@@ -444,14 +421,13 @@ def test_package_tolerates_thumb_odd_addresses(kit_copy: Path) -> None:
     first_c = sorted(submitted["results"])[0]
     entry = submitted["results"][first_c]
     fn_name, even = next(iter(entry["functions"].items()))
-    entry["functions"][fn_name] = f"0x{int(even, 16) | 1:x}"  # set the Thumb bit
+    entry["functions"][fn_name] = f"0x{int(even, 16) | 1:x}"
     _write_submission(kit_copy, submitted, {})
 
     proc = _run_package(kit_copy)
     assert proc.returncode == 0, proc.stderr
     with zipfile.ZipFile(kit_copy / "results.zip") as zf:
         packaged = json.loads(zf.read("results.json"))
-    # Normalized back to the even target address the kit actually assigned.
     assert packaged["results"][first_c]["functions"][fn_name] == f"0x{int(even, 16):x}"
 
 
@@ -462,8 +438,6 @@ def test_package_partial_submission_warns_but_packages(kit_copy: Path) -> None:
     _write_submission(kit_copy, submitted, {})
     proc = _run_package(kit_copy)
     assert proc.returncode == 0
-    # Uncovered binaries are summarized in ONE line naming the offenders — a
-    # per-binary warning would bury the real ones (224-binary kit, partial run).
     assert "no submission for 1 of 2 kit binaries" in proc.stderr
     assert "bin_001.elf" in proc.stderr
     assert proc.stderr.count("no submission") == 1
@@ -474,9 +448,6 @@ def test_package_partial_submission_warns_but_packages(kit_copy: Path) -> None:
     assert "no submission" not in quiet.stderr
 
 
-# --------------------------------------------------------------------------- #
-# Ingest (evaluate=False everywhere: pyjoern must never load)
-# --------------------------------------------------------------------------- #
 def _load_dec_result(tree: Path, project: str, stem: str, dec_id: str):
     from decbench.models.project import OptimizationLevel
 
@@ -517,7 +488,7 @@ def test_ingest_packaged_zip_happy_path(packaged_zip: Path, tree_copy: Path) -> 
     assert summary.dec_id == "mydec"
     assert summary.n_binaries == 2
     assert summary.n_functions == 4
-    assert summary.n_relabeled == 4  # every sub_<addr> was renamed to its DWARF name
+    assert summary.n_relabeled == 4
     assert summary.n_dropped_extra == 0
     assert summary.n_failed == 0
 
@@ -526,7 +497,7 @@ def test_ingest_packaged_zip_happy_path(packaged_zip: Path, tree_copy: Path) -> 
     assert set(result.functions) == {"add_nums", "mul_nums"}
     assert result.binary_name == "prog1"
     assert result.decompiler.decompiler_name == "mydec"
-    assert result.decompiler.decompiler_version == "1.2.3"  # inherited from the submission
+    assert result.decompiler.decompiler_version == "1.2.3"
     assert result.decompiler.extra["slice_scoped"] is True
     assert result.decompiler.extra["external_submission"] is True
     assert result.decompiler.extra["kit_dataset"] == "sample-set"
@@ -534,11 +505,9 @@ def test_ingest_packaged_zip_happy_path(packaged_zip: Path, tree_copy: Path) -> 
     for name in ("add_nums", "mul_nums"):
         func = result.functions[name]
         assert func.address == truth[name]
-        # Relabeled: the DWARF name is the identifier in the stored code.
         assert name in func.decompiled_code
         assert "sub_" not in func.decompiled_code
 
-    # Artifacts: run-driver layout with "// Function: <name> @ 0x<addr>" markers.
     c_art = tree_copy / "O0" / "proj1" / "decompiled" / "mydec_prog1.c"
     assert f"// Function: add_nums @ 0x{truth['add_nums']:x}" in c_art.read_text()
     assert (tree_copy / "O0" / "proj1" / "decompiled" / "mydec_prog1.toml").is_file()
@@ -562,7 +531,6 @@ def test_ingest_partial_submission_failed_functions(tree_copy: Path, tmp_path: P
     result = _load_dec_result(tree_copy, "proj1", "prog1", "partdec")
     assert result.decompiler.failed_functions == ["mul_nums"]
     assert set(result.functions) == {"add_nums"}
-    # The other manifest binary wasn't submitted at all: warned, not fabricated.
     assert not (tree_copy / "checkpoints" / "proj2.pkl").exists()
     assert any("1/2 manifest" in w for w in summary.warnings)
 
@@ -571,9 +539,9 @@ def test_ingest_drops_extra_and_unparseable_addresses(tree_copy: Path, tmp_path:
     truth = _nm_addrs(tree_copy / "O0" / "proj1" / "compiled" / "prog1")
     funcs = {
         "sub_good": f"0x{truth['add_nums']:x}",
-        "sub_main": f"0x{truth['main']:x}",  # resolvable, but main is off-manifest
-        "sub_ghost": "0x999999",  # resolves to no DWARF function at all
-        "sub_bad": "zzz",  # unparseable address
+        "sub_main": f"0x{truth['main']:x}",
+        "sub_ghost": "0x999999",
+        "sub_bad": "zzz",
     }
     c_text = "".join(f"int {n}(int a, int b) {{ return a; }}\n\n" for n in funcs)
     sub = _packaged_dir(tmp_path, funcs, c_text)
@@ -604,7 +572,6 @@ def test_ingest_force_semantics(packaged_zip: Path, tree_copy: Path) -> None:
     ingest_submission(packaged_zip, tree_copy, "mydec", evaluate=False)
     with pytest.raises(EvalKitError, match="force"):
         ingest_submission(packaged_zip, tree_copy, "mydec", evaluate=False)
-    # Same id, force=True: overwrite allowed. A different id needs no force.
     summary = ingest_submission(packaged_zip, tree_copy, "mydec", evaluate=False, force=True)
     assert summary.n_functions == 4
     other = ingest_submission(packaged_zip, tree_copy, "otherdec", evaluate=False)
@@ -621,7 +588,6 @@ def test_force_reingest_purges_slices_the_new_submission_dropped(
     ingest_submission(packaged_zip, tree_copy, "mydec", evaluate=False)
     assert (tree_copy / "O0" / "proj2" / "decompiled" / "mydec_prog2.c").is_file()
 
-    # Re-package covering only proj1.
     work = tmp_path / "resub"
     work.mkdir()
     with zipfile.ZipFile(packaged_zip) as zf:
@@ -635,12 +601,10 @@ def test_force_reingest_purges_slices_the_new_submission_dropped(
     summary = ingest_submission(work, tree_copy, "mydec", evaluate=False, force=True)
     assert summary.n_binaries == 1
     assert any("dropped stale" in w and "proj2" in w for w in summary.warnings)
-    # The dropped project's artifacts AND checkpoint entry are gone...
     assert not (tree_copy / "O0" / "proj2" / "decompiled" / "mydec_prog2.c").exists()
     assert not (tree_copy / "O0" / "proj2" / "decompiled" / "mydec_prog2.toml").exists()
     with pytest.raises(KeyError):
         _load_dec_result(tree_copy, "proj2", "prog2", "mydec")
-    # ...while the covered project survives.
     assert set(_load_dec_result(tree_copy, "proj1", "prog1", "mydec").functions) == {
         "add_nums",
         "mul_nums",
@@ -690,21 +654,15 @@ def test_ingest_requires_sample_manifest(packaged_zip: Path, tmp_path: Path) -> 
         ingest_submission(packaged_zip, bare, "mydec", evaluate=False)
 
 
-# --------------------------------------------------------------------------- #
-# AddrLookup tolerances
-# --------------------------------------------------------------------------- #
 def test_addrlookup_tolerances() -> None:
     lookup = resolve.AddrLookup({0x401000: "f", 0x8008000: "g"}, min_vaddr=0x400000)
-    assert lookup.name_for(0x401000) == "f"  # exact
-    assert lookup.name_for(0x8008001) == "g"  # Thumb bit cleared
-    assert lookup.name_for(0x1000) == "f"  # rebased by min_vaddr
-    assert lookup.name_for(0x7C08001) == "g"  # rebased + Thumb-cleared
-    assert lookup.name_for(0x5000) is None  # no tolerance rule reaches a match
+    assert lookup.name_for(0x401000) == "f"
+    assert lookup.name_for(0x8008001) == "g"
+    assert lookup.name_for(0x1000) == "f"
+    assert lookup.name_for(0x7C08001) == "g"
+    assert lookup.name_for(0x5000) is None
 
 
-# --------------------------------------------------------------------------- #
-# CLI smoke (CliRunner)
-# --------------------------------------------------------------------------- #
 def test_cli_export_smoke(tree: Path, tmp_path: Path) -> None:
     from decbench.cli import main
 

--- a/tests/test_improvements.py
+++ b/tests/test_improvements.py
@@ -40,18 +40,13 @@ def _fake_elf(path: Path) -> None:
     path.write_bytes(b"\x7fELF" + b"\x00" * 16)
 
 
-# --------------------------------------------------------------------------- #
-# Core selection (GED — lower is better)
-# --------------------------------------------------------------------------- #
-
-
 def test_ged_selects_only_wins_sorted_by_margin() -> None:
     fd = _fd(
         [
-            _rec("win_big", angr={"ged": 0.0}, kuna={"ged": 10.0}),  # win, margin 10
-            _rec("win_small", angr={"ged": 3.0}, kuna={"ged": 5.0}),  # win, margin 2
-            _rec("tie", angr={"ged": 5.0}, kuna={"ged": 5.0}),  # tie -> excluded
-            _rec("base_loses", angr={"ged": 8.0}, kuna={"ged": 2.0}),  # loss -> excluded
+            _rec("win_big", angr={"ged": 0.0}, kuna={"ged": 10.0}),
+            _rec("win_small", angr={"ged": 3.0}, kuna={"ged": 5.0}),
+            _rec("tie", angr={"ged": 5.0}, kuna={"ged": 5.0}),
+            _rec("base_loses", angr={"ged": 8.0}, kuna={"ged": 2.0}),
         ]
     )
     cases = find_improvement_cases(fd, "angr", "kuna", "ged")
@@ -76,13 +71,12 @@ def test_target_missing_excluded_by_default_included_on_flag() -> None:
     fd = _fd(
         [
             _rec("both", angr={"ged": 0.0}, kuna={"ged": 4.0}),
-            _rec("only_angr", angr={"ged": 1.0}),  # kuna produced nothing
+            _rec("only_angr", angr={"ged": 1.0}),
         ]
     )
     assert [c.function for c in find_improvement_cases(fd, "angr", "kuna", "ged")] == ["both"]
 
     cases = find_improvement_cases(fd, "angr", "kuna", "ged", include_target_missing=True)
-    # target-missing sorts first (infinite margin) then real wins.
     assert [c.function for c in cases] == ["only_angr", "both"]
     miss = cases[0]
     assert miss.target_missing is True
@@ -91,29 +85,23 @@ def test_target_missing_excluded_by_default_included_on_flag() -> None:
 
 
 def test_base_without_value_is_never_a_win() -> None:
-    # base has no ged value; even though kuna is worse it cannot "win".
     fd = _fd([_rec("no_base", kuna={"ged": 9.0})])
     assert find_improvement_cases(fd, "angr", "kuna", "ged") == []
 
 
 def test_nonfinite_target_treated_as_missing() -> None:
-    # A target GED of inf (metric errored though it decompiled) is NOT a genuine
-    # win: it must be gated behind include_target_missing, not ranked #1.
     fd = _fd(
         [
             _rec("real_win", angr={"ged": 0.0}, kuna={"ged": 5.0}),
             _rec("errored", angr={"ged": 0.0}, kuna={"ged": float("inf")}),
         ]
     )
-    # Default: the inf-target function is excluded, only the real win shows.
     assert [c.function for c in find_improvement_cases(fd, "angr", "kuna", "ged")] == ["real_win"]
 
-    # With the flag it appears, but normalized to the "no usable score" bucket.
     cases = find_improvement_cases(fd, "angr", "kuna", "ged", include_target_missing=True)
     errored = next(c for c in cases if c.function == "errored")
     assert errored.target_missing is True
-    assert errored.target_value is None  # not inf
-    # ...and its JSON is valid (no `Infinity` token).
+    assert errored.target_value is None
     import json
 
     dumped = json.dumps(errored.to_dict())
@@ -122,22 +110,16 @@ def test_nonfinite_target_treated_as_missing() -> None:
 
 
 def test_nonfinite_target_with_perfect_only() -> None:
-    # perfect_only + a non-finite target must still not sneak the inf case in.
     fd = _fd([_rec("errored", angr={"ged": 0.0}, kuna={"ged": float("inf")})])
     assert find_improvement_cases(fd, "angr", "kuna", "ged", perfect_only=True) == []
-
-
-# --------------------------------------------------------------------------- #
-# Direction handling (type_match — higher is better)
-# --------------------------------------------------------------------------- #
 
 
 def test_higher_is_better_metric_direction() -> None:
     fd = _fd(
         [
-            _rec("win", angr={"type_match": 1.0}, kuna={"type_match": 0.5}),  # win 0.5
-            _rec("loss", angr={"type_match": 0.5}, kuna={"type_match": 0.8}),  # excluded
-            _rec("win2", angr={"type_match": 0.8}, kuna={"type_match": 0.5}),  # win 0.3
+            _rec("win", angr={"type_match": 1.0}, kuna={"type_match": 0.5}),
+            _rec("loss", angr={"type_match": 0.5}, kuna={"type_match": 0.8}),
+            _rec("win2", angr={"type_match": 0.8}, kuna={"type_match": 0.5}),
         ]
     )
     cases = find_improvement_cases(fd, "angr", "kuna", "type_match")
@@ -149,29 +131,19 @@ def test_higher_is_better_metric_direction() -> None:
     assert [c.function for c in perfect] == ["win"]
 
 
-# --------------------------------------------------------------------------- #
-# Validation
-# --------------------------------------------------------------------------- #
-
-
 @pytest.mark.parametrize(
     "base,target,metric",
     [
         ("nope", "kuna", "ged"),
         ("angr", "nope", "ged"),
         ("angr", "kuna", "nope"),
-        ("angr", "angr", "ged"),  # base must differ from target
+        ("angr", "angr", "ged"),
     ],
 )
 def test_invalid_inputs_raise(base: str, target: str, metric: str) -> None:
     fd = _fd([_rec("f", angr={"ged": 0.0}, kuna={"ged": 1.0})])
     with pytest.raises(ValueError):
         find_improvement_cases(fd, base, target, metric)
-
-
-# --------------------------------------------------------------------------- #
-# On-disk resolution
-# --------------------------------------------------------------------------- #
 
 
 def test_resolves_binary_path_and_address(tmp_path: Path) -> None:
@@ -200,7 +172,6 @@ def test_resolves_binary_path_and_address(tmp_path: Path) -> None:
 
 
 def test_versioned_binary_stem_resolution(tmp_path: Path) -> None:
-    # group binary stem is "libz.so.1.2" but the real file is "libz.so.1.2.13".
     root = tmp_path
     comp = root / "O0" / "proj" / "compiled"
     dec = root / "O0" / "proj" / "decompiled"
@@ -216,8 +187,6 @@ def test_versioned_binary_stem_resolution(tmp_path: Path) -> None:
 
 
 def test_versioned_decompiler_artifact_name(tmp_path: Path) -> None:
-    # A versioned id (ghidra@12.0) must resolve addresses from the unversioned
-    # artifact filename (ghidra_bin.c), which is how to_c_file names them.
     root = tmp_path
     comp = root / "O0" / "proj" / "compiled"
     dec = root / "O0" / "proj" / "decompiled"
@@ -243,7 +212,6 @@ def test_versioned_decompiler_artifact_name(tmp_path: Path) -> None:
 
 
 def test_missing_tree_degrades_gracefully(tmp_path: Path) -> None:
-    # results_root exists but has no compiled/decompiled artifacts.
     fd = _fd([_rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0})])
     (case,) = find_improvement_cases(fd, "angr", "kuna", "ged", results_root=tmp_path)
     assert case.binary_path is None
@@ -254,11 +222,6 @@ def test_no_results_root_leaves_locations_unset() -> None:
     fd = _fd([_rec("foo", angr={"ged": 0.0}, kuna={"ged": 7.0})])
     (case,) = find_improvement_cases(fd, "angr", "kuna", "ged")
     assert case.binary_path is None and case.address is None
-
-
-# --------------------------------------------------------------------------- #
-# Rendering
-# --------------------------------------------------------------------------- #
 
 
 def test_render_text_and_to_dict() -> None:

--- a/tests/test_llm_decompilers.py
+++ b/tests/test_llm_decompilers.py
@@ -30,7 +30,6 @@ def test_versioned_spec_sets_model():
     dec = DecompilerRegistry.get("codex@gpt-5.6-sol")
     assert dec.id == "codex@gpt-5.6-sol"
     assert dec._model() == "gpt-5.6-sol"
-    # The kimi model alias itself contains a slash and a dash.
     dec = DecompilerRegistry.get("kimi-code@kimi-code/k3")
     assert dec.id == "kimi-code@kimi-code/k3"
     assert dec._model() == "kimi-code/k3"
@@ -38,12 +37,10 @@ def test_versioned_spec_sets_model():
 
 def test_shared_prompt_states_the_policy():
     p = llm_dec.LLM_DECOMPILE_PROMPT.lower()
-    # Banned from decompilers, allowed simple disassemblers.
     assert "banned" in p
     for tool in ("ghidra", "ida", "hex-rays", "binary ninja", "angr"):
         assert tool in p
     assert "objdump" in p
-    # Reconstruct C faithful to the original source.
     assert "c source" in p or "reconstruct the original c" in p
 
 
@@ -64,7 +61,6 @@ def test_extract_c_from_bare_definition():
 def test_rename_func_matches_placeholder():
     code = "int wcomment(char *s) { return wcomment(s); }"
     renamed = llm_dec._rename_func(code, "sub_18a5")
-    # Both the definition and the recursive call are renamed.
     assert "int sub_18a5(" in renamed
     assert "wcomment" not in renamed
 
@@ -96,7 +92,7 @@ def test_cost_cap_truncates(monkeypatch, tmp_path):
     fake_bin.write_bytes(b"\x7fELF")
     res = dec.decompile_binary(fake_bin, function_names={i for i in range(20)})
     assert isinstance(res, DecompilationResult)
-    assert len(calls) == 3  # capped, not 20
+    assert len(calls) == 3
 
 
 def test_disasm_hint_on_real_binary():
@@ -105,7 +101,6 @@ def test_disasm_hint_on_real_binary():
     if not b.is_file():
         pytest.skip("sample binary not present")
     hint = llm_dec._disasm_hint(b, 0x18A5)
-    # Non-empty and looks like disassembly (has an address + a mnemonic).
     assert hint and "0x18a5" in hint
 
 

--- a/tests/test_materialized.py
+++ b/tests/test_materialized.py
@@ -36,7 +36,6 @@ timeout = false
 failed_functions = [ "broken_fn",]
 """
 
-# A 4-node diamond: 0 -> {1, 2} -> 3, entry 0, exit 3.
 CFG_JSON = {
     "opt": "O0",
     "project": "demo",
@@ -57,8 +56,6 @@ CFG_JSON = {
 def _write_tree(root: Path) -> Path:
     proj = root / "O0" / "demo"
     (proj / "compiled").mkdir(parents=True)
-    # A minimal but well-formed ELF64 header (e_type=EXEC at offset 16), padded
-    # so binfmt/resolve_binary header reads never run short.
     elf = b"\x7fELF" + bytes([2, 1, 1, 0]) + b"\x00" * 8 + struct.pack("<HH", 2, 0x3E)
     (proj / "compiled" / "demo").write_bytes(elf.ljust(64, b"\x00"))
     (proj / "decompiled").mkdir()
@@ -93,7 +90,6 @@ def test_discover_decompilations_shape_and_filter(tmp_path: Path) -> None:
     assert set(per_opt["demo"]) == {"ghidra"}
     assert per_opt["demo"]["ghidra"].function_count == 2
 
-    # Decompiler filter excludes non-matching artifacts entirely.
     assert discover_decompilations(tmp_path, [OptimizationLevel.O0], decompilers=["ida"]) == {}
 
 
@@ -109,7 +105,6 @@ def test_load_source_cfgs_rebuilds_ged_ready_graphs(tmp_path: Path) -> None:
     assert [n.id for n in entries] == [0]
     assert [n.id for n in exits] == [3]
 
-    # Missing dir -> None (caller falls back to .i extraction).
     assert load_source_cfgs(tmp_path, "O2", "demo") is None
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,7 +39,7 @@ class TestMetricRegistry:
         with pytest.raises(KeyError):
             MetricRegistry.get("nonexistent")
 
-    def test_get_all(self) -> None:
+    def test_list_registered(self) -> None:
         @register_metric("m1")
         class M1(Metric):
             name = "m1"
@@ -54,9 +54,9 @@ class TestMetricRegistry:
             def compute_for_function(self, decompiled, **kwargs):
                 return MetricValue(value=0.0)
 
-        all_metrics = MetricRegistry.get_all()
-        assert "m1" in all_metrics
-        assert "m2" in all_metrics
+        registered = MetricRegistry.list_registered()
+        assert "m1" in registered
+        assert "m2" in registered
 
 
 class TestGEDMetric:
@@ -97,12 +97,9 @@ class TestGEDMetric:
 
         from decbench.metrics.ged import GEDMetric
 
-        # What Joern produces when it only sees a declaration: one lone node.
         source = nx.DiGraph()
         source.add_node("decl_only")
 
-        # A truncated (prologue-only) decompilation stub: also one node. Under
-        # exact GED these "match" for 0 — the exact artifact being excluded.
         stub = nx.DiGraph()
         stub.add_node("stub_block")
 
@@ -118,14 +115,11 @@ class TestGEDMetric:
         assert "degenerate source CFG" in result.metadata["error"]
         assert result.metadata["source_nodes"] == 1
 
-        # A degenerate source must exclude the function no matter how big the
-        # decompiled CFG is (previously: bigger output = worse score).
         big = nx.DiGraph()
         big.add_edges_from((i, i + 1) for i in range(10))
         result_big = metric.compute_for_function(func, source_cfg=source, decompiled_cfg=big)
         assert result_big.value == float("inf")
 
-        # An empty source graph is degenerate too.
         empty = nx.DiGraph()
         result_empty = metric.compute_for_function(func, source_cfg=empty, decompiled_cfg=stub)
         assert result_empty.value == float("inf")
@@ -137,7 +131,6 @@ class TestGEDMetric:
 
         from decbench.metrics.ged import GEDMetric
 
-        # cfgutils expects nodes with is_entrypoint attribute
         class CFGNode:
             def __init__(self, addr: int, is_entry: bool = False, is_exit: bool = False):
                 self.addr = addr
@@ -228,7 +221,6 @@ class TestTypeMatchMetric:
 
         metric = TypeMatchMetric()
         result = metric.compute_for_function(func, ground_truth_vars=gt_vars)
-        # x matches, y doesn't
         assert result.value == pytest.approx(0.5)
 
     def test_type_match_no_ground_truth(self) -> None:
@@ -296,7 +288,6 @@ int main() {
                 VariableInfo(name="a1", type="char *", kind="arg", arg_index=1),
             ],
         )
-        # Register-resident args at -O2: names differ, no stack offsets.
         gt_vars = [
             {
                 "name": "count",
@@ -399,7 +390,6 @@ int main() {
         gt = extract_ground_truth_types(binary)
         assert "helper" in gt, f"helper missing from O2 ground truth: {sorted(gt)}"
         by_name = {v["name"]: v for v in gt["helper"]}
-        # Register-resident args kept, with positional indices
         assert by_name["first"]["is_arg"] is True
         assert by_name["first"]["arg_index"] == 0
         assert by_name["second"]["arg_index"] == 1
@@ -417,7 +407,6 @@ int main() {
                 VariableInfo(name="i", type="int", stack_offset=-8, kind="stack"),
             ],
         )
-        # Two shadowed locals named "i" at distinct offsets; only one recovered
         gt_vars = [
             {"name": "i", "type": ["int"], "rbp_offset": [-8], "size": 4},
             {"name": "i", "type": ["int"], "rbp_offset": [-16], "size": 4},
@@ -443,8 +432,6 @@ int main() {
         """All-single-var functions must not elect a spurious nonzero shift."""
         from decbench.metrics.type_match import _calibrate_shift_multi
 
-        # Three coincidental +4 alignments from unrelated single slots, and
-        # one function genuinely aligned at shift 0.
         pairs = [
             ([-8], [-12]),
             ([-12], [-16]),
@@ -463,7 +450,6 @@ int main() {
             decompiled_code="// no decls",
             variables=[
                 VariableInfo(name="x", type="int", stack_offset=-4, kind="stack"),
-                # argc was promoted to an argument: correct name+type, no offset
                 VariableInfo(name="argc", type="int", stack_offset=None, kind="arg"),
             ],
         )
@@ -563,8 +549,6 @@ int main() {
 
         metric = TypeMatchMetric()
         result = metric.compute_for_function(func, ground_truth_vars=gt_vars)
-        # The local declaration is now parsed into a structured variable and
-        # matched by name via the structured matcher (value unchanged at 1.0).
         assert result.metadata["matched_by"] == "structured"
         assert result.value == 1.0
 
@@ -580,8 +564,6 @@ int main() {
             decompiled_code='void wcomment(FILE *fp, int c)\n{\n    fputs("x", fp);\n}\n',
             variables=[],
         )
-        # DWARF ground truth: two arguments; the decompiler renamed the 2nd
-        # (``c`` vs ``i``), so only ABI position — not name — can match it.
         gt_vars = [
             {"name": "fp", "type": ["FILE*"], "is_arg": True, "arg_index": 0, "rbp_offset": [-8]},
             {"name": "i", "type": ["int"], "is_arg": True, "arg_index": 1, "rbp_offset": [-12]},
@@ -645,20 +627,17 @@ class TestByteMatchMetric:
     def test_jaccard_similarity(self) -> None:
         from decbench.metrics.byte_match import _compute_jaccard_similarity
 
-        # Returns (similarity, changed_lines). Identical -> perfect, 0 changes.
         lines = ["mov rax, rbx", "add rax, 1", "ret"]
         sim, changed = _compute_jaccard_similarity(lines, lines)
         assert sim == 1.0
         assert changed == 0
 
-        # Completely different -> 0 similarity, every line changed on both sides.
         lines_a = ["mov rax, rbx", "ret"]
         lines_b = ["push rbp", "pop rbp"]
         sim, changed = _compute_jaccard_similarity(lines_a, lines_b)
         assert sim == 0.0
         assert changed == len(lines_a) + len(lines_b)
 
-        # Empty
         sim, changed = _compute_jaccard_similarity([], [])
         assert sim == 1.0
         assert changed == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,11 +65,9 @@ optimization_levels = ["O2"]
         assert OptimizationLevel.O2.gcc_flags == ["-O2"]
         assert OptimizationLevel.O2_NOINLINE.gcc_flags == ["-O2", "-fno-inline"]
 
-        # String values and enum members map identically
         assert opt_gcc_flags("O2-noinline") == ["-O2", "-fno-inline"]
         assert opt_gcc_flags(OptimizationLevel.O2_NOINLINE) == ["-O2", "-fno-inline"]
         assert opt_gcc_flags("O0") == ["-O0"]
-        # Unknown ad-hoc levels fall back to -<value>
         assert opt_gcc_flags("Og") == ["-Og"]
 
     def test_o2_noinline_round_trip(self) -> None:
@@ -89,7 +87,6 @@ optimization_levels = ["O0", "O2", "O2-noinline"]
             assert OptimizationLevel.O2_NOINLINE in project.compilation.optimization_levels
 
     def test_base_flags_no_inline_by_default(self) -> None:
-        # Inlining is controlled by the opt level, not base flags
         config = CompilationConfig()
         assert "-fno-inline" not in config.base_flags
         assert "-fno-builtin" in config.base_flags
@@ -122,18 +119,7 @@ class TestDecompilationModels:
         )
         assert func.name == "main"
         assert func.address == 0x1000
-        assert func.has_gotos is False
-        assert func.goto_count == 0
-
-    def test_function_with_gotos(self) -> None:
-        func = FunctionDecompilation(
-            name="test",
-            address=0x2000,
-            decompiled_code="void test() { goto label; label: return; }",
-            metadata={"gotos": 1},
-        )
-        assert func.has_gotos is True
-        assert func.goto_count == 1
+        assert func.metadata["gotos"] == 0
 
     def test_decompilation_result(self) -> None:
         result = DecompilationResult(

--- a/tests/test_publish_layout.py
+++ b/tests/test_publish_layout.py
@@ -90,10 +90,8 @@ def test_strip_decompilers_removes_all_traces():
     fd = make_fd()
     removed = strip_decompilers(fd, [STRIPPED])
     assert removed == [STRIPPED]
-    # No trace anywhere in the serialized dataset.
     dumped = json.dumps(fd.model_dump(mode="json"))
     assert STRIPPED not in dumped
-    # The kept decompiler is untouched.
     assert fd.decompilers == [KEPT]
     assert fd.decompiler_versions == {KEPT: "9.2"}
     assert fd.compile_rates == {KEPT: 0.9}
@@ -114,17 +112,14 @@ def test_strip_decompilers_idempotent_and_unknown():
     fd = make_fd()
     assert strip_decompilers(fd, [STRIPPED]) == [STRIPPED]
     before = fd.model_dump(mode="json")
-    # Second strip: nothing left to remove, data unchanged.
     assert strip_decompilers(fd, [STRIPPED]) == []
     assert fd.model_dump(mode="json") == before
-    # Unknown decompiler / empty exclusions: no-ops.
     assert strip_decompilers(fd, ["nonexistent"]) == []
     assert strip_decompilers(fd, []) == []
     assert fd.model_dump(mode="json") == before
 
 
 def test_strip_decompilers_reports_partial_traces():
-    # A decompiler present ONLY in hardest is still detected and removed.
     fd = make_fd()
     fd.decompilers = [KEPT]
     fd.decompiler_versions.pop(STRIPPED)
@@ -161,7 +156,6 @@ def test_load_dataset_strips_explicit_exclusions(results_tree: Path):
     fd = load_dataset(results_tree, exclude=(STRIPPED,))
     assert STRIPPED not in json.dumps(fd.model_dump(mode="json"))
     assert fd.decompilers == [KEPT]
-    # Presets were still assigned after the strip.
     assert [p.name for p in fd.dataset_presets]
 
 
@@ -187,7 +181,6 @@ def _publish_master(root: Path, dest: Path, exclude: tuple[str, ...]) -> Functio
 def test_write_master_scores_excludes_and_regenerates_scoreboard(results_tree: Path, tmp_path):
     from decbench.scoring.scoreboard import build_scoreboard_from_function_data
 
-    # The tree's own scoreboard aggregates BOTH decompilers.
     tree_sb = build_scoreboard_from_function_data(load_dataset(results_tree, exclude=()))
     tree_sb.to_toml(results_tree / "scoreboard.toml")
 
@@ -200,14 +193,11 @@ def test_write_master_scores_excludes_and_regenerates_scoreboard(results_tree: P
     sb_text = (dest / "results" / "scoreboard.toml").read_text()
     assert STRIPPED not in sb_text
     assert KEPT in sb_text
-    # The tree's own files still contain the excluded decompiler.
     assert STRIPPED in (results_tree / "function_results.json").read_text()
     assert STRIPPED in (results_tree / "scoreboard.toml").read_text()
 
 
 def test_write_master_scores_never_truncates_hardlinked_source(results_tree: Path, tmp_path):
-    # Simulate a previous hardlink-first publish: dest master shares the tree
-    # file's inode. A rewrite must break the link, not truncate through it.
     dest = tmp_path / "dataset"
     out = dest / "results" / "function_results.json"
     out.parent.mkdir(parents=True)
@@ -216,7 +206,7 @@ def test_write_master_scores_never_truncates_hardlinked_source(results_tree: Pat
     _publish_master(results_tree, dest, exclude=(STRIPPED,))
 
     source = (results_tree / "function_results.json").read_text()
-    assert STRIPPED in source  # tree file intact
+    assert STRIPPED in source
     assert STRIPPED not in out.read_text()
     assert (results_tree / "function_results.json").stat().st_ino != out.stat().st_ino
 
@@ -238,7 +228,5 @@ def test_write_master_scores_verbatim_scoreboard_without_exclusions(results_tree
 
 def test_full_config_has_publisher_description():
     assert _preset_description("full") != ""
-    # Scoring presets get their publisher-side text too (renderer copy lives
-    # elsewhere; the published dataset.toml must not have blank descriptions).
     for name in ("unoptimized", "optimized", "inlined", "large", "sample-set"):
         assert _preset_description(name) != ""

--- a/tests/test_report_extras.py
+++ b/tests/test_report_extras.py
@@ -30,8 +30,6 @@ int target(int a, int b) {
 }
 """
 
-# A minimal-but-valid ELF header (x86-64) so `binfmt.detect` / `resolve_binary`
-# accept the fake binary and source_extract will search its sibling .c.
 _ELF64_HEADER = b"\x7fELF" + b"\x00" * 14 + b"\x3e\x00"
 
 
@@ -60,7 +58,6 @@ def _function_data():
 
 
 def test_build_samples_includes_source_and_decompiled(tmp_path: Path) -> None:
-    # A fake binary with a sibling .c source (source_extract finds it w/o DWARF).
     binary = tmp_path / "bin1"
     binary.write_bytes(b"\x7fELF not-really")
     (tmp_path / "bin1.c").write_text(SOURCE)
@@ -74,7 +71,6 @@ def test_build_samples_includes_source_and_decompiled(tmp_path: Path) -> None:
     assert "return a+b+b" in s.decompiled["angr"]
     assert s.source_code is not None
     assert "return s * 2;" in s.source_code
-    # Carries the per-metric scores for display.
     assert s.values["angr"]["byte_match"] == 0.5
 
 
@@ -101,14 +97,6 @@ def test_compute_compile_rates() -> None:
     evaluation = {"proj": {"O0": {"bin1": {"angr": {"byte_match": bm}}}}}
     rates = compute_compile_rates(evaluation)
     assert abs(rates["angr"] - (2 / 3)) < 1e-9
-
-
-# --- sample-set materialization (site-build time) ----------------------------
-#
-# `build_sample_set_samples` is the site-build path that turns every function
-# tagged `sample-set` into a View-page entry, reading decompiled code + source
-# straight off the on-disk results tree (not the in-memory decompile results the
-# GED-tiered `build_samples` uses).
 
 
 def _write_results_tree(root: Path, project: str = "proj") -> None:
@@ -160,9 +148,7 @@ def test_build_sample_set_samples_materializes_from_tree(tmp_path: Path, monkeyp
     assert s.difficulty == "sample-set"
     assert s.function == "target"
     assert "return a+b+b" in s.decompiled["codex"]
-    # Source resolved from the sibling .c (no DWARF needed for the fake binary).
     assert s.source_code is not None and "return s * 2;" in s.source_code
-    # Per-metric scores carried from the record, for the View page's score strip.
     assert s.values["codex"]["ged"] == 0.0
     assert s.perfects["codex"]["type_match"] is True
 
@@ -173,7 +159,7 @@ def test_build_sample_set_samples_skips_untagged(tmp_path: Path) -> None:
     fd = _sample_set_fd()
     for group in fd.groups:
         for func in group.functions:
-            func.datasets = ["unoptimized"]  # not sampled into the sample-set
+            func.datasets = ["unoptimized"]
     assert build_sample_set_samples(fd, tmp_path) == []
 
 
@@ -181,7 +167,6 @@ def test_build_sample_set_samples_skips_bare_tree(tmp_path: Path, caplog) -> Non
     """A bare scoreboard+function_results dir (no per-opt artifact dirs) yields []."""
     import logging
 
-    # tmp_path has no O0/O2/... subdirs, so there is nothing to read.
     with caplog.at_level(logging.WARNING, logger="decbench.scoring.report_extras"):
         assert build_sample_set_samples(_sample_set_fd(), tmp_path) == []
     assert "no artifact directories" in caplog.text
@@ -193,14 +178,6 @@ def test_build_sample_set_samples_excludes_malware(tmp_path: Path, monkeypatch) 
     _write_results_tree(tmp_path, project="mirai")
     fd = _sample_set_fd(project="mirai", labels=["malware", "do-not-execute"])
     assert build_sample_set_samples(fd, tmp_path) == []
-
-
-# --- Malware code must never reach a published payload -----------------------
-#
-# The `samples`/`hardest` payloads carry real C source, get committed to site/,
-# and are published by GitHub Pages (which is PUBLIC even for a private repo on
-# Pro/Team). Six benchmark targets are REAL malware from theZoo. These tests are
-# the tripwire: if the filter is ever "optimized" away, they fail.
 
 
 def _malware_function_data() -> FunctionData:
@@ -310,7 +287,6 @@ def test_attach_extras_keeps_malware_out_of_code_payloads(tmp_path: Path, monkey
     )
     assert "MALWARE_C" not in blob
     assert "mirai" not in blob
-    # The score path is untouched: the malware function still counts.
     assert any(g.project == "mirai" for g in fd.groups)
 
 
@@ -326,7 +302,6 @@ def test_build_payloads_scrubs_prebaked_malware(tmp_path: Path, monkeypatch) -> 
     from decbench.rendering.aggregate import build_payloads
 
     fd = _malware_function_data()
-    # Simulate the already-baked payload: malware code sitting in the file.
     fd.samples = [
         SampleEntry(
             project="mirai",
@@ -353,8 +328,5 @@ def test_build_payloads_scrubs_prebaked_malware(tmp_path: Path, monkeypatch) -> 
     payloads = build_payloads(fd, Scoreboard(name="t"))
 
     assert payloads["samples"] == []
-    # hardest is stored in function_results.json but never shipped as a payload
-    # anymore (the View page's hard tier replaced it) — so prebaked malware in
-    # it cannot publish either.
     assert "hardest" not in payloads
     assert "MALWARE_C" not in json.dumps(payloads)

--- a/tests/test_results_store.py
+++ b/tests/test_results_store.py
@@ -70,12 +70,9 @@ def test_update_ged_slice_scoped_clear_regression_kuna() -> None:
     n = update_ged(fd, overlay)
     assert n == 1
     o0, noinline = fd.groups
-    # Covered slice: cleared + rewritten from the overlay.
     assert o0.functions[0].values["kuna"]["ged"] == 0.0
     assert o0.functions[0].perfects["kuna"]["ged"] is True
-    # Uncovered slice of the SAME decompiler: inline value KEPT.
     assert noinline.functions[0].values["kuna"]["ged"] == 5.0
-    # Uncovered decompiler untouched everywhere.
     assert o0.functions[0].values["angr"]["ged"] == 1.0
     assert noinline.functions[0].values["angr"]["ged"] == 2.0
 
@@ -87,7 +84,7 @@ def test_update_ged_sidecar_covers_empty_slice() -> None:
     overlay = {"O0::projA::binA::kuna::f1": {"value": 0.0, "perfect": True}}
     covered = {
         ("O0", "projA", "binA", "kuna"),
-        ("O2-noinline", "projA", "binA", "kuna"),  # evaluated: artifact empty
+        ("O2-noinline", "projA", "binA", "kuna"),
     }
     update_ged(fd, overlay, covered=covered)
     o0, noinline = fd.groups
@@ -107,12 +104,9 @@ def test_update_byte_match_slice_scoped() -> None:
     tally = update_byte_match(fd, overlay)
     o0, noinline = fd.groups
     assert o0.functions[0].values["kuna"]["byte_match"] == 1.0
-    # Same decompiler, uncovered slice: stale value KEPT (per-slice scoping).
     assert noinline.functions[0].values["kuna"]["byte_match"] == 0.4
-    # Uncovered decompiler untouched.
     assert o0.functions[0].values["angr"]["byte_match"] == 0.4
     assert tally["kuna"] == {"comp": 1, "tot": 1}
-    # add_only never drops anything even inside a covered slice.
     fd2 = _fd_two_slices()
     fd2.groups[0].functions[0].values["kuna"]["byte_match"] = 0.4
     update_byte_match(fd2, {"O0::projA::binA::kuna::zzz": {"value": 1.0}}, add_only=True)
@@ -128,7 +122,6 @@ def test_read_ged_overlay_covers_evaluated_empty_slices(tmp_path: Path) -> None:
     (root / "ged_new.json").write_text(
         json.dumps({"O0::projA::binA::angr::f1": {"value": 0.0, "perfect": True}})
     )
-    # reeval cache has an EMPTY checkpoint for a kuna slice that scored nothing.
     (root / "reeval_ged").mkdir()
     (root / "reeval_ged" / "O2-noinline__projA__binA__kuna.json").write_text("{}")
     (root / "reeval_ged" / "O0__projA__binA__angr.json").write_text(
@@ -136,10 +129,9 @@ def test_read_ged_overlay_covers_evaluated_empty_slices(tmp_path: Path) -> None:
     )
     payload, covered = read_ged_overlay(root)
     assert payload is not None
-    assert ("O0", "projA", "binA", "angr") in covered  # from entries + cache
-    assert ("O2-noinline", "projA", "binA", "kuna") in covered  # empty cache slice
+    assert ("O0", "projA", "binA", "angr") in covered
+    assert ("O2-noinline", "projA", "binA", "kuna") in covered
 
-    # That empty-but-evaluated kuna slice must clear its stale inline GED.
     fd = _fd_two_slices()
     update_ged(fd, payload, covered=covered)
     noinline = fd.groups[1]
@@ -150,16 +142,16 @@ def test_merge_typematch_overlay() -> None:
     existing = {"kuna": {"a::O0::b::f": {"value": 0.5}}, "angr": {"a::O0::b::f": {"value": 0.2}}}
     fresh = {"kuna": {"a::O0::b::f": {"value": 0.9}, "a::O0::b::g": {"value": 0.1}}}
     merged = merge_typematch_overlay(existing, fresh)
-    assert merged["kuna"]["a::O0::b::f"] == {"value": 0.9}  # fresh wins
-    assert merged["kuna"]["a::O0::b::g"] == {"value": 0.1}  # fresh added
-    assert merged["angr"]["a::O0::b::f"] == {"value": 0.2}  # untouched dec kept
-    assert existing["kuna"]["a::O0::b::f"] == {"value": 0.5}  # inputs not mutated
+    assert merged["kuna"]["a::O0::b::f"] == {"value": 0.9}
+    assert merged["kuna"]["a::O0::b::g"] == {"value": 0.1}
+    assert merged["angr"]["a::O0::b::f"] == {"value": 0.2}
+    assert existing["kuna"]["a::O0::b::f"] == {"value": 0.5}
 
 
 def test_coverage_guard_catches_column_drop() -> None:
     old = coverage_counts(_fd_two_slices())
     shrunk = _fd_two_slices()
-    shrunk.groups[1].functions[0].values.pop("kuna")  # the kuna wipe, in miniature
+    shrunk.groups[1].functions[0].values.pop("kuna")
     regs = coverage_regressions(old, coverage_counts(shrunk))
     assert any(g == "projA::O2-noinline::binA" and c == "kuna::ged" for g, c, _o, _n in regs)
 
@@ -179,27 +171,22 @@ def test_guard_allows_excluded_project_and_decompiler() -> None:
 
 def test_guarded_write_blocks_and_preserves_old_file(tmp_path: Path) -> None:
     root = tmp_path
-    write_function_data_guarded(_fd_two_slices(), root)  # first write: no old file
+    write_function_data_guarded(_fd_two_slices(), root)
     original = (root / "function_results.json").read_bytes()
 
     shrunk = _fd_two_slices()
     shrunk.groups[1].functions[0].values.pop("kuna")
     with pytest.raises(CoverageRegressionError):
         write_function_data_guarded(shrunk, root)
-    # Failed guard leaves the previous file byte-identical and no temp litter.
     assert (root / "function_results.json").read_bytes() == original
     assert not (root / "function_results.json.tmp").exists()
 
-    # allow_drops writes and rotates the previous file to .prev.
     write_function_data_guarded(shrunk, root, allow_drops=True)
     assert (root / "function_results.prev.json").read_bytes() == original
     reloaded = FunctionData.from_json(root / "function_results.json")
     assert "kuna" not in reloaded.groups[1].functions[0].values
 
 
-# --------------------------------------------------------------------------- #
-# finalize_tree over a miniature results tree.
-# --------------------------------------------------------------------------- #
 def _mini_checkpoint(project: str, dec: str = "angr") -> dict:
     fn = FunctionDecompilation(name="main", address=0x1000, decompiled_code="int main(){}\n")
     dr = DecompilationResult(
@@ -236,11 +223,9 @@ def test_finalize_tree_reads_all_checkpoints(tmp_path: Path) -> None:
     assert (root / "scoreboard.toml").exists()
     assert sb.decompilers == ["angr"]
 
-    # A vanished checkpoint is a coverage regression, not a silent drop...
     (root / "checkpoints" / "beta.pkl").unlink()
     with pytest.raises(CoverageRegressionError):
         finalize_tree(root, log=lambda _msg: None)
-    # ...unless the project is explicitly excluded.
     fd2, _sb2 = finalize_tree(root, exclude_projects=["beta"], log=lambda _msg: None)
     assert sorted(g.project for g in fd2.groups) == ["alpha"]
 
@@ -248,7 +233,6 @@ def test_finalize_tree_reads_all_checkpoints(tmp_path: Path) -> None:
 def test_finalize_preserves_dataset_info_and_history(tmp_path: Path) -> None:
     root = _mini_tree(tmp_path, projects=("alpha",))
     fd, _ = finalize_tree(root, log=lambda _msg: None)
-    # Simulate compute_dataset_info + ingest_history having written their fields.
     fd.dataset_info = {"total_loc": 123}
     fd.history = []
     raw = json.loads((root / "function_results.json").read_text())
@@ -298,7 +282,6 @@ def test_audit_tree_scopes_slice_scoped_decompilers(tmp_path: Path) -> None:
         "evaluate": {},
     }
     (root / "checkpoints" / "alpha.pkl").write_bytes(pickle.dumps(ckpt))
-    # Manifest covers ONLY the O2 slice: mydec's O0 checkpoint data is off-slice.
     (root / "sample_set_manifest.json").write_text(
         json.dumps(
             {
@@ -311,9 +294,9 @@ def test_audit_tree_scopes_slice_scoped_decompilers(tmp_path: Path) -> None:
 
     gaps = audit_tree(root, log=lambda _msg: None)
     flagged = {(g.decompiler, g.opt) for g in gaps}
-    assert ("angr", "O0") in flagged  # unscoped decompiler: audited everywhere
-    assert ("mydec", "O0") not in flagged  # slice_scoped + off-manifest: by design
-    assert ("mydec", "O2") in flagged  # slice_scoped + on-manifest: still audited
+    assert ("angr", "O0") in flagged
+    assert ("mydec", "O0") not in flagged
+    assert ("mydec", "O2") in flagged
 
 
 def test_finalize_tree_strips_excluded_decompilers(tmp_path: Path) -> None:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -30,16 +30,8 @@ from decbench.rendering.content import load_content
 from decbench.rendering.html import render_html_report
 from decbench.rendering.site import build_site
 
-# `hardest` and `history` are deliberately absent: both are still stored in
-# function_results.json but no longer shipped — the View page's `hard` difficulty
-# tier (inside samples.json) replaced the Hardest view, and the Historical view
-# was removed outright.
 DATA_FILES = ["aggregates", "dataset", "samples"]
 
-# One `<view>/index.html` subpage per visible view (all five, given data), so
-# /leaderboard/, /data/, ... are directly linkable. `changelog` is a prose-only
-# view (no per-function data, no generated table). The `data` subpage shares its
-# directory with the data/*.json payloads — deliberate (see docs/site.md).
 VIEW_IDS = ["leaderboard", "data", "view", "about", "changelog"]
 
 
@@ -118,9 +110,6 @@ def function_data() -> FunctionData:
     )
 
 
-# -- the emitted tree ------------------------------------------------------
-
-
 def test_build_site_writes_the_documented_tree(
     tmp_path: Path, scoreboard: Scoreboard, function_data: FunctionData
 ) -> None:
@@ -135,14 +124,12 @@ def test_build_site_writes_the_documented_tree(
         "app.js",
         ".nojekyll",
         "CNAME",
-        # Favicon, apple-touch icon, and the Open Graph / Twitter share card.
         "favicon.png",
         "apple-touch-icon.png",
         "decbench_card.png",
         "fonts/source-code-pro-latin.woff2",
         *(f"data/{name}.json" for name in DATA_FILES),
         *(f"{view}/index.html" for view in VIEW_IDS),
-        # The marker-less redirect stub keeping old /distance/ links alive.
         "distance/index.html",
     }
 
@@ -166,7 +153,6 @@ def test_aggregates_carry_the_registry_and_the_default_view(
 
     assert agg["metric_registry"]["ged"]["short_name"] == "Structure"
     assert agg["default_view"] == "leaderboard"
-    # Every (preset x normalize) combination is precomputed, not recomputed client-side.
     assert set(agg["combos"]) == {
         "unoptimized|0",
         "unoptimized|1",
@@ -186,7 +172,7 @@ def test_preset_text_comes_from_the_content_registry(
     unopt = next(p for p in agg["presets"] if p["name"] == "unoptimized")
     assert unopt["label"] == "unoptimized"
     assert "O0" in unopt["description"]
-    assert "UNOPTIMIZED" in unopt["long_description"]  # the leaderboard explainer
+    assert "UNOPTIMIZED" in unopt["long_description"]
     assert unopt["default"] is True
 
 
@@ -197,9 +183,6 @@ def test_nojekyll_is_present(
     out = tmp_path / "site"
     build_site(scoreboard, function_data, out)
     assert (out / ".nojekyll").exists()
-
-
-# -- idempotency -----------------------------------------------------------
 
 
 def test_rebuild_is_byte_identical(
@@ -230,9 +213,6 @@ def test_rebuild_removes_stale_data_files(
     assert (out / "data" / "aggregates.json").exists()
 
 
-# -- the linkable subpage tree ---------------------------------------------
-
-
 def test_each_visible_view_gets_a_subpage(
     tmp_path: Path, scoreboard: Scoreboard, function_data: FunctionData
 ) -> None:
@@ -260,15 +240,11 @@ def test_legacy_distance_redirect_stub(
     html = stub.read_text()
     assert "../data/" in html
     assert SITE_PAGE_MARKER not in html
-    # Canonicalizes to the new PAGE (not the anchor), and lands on the distance
-    # SECTION: the script honors an incoming #hash but defaults to #distance, and
-    # preserves the ?query a deep link carries (meta refresh drops both).
     domain = load_content().site.pages_domain
     assert f'<link rel="canonical" href="https://{domain}/data/">' in html
     assert '<meta http-equiv="refresh" content="0; url=../data/#distance">' in html
     assert 'location.replace("../data/" + location.search + (location.hash || "#distance"))' in html
 
-    # A rebuild keeps the stub (the prune loop must treat it as a user page).
     build_site(scoreboard, function_data, out)
     assert stub.is_file()
 
@@ -288,7 +264,6 @@ def test_subpage_carries_prefixed_assets_and_opens_on_its_own_view(
 
     assert "<base" not in about
     assert 'window.__DECBENCH_ROOT__ = "../"' in about
-    # Its own section (and nav item) is the active one, not the site default.
     assert '<section class="view active" id="view-about"' in about
     assert '<section class="view active" id="view-leaderboard"' not in about
     assert '<link rel="stylesheet" href="../app.css">' in about
@@ -340,9 +315,6 @@ def test_rebuild_prunes_stale_view_dirs_but_spares_user_dirs(
         assert (out / view / "index.html").is_file()
 
 
-# -- linked vs inlined -----------------------------------------------------
-
-
 def test_index_links_assets_and_does_not_inline_them(
     tmp_path: Path, scoreboard: Scoreboard, function_data: FunctionData
 ) -> None:
@@ -353,10 +325,8 @@ def test_index_links_assets_and_does_not_inline_them(
 
     assert '<link rel="stylesheet" href="app.css">' in index
     assert '<script src="app.js"></script>' in index
-    # No inline payload => app.js fetches data/*.json.
     assert "__DECBENCH_INLINE__" not in index
     assert "<style>" not in index
-    # The stylesheet is a sibling of fonts/, so its relative url() resolves.
     assert "url(fonts/source-code-pro-latin.woff2)" in (out / "app.css").read_text()
 
 
@@ -373,7 +343,6 @@ def test_single_file_report_inlines_everything(
     assert "window.__DECBENCH_INLINE__" in html
     assert '<link rel="stylesheet"' not in html
     assert "<script src=" not in html
-    # The font is embedded, not referenced by a path that would not resolve.
     assert "url(data:font/woff2;base64," in html
     assert "url(fonts/source-code-pro-latin.woff2)" not in html
 
@@ -433,8 +402,6 @@ def test_inline_json_cannot_close_the_script_tag(tmp_path: Path, scoreboard: Sco
     html = path.read_text()
 
     assert "\\u003c/script>" in html
-    # The only literal </script> tags are the ones the renderer itself emits: the
-    # <head> theme bootstrap, the inline data payload, and the client script.
     assert html.count("</script>") == 3
 
 
@@ -450,12 +417,8 @@ def test_report_without_data_ships_no_client(tmp_path: Path, scoreboard: Scorebo
 
     assert "__DECBENCH_INLINE__" not in html
     assert "<script" not in html
-    # Still styled, and still showing real numbers from the scoreboard.
     assert "<style>" in html
     assert "interactive views unavailable" in html.lower()
-
-
-# -- the shared skeleton ---------------------------------------------------
 
 
 def test_both_modes_render_the_same_skeleton(
@@ -499,13 +462,10 @@ def test_theme_bootstrap_and_toggle_ship_in_both_data_modes(
     render_html_report(scoreboard, report, function_data)
     single = report.read_text()
 
-    # Split mode links app.css; the single-file report inlines a <style> block.
     for html, sheet in ((index, '<link rel="stylesheet"'), (single, "<style>")):
         assert "localStorage.getItem('decbench-theme')" in html
         assert "document.documentElement.dataset.theme" in html
-        # The bootstrap must run BEFORE the stylesheet or the default theme flashes.
         assert html.index("decbench-theme") < html.index(sheet)
-        # The sidebar toggle button ships both CSS-driven labels.
         assert 'id="theme-toggle"' in html
         assert "[ light mode ]" in html
         assert "[ dark mode ]" in html
@@ -518,9 +478,6 @@ def test_scoreboard_only_report_has_no_theme_ui(tmp_path: Path, scoreboard: Scor
     render_html_report(scoreboard, path, None)
     html = path.read_text()
 
-    # Functional markers only: the inlined stylesheet's comments mention the
-    # localStorage key in prose, so match the bootstrap's actual code and the
-    # button id instead.
     assert "localStorage.getItem('decbench-theme')" not in html
     assert "document.documentElement.dataset.theme" not in html
     assert 'id="theme-toggle"' not in html
@@ -534,11 +491,8 @@ def test_build_site_writes_the_custom_domain_cname(
     out = tmp_path / "site"
     build_site(scoreboard, function_data, out)
     domain = load_content().site.pages_domain
-    assert domain  # site.toml carries one today
+    assert domain
     assert (out / "CNAME").read_text() == f"{domain}\n"
-
-
-# -- favicon and social share metadata -------------------------------------
 
 
 def _meta_content(html: str, attr: str, value: str) -> str:
@@ -556,7 +510,6 @@ def test_favicon_and_share_card_ship_at_the_tree_root(
     build_site(scoreboard, function_data, out)
     for name in ("favicon.png", "apple-touch-icon.png", "decbench_card.png"):
         assert (out / name).is_file(), name
-    # The share card is the real Open Graph image, not an empty stub.
     assert (out / "decbench_card.png").stat().st_size > 1000
     assert (out / "favicon.png").read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
@@ -595,7 +548,6 @@ def test_root_and_subpage_carry_matching_social_meta(
     assert _meta_content(index, "property", "og:title") == "DecBench — decompiler benchmark"
     assert _meta_content(index, "name", "twitter:card") == "summary_large_image"
     assert _meta_content(index, "property", "og:image") == f"https://{domain}/decbench_card.png"
-    # The description names the #1 decompiler by its display name.
     assert top_name in _meta_content(index, "property", "og:description")
 
     about = (out / "about" / "index.html").read_text()
@@ -634,13 +586,9 @@ def test_social_meta_absent_without_a_pages_domain(
     index = (out / "index.html").read_text()
     assert "og:title" not in index
     assert "twitter:card" not in index
-    # ...but the favicon still ships and is still linked.
     assert (out / "favicon.png").is_file()
     assert '<link rel="icon" type="image/png" href="favicon.png">' in index
     assert not (out / "CNAME").exists()
-
-
-# -- sample-set manifest pinning at build time -----------------------------
 
 
 def test_site_build_pins_sample_set_to_the_manifest(

--- a/tests/test_source_extract.py
+++ b/tests/test_source_extract.py
@@ -38,7 +38,6 @@ class TestExtractFromText:
         assert out is not None
         assert out.startswith("static int helper(int x)")
         assert "return x * 2;" in out
-        # Must stop at the function's closing brace, not run into main.
         assert "int main" not in out
 
     def test_brace_matching_handles_nested_blocks(self) -> None:
@@ -46,13 +45,10 @@ class TestExtractFromText:
         assert out is not None
         assert out.startswith("int main(")
         assert "return total;" in out
-        # Balanced braces.
         assert out.count("{") == out.count("}")
-        # Should not swallow the following function.
         assert "void cleanup" not in out
 
     def test_call_site_not_mistaken_for_definition(self) -> None:
-        # `helper` is called inside main; extraction must return the real def.
         out = extract_from_text(SRC, "helper")
         assert "return x * 2;" in out
 
@@ -66,7 +62,6 @@ class TestExtractFromText:
         assert out.count("{") == out.count("}")
 
     def test_function_pointer_parameter_signature(self) -> None:
-        # The param list contains parens; the naive "first )" would reject this.
         src = "int registerit(void (*cb)(int), int n) {\n" "    return cb ? n : 0;\n" "}\n"
         out = extract_from_text(src, "registerit")
         assert out is not None
@@ -74,8 +69,6 @@ class TestExtractFromText:
         assert "return cb ? n : 0;" in out
 
 
-# Classic K&R definition: bare-identifier param list, a run of parameter
-# declarations, then the body — plus an ANSI prototype ahead of it.
 KNR_SRC = """\
 local void send_all_trees OF((deflate_state *s, int a, int b));
 
@@ -99,37 +92,28 @@ class TestKandR:
         out = extract_from_text(KNR_SRC, "send_all_trees")
         assert out is not None
         assert out.startswith("local void send_all_trees(s, lcodes, dcodes, blcodes)")
-        # The K&R parameter declarations are part of the definition.
         assert "deflate_state *s;" in out
         assert "int lcodes, dcodes, blcodes;" in out
         assert "rank = lcodes + dcodes + blcodes;" in out
         assert out.count("{") == out.count("}")
-        # Must stop at its own closing brace, not run into the next function.
         assert "next_fn" not in out
 
     def test_prototype_only_returns_none(self) -> None:
-        # A file with ONLY a prototype (no body) must not yield a definition.
         src = "void file_compress(char *in, char *out);\nint other(void){return 0;}\n"
         assert extract_from_text(src, "file_compress") is None
 
     def test_bare_param_prototype_not_stitched_to_later_body(self) -> None:
-        # The ';' guard: an empty/bare-param prototype must NOT be joined to an
-        # unrelated later '{' by the K&R scan.
         src = "int foo();\n\nint bar(void) {\n    return 42;\n}\n"
         out = extract_from_text(src, "foo")
         assert out is None
 
     def test_prototype_then_knr_def_picks_def(self) -> None:
-        # Prototype (OF-macro-expanded, typed params) precedes the real K&R def;
-        # extraction must return the definition, not the prototype.
         out = extract_from_text(KNR_SRC, "send_all_trees")
         assert out is not None and "{" in out and "rank" in out
 
 
 class TestFunctionSourceEx:
     def _binary(self, tmp_path: Path) -> Path:
-        # A non-ELF stub: _dwarf_decl fails gracefully, so extraction searches
-        # every sibling source without a DWARF hint.
         binary = tmp_path / "bin"
         binary.write_bytes(b"not-an-elf")
         return binary
@@ -151,8 +135,6 @@ class TestFunctionSourceEx:
 
     def test_status_binary_not_found(self, tmp_path: Path) -> None:
         assert function_source_ex(None, "f") == (None, "binary_not_found")
-        # Only a missing DIRECTORY is a dead end; a missing binary in an existing
-        # dir just loses the DWARF hint (see next test).
         assert function_source_ex(tmp_path / "gone" / "nope", "f") == (None, "binary_not_found")
 
     def test_missing_binary_still_searches_sibling_sources(self, tmp_path: Path) -> None:
@@ -172,7 +154,7 @@ class TestFunctionSourceEx:
 
     def test_status_extract_failed_on_prototype(self, tmp_path: Path) -> None:
         binary = self._binary(tmp_path)
-        (tmp_path / "mod.c").write_text("int f(int x);\n")  # prototype only
+        (tmp_path / "mod.c").write_text("int f(int x);\n")
         assert function_source_ex(binary, "f") == (None, "extract_failed")
 
     def test_function_source_wrapper_returns_code(self, tmp_path: Path) -> None:

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -90,7 +90,7 @@ def _content_hiding(*hidden: str):
 
 def test_is_hidden_matches_id_and_base_name() -> None:
     assert is_hidden("hiddendec", {"hiddendec"})
-    assert is_hidden("hiddendec@9.2", {"hiddendec"})  # base-name match
+    assert is_hidden("hiddendec@9.2", {"hiddendec"})
     assert not is_hidden("ghidra@12.1", {"hiddendec"})
     assert not is_hidden("angr", {"hiddendec"})
 
@@ -110,20 +110,20 @@ def test_hidden_decompiler_stripped_everywhere() -> None:
         assert "hiddendec" not in m and "angr" in m
     s = out_fd.samples[0]
     assert set(s.decompiled) == {"angr", "ghidra"}
-    assert [h.decompiler for h in out_fd.history] == ["ghidra@12.1"]  # base-name hide
+    assert [h.decompiler for h in out_fd.history] == ["ghidra@12.1"]
 
 
 def test_filter_is_a_copy_inputs_untouched() -> None:
     fd, sb = _fd(), _sb()
     apply_hidden_decompilers(sb, fd, _content_hiding("hiddendec"))
-    assert "hiddendec" in fd.decompilers  # original untouched
+    assert "hiddendec" in fd.decompilers
     assert "hiddendec" in sb.decompilers
 
 
 def test_no_hidden_is_a_noop() -> None:
     fd, sb = _fd(), _sb()
     out_sb, out_fd = apply_hidden_decompilers(sb, fd, _content_hiding())
-    assert out_sb is sb and out_fd is fd  # same objects, no copy
+    assert out_sb is sb and out_fd is fd
 
 
 def test_shipped_config_hides_nothing() -> None:
@@ -139,8 +139,6 @@ def test_build_site_omits_hidden_decompiler(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """End-to-end: a hidden decompiler must not appear in any shipped payload."""
-    # build_site consults the shipped content for hiding; point it at a content
-    # that hides the synthetic decompiler (the shipped list is empty).
     monkeypatch.setattr(
         "decbench.rendering.visibility.load_content", lambda: _content_hiding("hiddendec")
     )
@@ -149,8 +147,6 @@ def test_build_site_omits_hidden_decompiler(
     agg = json.loads((out / "data" / "aggregates.json").read_text())
     assert "hiddendec" not in agg["decompilers"]
     assert set(agg["decompilers"]) == {"angr", "ghidra"}
-    # The decompiler registry is gated on the (already-filtered) decompiler list,
-    # so a hidden backend can never re-enter through it.
     assert set(agg["decompiler_registry"]) == {"angr", "ghidra"}
     blob = "".join(
         (out / "data" / f"{name}.json").read_text() for name in ("aggregates", "samples")


### PR DESCRIPTION
Removes code nothing calls, and cuts inline comments down to the policy in `AGENTS.md`: file headers and minimal docstrings, with inline comments reserved for the rare genuinely-confusing or hacky line.

**104 files changed, 647 insertions, 3795 deletions** — a net ~3,150 lines removed.

## Dead code (~360 lines)

Found by an AST scan cross-referencing every definition against the whole repo, filtered for framework-invoked symbols (`@register_decompiler`, click commands, pydantic validators, abstract methods).

- **The entire `discover_functions` plugin API** — 9 implementations across `base`, `declib_dec`, `dockerized`, and the six raw backends. Nothing ever called it; the pipeline derives its function set from DWARF instead.
- `Decompiler.cleanup` (2 impls, never invoked), `DecompilerRegistry.get_all`, `MetricRegistry.get_all`, `cfg_to_dict`, `compute_cfg_stats`, `missing_targets`, `iter_unique`, `_compile_function`, `PerFunctionResults`, `DecompilationResult.get_function`, `FunctionMetrics.get/set_metric`, `FunctionDecompilation.has_gotos`/`goto_count`, `ViewContent.has_empty_state`, `DecompilerConfig.dump_early_metrics`, and the stale `GED_MIN_SOURCE_NODES` (its logic moved into `is_degenerate_source_cfg` some time ago).

Pydantic model **fields** are deliberately left alone — removing them risks breaking the unpickling of existing checkpoints.

## Comments

2694 → 278 lines in Python; 283 → 90 in `app.js`/`app.css`.

What stayed is the small set of real landmines, each compressed to 1–3 lines: the spawn-vs-fork/angr deadlock, `LC_ALL=C` for gcc diagnostics, IDA's `_DWORD` widths that must not fall back to `long`, the do-not-reintroduce-rounding note in `aggregate.py`, the nested-`claude` daemon hang, the neutral-filename fairness rule, `cache_version` bumping, and the malware compile-only guard.

## Docs

- Dropped the removed plugin methods from `docs/decompilers.md`.
- Moved the per-backend timeout rationale out of `run_benchmark.py` into a table in `docs/benchmarking.md`, verified against the code's actual defaults. This is the one place I added rather than deleted: it's operational knowledge with no other home.

`site/app.css` and `site/app.js` are refreshed so the committed deploy tree matches the source assets; the change is comments only.

## Verification

- **387 tests pass**, with the same **5 pre-existing** `test_content.py` failures as on `main` (387 vs 388 because two `has_gotos` tests merged into one).
- **ruff 35 → 33**, diffed against a baseline checkout: **only removals, no new findings**. `black`-dirty file count unchanged at 12 (pre-existing).
- **Render smoke test** — `decbench site build results/full_run` over the full 24 GB tree: every HTML page and data payload is **byte-identical** to the committed site. Only `app.css`/`app.js` differ, and both are verified code-identical modulo comments (whitespace- and comment-stripped compare; `node --check` passes).

## CHANGELOG

Not touched, per `AGENTS.md`. Suggested entry for a maintainer, if you want one:

> - Pruned unused code (the never-called `discover_functions`/`cleanup` plugin methods, unused registry and model helpers) and reduced inline comments across the codebase. No behavioral change — the rendered site is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkLE1KPpSf4sJFu4ekLhta
