### PR TITLE
decompilers: add a manifold backend (whole-binary; CompCert pipeline in reverse)

### DIFF
--- a/decbench/cli.py
+++ b/decbench/cli.py
@@ -1005,7 +1005,7 @@ def download(config, dest, repo_path, include, revision) -> None:
 @main.command("decompiler-build")
 @click.argument("name")
 def decompiler_build(name) -> None:
-    """Build the Docker image for a dockerized decompiler (reko/retdec/r2dec)."""
+    """Build the Docker image for a decompiler (reko/retdec/r2dec/manifold)."""
     from rich.console import Console
 
     import decbench.decompilers  # noqa: F401  (register backends)

--- a/decbench/decompilers/raw/__init__.py
+++ b/decbench/decompilers/raw/__init__.py
@@ -24,6 +24,15 @@ from decbench.decompilers.raw import (
     ghidra_raw,  # noqa: F401
     ida_raw,  # noqa: F401
     kuna_raw,  # noqa: F401
+    manifold_raw,  # noqa: F401
 )
 
-__all__ = ["angr_raw", "ghidra_raw", "ida_raw", "binja_raw", "kuna_raw", "dewolf_raw"]
+__all__ = [
+    "angr_raw",
+    "ghidra_raw",
+    "ida_raw",
+    "binja_raw",
+    "kuna_raw",
+    "dewolf_raw",
+    "manifold_raw",
+]

--- a/decbench/decompilers/raw/manifold_raw.py
+++ b/decbench/decompilers/raw/manifold_raw.py
@@ -71,6 +71,13 @@ _DOCKER_DIR = _REPO_ROOT / "docker"
 # Path inside the image holding the manifold revision it was built from.
 _IMAGE_REV_FILE = "/opt/manifold.rev"
 
+# Upstream manifold, and the revision the image builds. Both mirror the
+# Dockerfile's ARG defaults and are overridable by the matching env vars.
+_DEFAULT_REPO = "https://github.com/changliu98/manifold"
+_DEFAULT_REF = "master"
+
+_SHA = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
 
 def _executable(path: Path) -> Path | None:
     """``path`` if it is a runnable file, else None."""
@@ -124,6 +131,40 @@ def _run_env() -> dict[str, str]:
 
 def _docker_bin() -> str | None:
     return shutil.which("docker")
+
+
+def _resolve_ref(repo: str, ref: str) -> str | None:
+    """``ref`` resolved to a commit SHA against ``repo``, or None if it cannot be.
+
+    This is what keeps a rebuild honest. Docker keys the ``RUN git clone`` layer
+    on the command string, which does not change when the branch moves, so
+    rebuilding against a bare ``master`` reuses the cached clone and silently
+    ships the revision the image already had. Passing the resolved SHA as the
+    build arg changes that layer's key exactly when upstream moved -- and leaves
+    it cached, along with the expensive apt/rust/z3 layers, when it did not.
+    """
+    if _SHA.match(ref):
+        return ref
+    git = shutil.which("git")
+    if not git:
+        _l.warning(
+            "manifold: git not found; cannot resolve %s, rebuild may reuse a stale clone", ref
+        )
+        return None
+    try:
+        proc = subprocess.run(
+            [git, "ls-remote", repo, ref],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except Exception as e:  # noqa: BLE001
+        _l.warning("manifold: could not reach %s to resolve %s: %s", repo, ref, e)
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        _l.warning("manifold: %s does not name a ref in %s", ref, repo)
+        return None
+    return proc.stdout.split()[0]
 
 
 def _image_present(image: str) -> bool:
@@ -429,6 +470,11 @@ class ManifoldDecompiler(Decompiler):
         decompiler-build manifold`` picks this up through its ``build_image``
         hook. The build clones and compiles manifold from source, so it takes
         several minutes.
+
+        ``MANIFOLD_REPO`` / ``MANIFOLD_REF`` select what is built. The ref is
+        resolved to a SHA first, so re-running this after manifold gains commits
+        actually rebuilds instead of reusing the cached clone -- see
+        :func:`_resolve_ref`.
         """
         docker = _docker_bin()
         if not docker:
@@ -437,7 +483,18 @@ class ManifoldDecompiler(Decompiler):
         if not dockerfile_path.is_file():
             raise FileNotFoundError(f"Dockerfile not found: {dockerfile_path}")
         image = os.environ.get("MANIFOLD_IMAGE") or cls.image
+        repo = os.environ.get("MANIFOLD_REPO") or _DEFAULT_REPO
+        ref = os.environ.get("MANIFOLD_REF") or _DEFAULT_REF
+        resolved = _resolve_ref(repo, ref)
+        if resolved is None:
+            # Better a slow honest build than a fast stale one.
+            _l.warning("manifold: building %s with --no-cache (could not resolve %s)", image, ref)
+            no_cache = True
+        else:
+            _l.info("manifold: %s resolves to %s", ref, resolved)
         cmd = [docker, "build", "-f", str(dockerfile_path), "-t", image]
+        cmd += ["--build-arg", f"MANIFOLD_REPO={repo}"]
+        cmd += ["--build-arg", f"MANIFOLD_REF={resolved or ref}"]
         if no_cache:
             cmd.append("--no-cache")
         cmd.append(str(_DOCKER_DIR))

--- a/decbench/decompilers/raw/manifold_raw.py
+++ b/decbench/decompilers/raw/manifold_raw.py
@@ -8,12 +8,25 @@ one process call decompiles the whole binary and writes a single ``.c`` file.
 
 This backend therefore:
 
-* shells out to the ``manifold`` executable once per binary (with a timeout),
+* runs manifold once per binary (with a timeout),
 * splits the emitted translation unit into per-function definitions with a
   brace/string-aware scanner, and
 * recovers each function's address from the ``FUN_<hex>`` names manifold gives
   functions in a stripped binary (falling back to the ELF symbol table when the
   binary still carries symbols).
+
+That single run happens over one of two paths, tried in this order:
+
+* **native** -- a ``manifold`` executable resolved from ``MANIFOLD_BIN``, the
+  decompilers config, or ``$PATH``;
+* **Docker** -- the ``decbench/manifold:latest`` image built from
+  ``docker/manifold.Dockerfile`` by ``decbench decompiler-build manifold``,
+  which compiles manifold (Rust + a pinned Z3) from source so a host needs
+  nothing installed but Docker.
+
+Both paths write the same whole-program ``.c``, so everything downstream of the
+run is shared. Native wins when both exist: it avoids the container round-trip
+and lets a developer benchmark a working tree.
 
 Addresses are reported in **ELF-file space**, matching the other raw backends:
 manifold reads the ELF's own virtual addresses, so its addresses are already in
@@ -50,6 +63,13 @@ from decbench.models.decompilation import (
 _l = logging.getLogger(__name__)
 
 _FUN_NAME = re.compile(r"^FUN_([0-9a-fA-F]+)$")
+
+# manifold_raw.py -> raw -> decompilers -> decbench -> repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DOCKER_DIR = _REPO_ROOT / "docker"
+
+# Path inside the image holding the manifold revision it was built from.
+_IMAGE_REV_FILE = "/opt/manifold.rev"
 
 
 def _executable(path: Path) -> Path | None:
@@ -100,6 +120,32 @@ def _run_env() -> dict[str, str]:
     if threads:
         env["RAYON_NUM_THREADS"] = threads
     return env
+
+
+def _docker_bin() -> str | None:
+    return shutil.which("docker")
+
+
+def _image_present(image: str) -> bool:
+    """True iff ``docker image inspect <image>`` succeeds.
+
+    Never builds: building manifold is a multi-minute side effect, so it stays
+    an explicit ``decbench decompiler-build manifold``, as for the other
+    container-backed backends.
+    """
+    docker = _docker_bin()
+    if not docker or not image:
+        return False
+    try:
+        proc = subprocess.run(
+            [docker, "image", "inspect", image],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+        )
+        return proc.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _strip_comments_and_strings(text: str) -> str:
@@ -338,19 +384,79 @@ def _symbol_addresses(binary_path: Path) -> dict[str, int]:
 
 @register_decompiler("manifold")
 class ManifoldDecompiler(Decompiler):
-    """Manifold driven as a one-shot whole-binary subprocess."""
+    """Manifold driven as a one-shot whole-binary run, natively or in Docker."""
 
     name = "manifold"
     display_name = "Manifold"
 
+    #: Docker image built from :attr:`dockerfile`, used when no native manifold
+    #: executable resolves. ``MANIFOLD_IMAGE`` overrides the tag.
+    image = "decbench/manifold:latest"
+    #: Dockerfile basename under ``docker/`` that builds :attr:`image`.
+    dockerfile = "manifold.Dockerfile"
+
+    #: Memo for :meth:`get_version`. Probing the Docker path costs a container
+    #: spawn, and results ask for the version once per binary.
+    _version_probed: bool = False
+    _version_value: str | None = None
+
+    @property
+    def _image(self) -> str:
+        return os.environ.get("MANIFOLD_IMAGE") or self.image
+
+    def _select_path(self) -> tuple[str, Path | None]:
+        """``("native", exe)``, ``("docker", None)``, or ``("none", None)``.
+
+        Native first: it skips the container round-trip and lets a developer
+        benchmark a working tree without rebuilding an image.
+        """
+        exe = _manifold_bin(self.requested_version)
+        if exe is not None:
+            return "native", exe
+        if _image_present(self._image):
+            return "docker", None
+        return "none", None
+
     def is_available(self) -> bool:
-        return _manifold_bin(self.requested_version) is not None
+        return self._select_path()[0] != "none"
+
+    @classmethod
+    def build_image(cls, no_cache: bool = False) -> int:
+        """Build the manifold image; returns the ``docker build`` exit code.
+
+        Runs ``docker build -f docker/manifold.Dockerfile -t <image> docker/``,
+        the same shape as the container-backed backends, so ``decbench
+        decompiler-build manifold`` picks this up through its ``build_image``
+        hook. The build clones and compiles manifold from source, so it takes
+        several minutes.
+        """
+        docker = _docker_bin()
+        if not docker:
+            raise RuntimeError("docker binary not found on PATH")
+        dockerfile_path = _DOCKER_DIR / cls.dockerfile
+        if not dockerfile_path.is_file():
+            raise FileNotFoundError(f"Dockerfile not found: {dockerfile_path}")
+        image = os.environ.get("MANIFOLD_IMAGE") or cls.image
+        cmd = [docker, "build", "-f", str(dockerfile_path), "-t", image]
+        if no_cache:
+            cmd.append("--no-cache")
+        cmd.append(str(_DOCKER_DIR))
+        _l.info("Building %s: %s", image, " ".join(cmd))
+        return subprocess.run(cmd).returncode
 
     def get_version(self) -> str | None:
+        if not self._version_probed:
+            self._version_value = self._probe_version()
+            self._version_probed = True
+        return self._version_value
+
+    def _probe_version(self) -> str | None:
         env = os.environ.get("MANIFOLD_VERSION")
         if env:
             return env
-        exe = _manifold_bin(self.requested_version)
+        mode, exe = self._select_path()
+        if mode == "docker":
+            return self._docker_version()
         if exe is None:
             return None
         # No --version flag; identify the build by the revision it was built from.
@@ -367,6 +473,60 @@ class ManifoldDecompiler(Decompiler):
         except Exception:  # noqa: BLE001
             pass
         return self.requested_version or "unknown"
+
+    def _docker_version(self) -> str | None:
+        """The revision baked into the image, as the same ``git-<rev>`` string a
+        native run reports. Falls back to the image tag if the file is absent."""
+        docker = _docker_bin()
+        image = self._image
+        if docker:
+            try:
+                proc = subprocess.run(
+                    [docker, "run", "--rm", "--entrypoint", "cat", image, _IMAGE_REV_FILE],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if proc.returncode == 0 and proc.stdout.strip():
+                    return f"git-{proc.stdout.strip()}"
+            except Exception as e:  # noqa: BLE001
+                _l.debug("manifold: could not read %s from %s: %s", _IMAGE_REV_FILE, image, e)
+        return image.rsplit(":", 1)[-1] if ":" in image else "unknown"
+
+    def _run_docker(
+        self,
+        binary_path: Path,
+        work_dir: Path,
+        out_name: str,
+        timeout_s: float,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run manifold in its image: binary read-only at ``/in``, ``work_dir``
+        read-write at ``/work``, output written to ``/work/<out_name>``.
+
+        Same mount layout the retdec/reko/r2dec images use. It is spelled out
+        here rather than reused from ``dockerized.py`` because that module
+        imports this package, so the reverse import would be a cycle.
+        """
+        docker = _docker_bin()
+        if not docker:
+            raise RuntimeError("docker binary not found on PATH")
+        cmd = [
+            docker,
+            "run",
+            "--rm",
+            "-v",
+            f"{binary_path.resolve()}:/in/{binary_path.name}:ro",
+            "-v",
+            f"{work_dir.resolve()}:/work",
+        ]
+        # Cap the container's rayon pool exactly as MANIFOLD_THREADS caps a
+        # native run, so N binaries in parallel do not each grab every core.
+        threads = os.environ.get("MANIFOLD_THREADS")
+        if threads:
+            cmd += ["-e", f"RAYON_NUM_THREADS={threads}"]
+        cmd += [self._image, f"/in/{binary_path.name}", f"/work/{out_name}"]
+        _l.debug("manifold docker run: %s", " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
 
     def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
         result = self.decompile_binary(binary_path)
@@ -387,9 +547,13 @@ class ManifoldDecompiler(Decompiler):
         manifold has no per-function entry point, so the narrowing is applied to
         the emitted functions rather than to the work.
         """
-        exe = _manifold_bin(self.requested_version)
-        if exe is None:
-            raise RuntimeError("Decompiler 'manifold' is not available (set MANIFOLD_BIN)")
+        mode, exe = self._select_path()
+        if mode == "none":
+            raise RuntimeError(
+                "Decompiler 'manifold' is not available (set MANIFOLD_BIN to a "
+                f"manifold executable, or run `decbench decompiler-build {self.name}` "
+                f"to build the {self._image} image)"
+            )
 
         start_time = time.time()
         elf_base = common.elf_min_vaddr(binary_path)
@@ -397,13 +561,19 @@ class ManifoldDecompiler(Decompiler):
         timeout_s = self.config.binary_timeout_seconds
 
         def _meta(failed: list[str], extra: dict[str, Any]) -> DecompilerMetadata:
+            # Stop the clock before probing the version: on the Docker path that
+            # probe is a container spawn, which is not decompilation time.
+            elapsed = time.time() - start_time
+            run_via: dict[str, Any] = {"run_via": mode}
+            if mode == "docker":
+                run_via["image"] = self._image
             return DecompilerMetadata(
                 decompiler_name=self.id,
                 decompiler_version=self.get_version(),
-                total_time_seconds=time.time() - start_time,
+                total_time_seconds=elapsed,
                 timeout_occurred=bool(extra.get("timeout")),
                 failed_functions=failed,
-                extra={"backend": "manifold", "via": "raw", **extra},
+                extra={"backend": "manifold", "via": "raw", **run_via, **extra},
             )
 
         def _error(msg: str, timed_out: bool = False) -> DecompilationResult:
@@ -416,16 +586,20 @@ class ManifoldDecompiler(Decompiler):
             )
 
         with tempfile.TemporaryDirectory(prefix="manifold-dec-") as tmp:
+            # The container writes into this same directory (bind-mounted at
+            # /work), so both paths read the result back from one place.
             out_c = Path(tmp) / f"{binary_path.stem}.c"
-            cmd = [str(exe), str(binary_path), str(out_c)]
             try:
-                proc = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout_s,
-                    env=_run_env(),
-                )
+                if mode == "docker":
+                    proc = self._run_docker(binary_path, Path(tmp), out_c.name, timeout_s)
+                else:
+                    proc = subprocess.run(
+                        [str(exe), str(binary_path), str(out_c)],
+                        capture_output=True,
+                        text=True,
+                        timeout=timeout_s,
+                        env=_run_env(),
+                    )
             except subprocess.TimeoutExpired:
                 return _error(f"timeout after {timeout_s}s", timed_out=True)
             except Exception as e:  # noqa: BLE001

--- a/decbench/decompilers/raw/manifold_raw.py
+++ b/decbench/decompilers/raw/manifold_raw.py
@@ -1,0 +1,494 @@
+"""Manifold decompiler backend.
+
+Manifold (https://github.com/changliu98/manifold) is a whole-binary decompiler that runs
+CompCert's compilation pipeline in reverse: the binary is raised through Mach ->
+Linear -> RTL -> Cminor -> Csharpminor -> Clight and printed as one C
+translation unit. Unlike angr/Ghidra/IDA there is no per-function entry point --
+one process call decompiles the whole binary and writes a single ``.c`` file.
+
+This backend therefore:
+
+* shells out to the ``manifold`` executable once per binary (with a timeout),
+* splits the emitted translation unit into per-function definitions with a
+  brace/string-aware scanner, and
+* recovers each function's address from the ``FUN_<hex>`` names manifold gives
+  functions in a stripped binary (falling back to the ELF symbol table when the
+  binary still carries symbols).
+
+Addresses are reported in **ELF-file space**, matching the other raw backends:
+manifold reads the ELF's own virtual addresses, so its addresses are already in
+that space and need no rebasing.
+
+Variables are deliberately left unset: manifold's C output carries declared
+types but no stack offsets, so ``type_match`` scores it through decbench's
+``parse_c_variables`` text path (arguments by ABI position + locals by name),
+exactly as it does for the code-only LLM backends.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from decbench.decompilers.base import Decompiler
+from decbench.decompilers.raw import common
+from decbench.decompilers.registry import register_decompiler
+from decbench.decompilers.spec import load_versions_config, version_settings
+from decbench.models.decompilation import (
+    DecompilationResult,
+    DecompilerMetadata,
+    FunctionDecompilation,
+)
+
+_l = logging.getLogger(__name__)
+
+_FUN_NAME = re.compile(r"^FUN_([0-9a-fA-F]+)$")
+
+
+def _executable(path: Path) -> Path | None:
+    """``path`` if it is a runnable file, else None."""
+    return path if path.is_file() and os.access(path, os.X_OK) else None
+
+
+def _manifold_bin(version: str | None = None) -> Path | None:
+    """Resolve the manifold executable.
+
+    ``MANIFOLD_BIN`` is an explicit override and wins outright -- a bad value is
+    a misconfiguration to report, not a reason to silently run some other build.
+    Otherwise take ``binary`` from the decompilers config (per-version first,
+    then the tool's default section), then fall back to ``$PATH``::
+
+        [manifold]
+        binary = "/opt/manifold/target/release/manifold"
+        [manifold.versions."0.1"]
+        binary = "/opt/manifold-0.1/target/release/manifold"
+    """
+    env = os.environ.get("MANIFOLD_BIN")
+    if env:
+        return _executable(Path(env))
+    settings = [version_settings("manifold", version)]
+    default = load_versions_config().get("manifold")
+    if isinstance(default, dict):
+        settings.append(default)
+    for source in settings:
+        binary = source.get("binary")
+        if binary:
+            exe = _executable(Path(str(binary)))
+            if exe is not None:
+                return exe
+    which = shutil.which("manifold")
+    return Path(which) if which else None
+
+
+def _run_env() -> dict[str, str]:
+    """Child environment: manifold links libz3 dynamically, so carry the extra
+    library path (``MANIFOLD_LD_LIBRARY_PATH``) into ``LD_LIBRARY_PATH``."""
+    env = dict(os.environ)
+    extra = os.environ.get("MANIFOLD_LD_LIBRARY_PATH")
+    if extra:
+        prev = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = f"{extra}:{prev}" if prev else extra
+    # Manifold's rayon pool defaults to every core; a parallel driver must cap it.
+    threads = os.environ.get("MANIFOLD_THREADS")
+    if threads:
+        env["RAYON_NUM_THREADS"] = threads
+    return env
+
+
+def _strip_comments_and_strings(text: str) -> str:
+    """Blank out string/char literals and comments, preserving offsets.
+
+    The function splitter scans for braces and parens; a ``'{'`` inside a string
+    literal or a comment must not move the depth counter. Replacing those spans
+    with spaces (same length) keeps every offset valid for slicing the original.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            for k in range(i, j):
+                if text[k] != "\n":
+                    out[k] = " "
+            i = j
+        elif c in ("'", '"'):
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                j += 1
+            for k in range(i, min(j, n)):
+                if text[k] != "\n":
+                    out[k] = " "
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _declarator_name(decl: str) -> str | None:
+    """The function name in a declarator like ``long FUN_401136(void *p0, int n)``.
+
+    The parameter list is the paren group that closes at the end of ``decl``;
+    the name is the identifier immediately before it.
+    """
+    decl = decl.strip()
+    if not decl.endswith(")"):
+        return None
+    depth = 0
+    open_i = None
+    for i in range(len(decl) - 1, -1, -1):
+        c = decl[i]
+        if c == ")":
+            depth += 1
+        elif c == "(":
+            depth -= 1
+            if depth == 0:
+                open_i = i
+                break
+    if open_i is None:
+        return None
+    m = re.search(r"([A-Za-z_]\w*)\s*$", decl[:open_i])
+    return m.group(1) if m else None
+
+
+_IDENT = re.compile(r"[A-Za-z_]\w*")
+
+
+class _Entity:
+    """One top-level item of a manifold translation unit."""
+
+    __slots__ = ("text", "defines", "refs", "is_function", "always")
+
+    def __init__(self, text: str, defines: set[str], refs: set[str], is_function: bool):
+        self.text = text
+        self.defines = defines
+        self.refs = refs
+        self.is_function = is_function
+        self.always = text.lstrip().startswith("#")
+
+
+def parse_translation_unit(text: str) -> list[_Entity]:
+    """Split a manifold translation unit into its top-level entities, in order.
+
+    Walks top-level brace groups with a comment/string-aware scanner: the text
+    since the last top-level ``;``/``}`` is the declarator, and a braced group
+    whose declarator ends in a parameter list is a function definition (struct /
+    union / enum definitions and prototypes end at a ``;`` instead).
+    Preprocessor lines are their own entities.
+    """
+    scan = _strip_comments_and_strings(text)
+    entities: list[_Entity] = []
+    depth = 0
+    decl_start = 0
+    body_start = -1
+    i, n = 0, len(scan)
+
+    def emit(start: int, end: int, is_function: bool) -> None:
+        chunk = text[start:end].strip()
+        if not chunk:
+            return
+        idents = set(_IDENT.findall(_strip_comments_and_strings(chunk)))
+        name = _declarator_name(text[start:body_start]) if is_function else None
+        defines = {name} if name else _declared_names(chunk)
+        entities.append(_Entity(chunk, defines, idents - defines, is_function))
+
+    while i < n:
+        c = scan[i]
+        if depth == 0 and c == "#" and (i == 0 or scan[i - 1] == "\n"):
+            j = scan.find("\n", i)
+            j = n if j == -1 else j
+            emit(decl_start, i, False)
+            entities.append(_Entity(text[i:j].strip(), set(), set(), False))
+            decl_start = j
+            i = j
+            continue
+        if c == "{":
+            if depth == 0:
+                body_start = i
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                # A struct/union/enum definition continues to its ``;``.
+                j = i + 1
+                while j < n and scan[j] in " \t\r\n":
+                    j += 1
+                end = j + 1 if j < n and scan[j] == ";" else i + 1
+                emit(decl_start, end, _declarator_name(text[decl_start:body_start]) is not None)
+                decl_start = end
+                body_start = -1
+                i = end
+                continue
+        elif c == ";" and depth == 0:
+            emit(decl_start, i + 1, False)
+            decl_start = i + 1
+        i += 1
+    return entities
+
+
+def _declared_names(chunk: str) -> set[str]:
+    """Names a non-function top-level declaration introduces.
+
+    Covers manifold's preamble forms: ``struct struct_1 { … };`` (the tag),
+    ``long L_1f27b;`` / ``char L_2b031 = -1;`` / ``int L_205e0[1];`` (the
+    variable), and ``extern unsigned char __TMC_END__;``.
+    """
+    body = _strip_comments_and_strings(chunk)
+    m = re.match(r"\s*(?:typedef\s+)?(?:struct|union|enum)\s+([A-Za-z_]\w*)", body)
+    if m:
+        return {m.group(1)}
+    head = re.split(r"[=;]", body, maxsplit=1)[0]
+    head = re.sub(r"\[[^\]]*\]", "", head)
+    m = re.search(r"([A-Za-z_]\w*)\s*$", head.strip())
+    return {m.group(1)} if m else set()
+
+
+def _with_preamble(func: _Entity, entities: list[_Entity]) -> str:
+    """The function definition preceded by the file-scope items it references.
+
+    Manifold prints one translation unit, but DecBench stores and recompiles one
+    function at a time, so each function's stored code must carry the struct
+    definitions and globals its body mentions -- transitively, since a struct's
+    fields can name other structs. This mirrors the other backends' artifacts
+    (angr's per-function code likewise repeats the typedefs and ``extern``
+    globals the body uses).
+    """
+    by_name: dict[str, _Entity] = {}
+    for e in entities:
+        if e.is_function or e.always:
+            continue
+        for nm in e.defines:
+            by_name.setdefault(nm, e)
+
+    needed: set[int] = set()
+    worklist = list(func.refs)
+    seen: set[str] = set()
+    while worklist:
+        nm = worklist.pop()
+        if nm in seen:
+            continue
+        seen.add(nm)
+        ent = by_name.get(nm)
+        if ent is None or id(ent) in needed:
+            continue
+        needed.add(id(ent))
+        worklist.extend(ent.refs - seen)
+
+    parts = [e.text for e in entities if e.always or id(e) in needed]
+    parts.append(func.text)
+    return "\n\n".join(parts)
+
+
+def split_functions(text: str) -> list[tuple[str, str]]:
+    """``(name, code)`` per function, each carrying the preamble it references."""
+    entities = parse_translation_unit(text)
+    out: list[tuple[str, str]] = []
+    for e in entities:
+        if not e.is_function:
+            continue
+        name = next(iter(e.defines), None)
+        if name:
+            out.append((name, _with_preamble(e, entities)))
+    return out
+
+
+def _symbol_addresses(binary_path: Path) -> dict[str, int]:
+    """``name -> st_value`` for STT_FUNC symbols (unstripped binaries only)."""
+    out: dict[str, int] = {}
+    try:
+        from elftools.elf.elffile import ELFFile
+        from elftools.elf.sections import SymbolTableSection
+
+        with open(binary_path, "rb") as f:
+            elf = ELFFile(f)
+            for sec in elf.iter_sections():
+                if not isinstance(sec, SymbolTableSection):
+                    continue
+                for sym in sec.iter_symbols():
+                    if sym["st_info"]["type"] != "STT_FUNC":
+                        continue
+                    if not sym.name or not sym["st_value"]:
+                        continue
+                    out.setdefault(sym.name, int(sym["st_value"]))
+    except Exception as e:  # noqa: BLE001
+        _l.debug("manifold: no symbol table for %s: %s", binary_path, e)
+    return out
+
+
+@register_decompiler("manifold")
+class ManifoldDecompiler(Decompiler):
+    """Manifold driven as a one-shot whole-binary subprocess."""
+
+    name = "manifold"
+    display_name = "Manifold"
+
+    def is_available(self) -> bool:
+        return _manifold_bin(self.requested_version) is not None
+
+    def get_version(self) -> str | None:
+        env = os.environ.get("MANIFOLD_VERSION")
+        if env:
+            return env
+        exe = _manifold_bin(self.requested_version)
+        if exe is None:
+            return None
+        # No --version flag; identify the build by the revision it was built from.
+        repo = exe.resolve().parents[2]
+        try:
+            rev = subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if rev.returncode == 0 and rev.stdout.strip():
+                return f"git-{rev.stdout.strip()}"
+        except Exception:  # noqa: BLE001
+            pass
+        return self.requested_version or "unknown"
+
+    def discover_functions(self, binary_path: Path) -> list[tuple[str, int]]:
+        result = self.decompile_binary(binary_path)
+        return [(fd.name, fd.address) for fd in result.functions.values()]
+
+    def decompile_binary(
+        self,
+        binary_path: Path,
+        functions: list[tuple[str, int]] | None = None,
+        output_dir: Path | None = None,
+        function_names: set[str] | None = None,
+        progress_path: Path | None = None,
+    ) -> DecompilationResult:
+        """Decompile a whole binary in one manifold invocation.
+
+        ``function_names`` carries the DWARF target *addresses* (the same
+        contract as the other raw backends, see ``common.narrow_to_source``);
+        manifold has no per-function entry point, so the narrowing is applied to
+        the emitted functions rather than to the work.
+        """
+        exe = _manifold_bin(self.requested_version)
+        if exe is None:
+            raise RuntimeError("Decompiler 'manifold' is not available (set MANIFOLD_BIN)")
+
+        start_time = time.time()
+        elf_base = common.elf_min_vaddr(binary_path)
+        text_range = common.elf_text_range(binary_path)
+        timeout_s = self.config.binary_timeout_seconds
+
+        def _meta(failed: list[str], extra: dict[str, Any]) -> DecompilerMetadata:
+            return DecompilerMetadata(
+                decompiler_name=self.id,
+                decompiler_version=self.get_version(),
+                total_time_seconds=time.time() - start_time,
+                timeout_occurred=bool(extra.get("timeout")),
+                failed_functions=failed,
+                extra={"backend": "manifold", "via": "raw", **extra},
+            )
+
+        def _error(msg: str, timed_out: bool = False) -> DecompilationResult:
+            _l.error("manifold failed on %s: %s", binary_path, msg)
+            return DecompilationResult(
+                binary_path=binary_path,
+                binary_name=binary_path.stem,
+                decompiler=_meta(["all"], {"error": msg, "timeout": timed_out}),
+                output_dir=output_dir,
+            )
+
+        with tempfile.TemporaryDirectory(prefix="manifold-dec-") as tmp:
+            out_c = Path(tmp) / f"{binary_path.stem}.c"
+            cmd = [str(exe), str(binary_path), str(out_c)]
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_s,
+                    env=_run_env(),
+                )
+            except subprocess.TimeoutExpired:
+                return _error(f"timeout after {timeout_s}s", timed_out=True)
+            except Exception as e:  # noqa: BLE001
+                return _error(f"spawn failed: {e}")
+
+            if not out_c.is_file():
+                tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-5:]
+                return _error(f"no output (exit {proc.returncode}): {' | '.join(tail)}")
+            text = out_c.read_text(errors="replace")
+
+        decompiled_functions: dict[str, FunctionDecompilation] = {}
+        unaddressed: list[str] = []
+        symbols: dict[str, int] | None = None
+
+        for name, code in split_functions(text):
+            m = _FUN_NAME.match(name)
+            if m:
+                file_addr = int(m.group(1), 16)
+            else:
+                # Symbol-named function: the binary was not stripped.
+                if symbols is None:
+                    symbols = _symbol_addresses(binary_path)
+                addr = symbols.get(name)
+                if addr is None:
+                    unaddressed.append(name)
+                    continue
+                file_addr = addr
+            if common.should_skip_function(name, file_addr, text_range):
+                continue
+            decompiled_functions[name] = FunctionDecompilation(
+                name=name,
+                address=file_addr,
+                decompiled_code=code,
+                line_count=len(code.splitlines()),
+                metadata=common.extract_metrics(code),
+            )
+
+        kept = common.narrow_to_source(
+            [(n, fd.address) for n, fd in decompiled_functions.items()],
+            function_names,
+            backend="manifold",
+            binary_name=binary_path.name,
+        )
+        keep_names = {n for n, _ in kept}
+        decompiled_functions = {n: fd for n, fd in decompiled_functions.items() if n in keep_names}
+
+        result = DecompilationResult(
+            binary_path=binary_path,
+            binary_name=binary_path.stem,
+            decompiler=_meta(
+                unaddressed,
+                {"elf_base": elf_base, "translation_unit_lines": len(text.splitlines())},
+            ),
+            functions=decompiled_functions,
+            combined_source=text,
+            output_dir=output_dir,
+        )
+
+        common.dump_progress(progress_path, result)
+
+        if output_dir:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            result.to_c_file(output_dir / f"{self.name}_{binary_path.stem}.c")
+            result.to_toml(output_dir / f"{self.name}_{binary_path.stem}.toml")
+
+        return result

--- a/decbench/rendering/content/decompilers.toml
+++ b/decbench/rendering/content/decompilers.toml
@@ -73,6 +73,13 @@ license = "open-source"
 logo = true
 
 [[decompiler]]
+id = "manifold"
+display_name = "Manifold"
+url = "https://github.com/changliu98/manifold"
+license = "open-source"
+logo = true
+
+[[decompiler]]
 id = "codex"
 display_name = "Codex"
 url = "https://openai.com/codex/"

--- a/decbench/rendering/content/site.toml
+++ b/decbench/rendering/content/site.toml
@@ -49,7 +49,9 @@ hidden = []
 # only where the comparison is fair (all decompilers cover the same 250
 # functions). Their data still ships in the payload; it is just not rendered
 # outside the sample-set preset. Base-name match, same as `hidden`.
-sample_set_only = ["codex", "claude-code", "kimi-code"]
+# manifold is here for the same reason: its published v1 numbers came from an
+# external sample-set submission. Drop it once a full-corpus run covers it.
+sample_set_only = ["codex", "claude-code", "kimi-code", "manifold"]
 
 # GitHub Pages custom domain. `decbench site build` writes it into the tree's
 # CNAME file; the authoritative routing for workflow deploys is the repo's Pages

--- a/docker/manifold.Dockerfile
+++ b/docker/manifold.Dockerfile
@@ -1,8 +1,18 @@
 # Manifold decompiler image for decbench.
 #
-# Build (from repo root or docker/):
+# Build:
+#   decbench decompiler-build manifold
+#
+# Prefer that over a bare `docker build`. Docker keys the `git clone` layer on
+# the command string, which does not change when the branch moves -- so
+#
 #   docker build -f docker/manifold.Dockerfile -t decbench/manifold:latest docker/
-#   # or simply:  decbench decompiler-build manifold
+#
+# re-run after manifold gains commits reuses the cached clone and silently
+# rebuilds the SAME revision, in about a second. `decompiler-build` resolves
+# MANIFOLD_REF to a SHA and passes it as the build arg, so the clone layer is
+# invalidated exactly when upstream moved and stays cached when it did not. By
+# hand, pass the SHA yourself (`--build-arg MANIFOLD_REF=<sha>`) or --no-cache.
 #
 # Run (decbench's ManifoldDecompiler._run_docker does this):
 #   docker run --rm \

--- a/docker/manifold.Dockerfile
+++ b/docker/manifold.Dockerfile
@@ -1,0 +1,174 @@
+# Manifold decompiler image for decbench.
+#
+# Build (from repo root or docker/):
+#   docker build -f docker/manifold.Dockerfile -t decbench/manifold:latest docker/
+#   # or simply:  decbench decompiler-build manifold
+#
+# Run (decbench's ManifoldDecompiler._run_docker does this):
+#   docker run --rm \
+#     -v /path/to/bin:/in/bin:ro -v /tmp/out:/work \
+#     decbench/manifold:latest /in/bin /work/out.c
+#
+# Manifold is whole-binary: one invocation raises the entire program and writes
+# it as a single C translation unit, which decbench then splits per function.
+# There is no per-function entry point, so there is no targets file (unlike
+# r2dec) and `binary_timeout_seconds` is the budget that matters.
+#
+# Selection order (ManifoldDecompiler._select_path): a NATIVE manifold from
+# MANIFOLD_BIN / decompilers.toml / $PATH first, then this image. Native wins so
+# a developer can benchmark a working tree without rebuilding; on a host that
+# only has Docker, this image is the entire install. MANIFOLD_THREADS reaches
+# the container as RAYON_NUM_THREADS, so a parallel driver can stop N containers
+# from each grabbing every core.
+#
+# An image is built from ONE manifold revision, so `manifold@<version>`
+# per-version settings apply to the native path only -- a second revision means a
+# second image tag, which MANIFOLD_IMAGE selects.
+#
+# Manifold is a Rust crate built from source. Three build inputs are not obvious:
+#
+#   * Submodule -- manifold vendors an Ascent fork (ascent-plusplus), so the
+#     submodules must be initialized or the crate will not resolve its path deps.
+#   * Z3 -- the `z3` crate locates libz3 through pkg-config, and Ubuntu's
+#     packaged 4.8 is too old for the bindings in z3-sys 0.11, so a pinned
+#     upstream Z3 release is unpacked to /opt/z3 with a hand-written z3.pc.
+#     libz3 is linked dynamically, so the runtime stage carries it too; that is
+#     the same z3 the published v1 numbers were produced against. Bump
+#     Z3_VERSION and Z3_DIST together -- the latter names the glibc the release
+#     was built for, which has to match the base image.
+#   * Linker -- manifold's own .cargo/config.toml is machine-local and
+#     git-ignored, so it is absent from a fresh clone. mold is installed and
+#     selected here instead, because linking a ~200 MB binary with bfd is slow.
+#
+# Rebuilding picks up manifold's latest; pass MANIFOLD_REF to build one specific
+# revision instead. Either way, retag if you want to keep the old image around.
+
+# ---- build stage: compile manifold with the Rust toolchain -----------------
+FROM ubuntu:24.04 AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+        build-essential \
+        pkg-config \
+        clang \
+        libclang-dev \
+        mold \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned upstream Z3. The release zip ships bin/libz3.so + include/ but no
+# pkg-config file, and z3-sys only emits its link flags when pkg-config finds
+# z3, so write the .pc by hand. The glibc-2.39 asset matches ubuntu:24.04.
+ARG Z3_VERSION=4.15.4
+ARG Z3_DIST=z3-4.15.4-x64-glibc-2.39
+RUN curl -fsSL -o /tmp/z3.zip \
+        "https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/${Z3_DIST}.zip" \
+    && unzip -q /tmp/z3.zip -d /tmp \
+    && mkdir -p /opt/z3/lib/pkgconfig \
+    && mv "/tmp/${Z3_DIST}/include" /opt/z3/include \
+    && mv "/tmp/${Z3_DIST}/bin/libz3.so" /opt/z3/lib/libz3.so \
+    && rm -rf /tmp/z3.zip "/tmp/${Z3_DIST}" \
+    && printf '%s\n' \
+        'prefix=/opt/z3' \
+        'libdir=${prefix}/lib' \
+        'includedir=${prefix}/include' \
+        '' \
+        'Name: z3' \
+        'Description: Z3 SMT solver' \
+        "Version: ${Z3_VERSION}" \
+        'Libs: -L${libdir} -lz3' \
+        'Cflags: -I${includedir}' \
+        > /opt/z3/lib/pkgconfig/z3.pc \
+    && PKG_CONFIG_PATH=/opt/z3/lib/pkgconfig pkg-config --modversion z3
+
+ENV PKG_CONFIG_PATH=/opt/z3/lib/pkgconfig
+ENV LD_LIBRARY_PATH=/opt/z3/lib
+
+# Pinned Rust toolchain. z3-sys 0.11 is edition 2024, so 1.85 is the floor.
+ARG RUST_VERSION=1.95.0
+ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:${PATH}
+RUN curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --no-modify-path --profile minimal --default-toolchain "${RUST_VERSION}" \
+    && rustc --version
+
+# Link with mold. manifold's own linker config is git-ignored and so is not in
+# the clone; put the equivalent in CARGO_HOME, which a repo config would win
+# over if the situation ever changes.
+RUN printf '%s\n' \
+        '[target.x86_64-unknown-linux-gnu]' \
+        'rustflags = ["-C", "link-arg=-fuse-ld=mold"]' \
+        > "${CARGO_HOME}/config.toml"
+
+ARG MANIFOLD_REPO=https://github.com/changliu98/manifold
+# The branch tip, so a rebuild picks up manifold's latest. Pass a SHA or tag as
+# MANIFOLD_REF to freeze a run against one revision; either way the image
+# records what it built at /opt/manifold.rev and get_version() reports it, so a
+# result always names the exact revision it was scored under.
+ARG MANIFOLD_REF=master
+# A full clone, not --depth=1, so MANIFOLD_REF can be any revision and not just
+# the branch tip. Submodules are initialized by the paths .gitmodules actually
+# maps: manifold's tree also carries a gitlink with no .gitmodules entry, and a
+# bare `submodule update --init --recursive` aborts on it ("No url found for
+# submodule path"), which would make the image build depend on that hygiene.
+RUN git clone "${MANIFOLD_REPO}" /src/manifold \
+    && cd /src/manifold \
+    && git checkout --detach "${MANIFOLD_REF}" \
+    && git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
+        | awk '{print $2}' \
+        | xargs -r git submodule update --init --recursive -- \
+    && test -f ascent-plusplus/ascent/Cargo.toml \
+    && git rev-parse --short HEAD > /src/manifold.rev
+
+# Manifold's own [profile.release] is tuned for BUILD speed, not run speed:
+# opt-level 0, lto "none", 256 codegen units. That is the right default for a
+# working tree you rebuild all day. An image is the opposite case -- built once,
+# then run over an entire corpus -- so trade build time for decompile time.
+#
+# These go through cargo's environment interface rather than a patch, so the
+# manifold checkout stays exactly as published and a `manifold` built here is
+# the same program, only compiled harder.
+#
+# Deliberately NOT set: `-C target-cpu=native`. It would bake this builder's ISA
+# into the image and SIGILL on any older host that pulls it.
+ARG CARGO_PROFILE_RELEASE_OPT_LEVEL=3
+ARG CARGO_PROFILE_RELEASE_LTO=thin
+ARG CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+ENV CARGO_PROFILE_RELEASE_OPT_LEVEL=${CARGO_PROFILE_RELEASE_OPT_LEVEL} \
+    CARGO_PROFILE_RELEASE_LTO=${CARGO_PROFILE_RELEASE_LTO} \
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS}
+
+WORKDIR /src/manifold
+RUN cargo build --release \
+    && strip --strip-unneeded target/release/manifold \
+    && cp target/release/manifold /usr/local/bin/manifold
+
+# ---- runtime stage --------------------------------------------------------
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# libz3.so needs only libstdc++/libgcc/libm/libc; name libstdc++ explicitly
+# rather than lean on it happening to be in the base image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /opt/z3/lib/libz3.so /usr/local/lib/libz3.so
+COPY --from=build /usr/local/bin/manifold /usr/local/bin/manifold
+# The revision the image was built from; ManifoldDecompiler.get_version() reads
+# it back, so a dockerized run reports the same `git-<rev>` a native one does.
+COPY --from=build /src/manifold.rev /opt/manifold.rev
+# manifold with no arguments prints its usage to stderr and exits 1, so this
+# asserts the dynamic loader resolved libz3 (a loader error prints instead).
+RUN ldconfig && manifold 2>&1 | grep -q "Usage: manifold"
+
+WORKDIR /work
+
+# Args: <input binary> <output .c path>
+ENTRYPOINT ["manifold"]

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -23,6 +23,9 @@ Backends subclass the `Decompiler` ABC (`base.py`) and register via
   CRT/PLT/thunk skip sets, `narrow_to_source` function filter, atomic
   `dump_progress` checkpoint, line-mapping helpers). This is the path
   benchmark runs use now.
+- **Whole-binary** (`raw/manifold_raw.py`: `manifold`): a tool with no
+  per-function entry point — one subprocess call per binary emits one C
+  translation unit, which the backend splits into per-function definitions.
 - **declib** (`declib_dec.py`, registered as `angr-declib`/`ghidra-declib`/…):
   the original declib-driven backends, kept for comparison.
 - **Dockerized** (`dockerized.py`: `reko`/`retdec`/`r2dec`): run a tool in a

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -24,8 +24,12 @@ Backends subclass the `Decompiler` ABC (`base.py`) and register via
   `dump_progress` checkpoint, line-mapping helpers). This is the path
   benchmark runs use now.
 - **Whole-binary** (`raw/manifold_raw.py`: `manifold`): a tool with no
-  per-function entry point — one subprocess call per binary emits one C
-  translation unit, which the backend splits into per-function definitions.
+  per-function entry point — one call per binary emits one C translation unit,
+  which the backend splits into per-function definitions. It runs manifold
+  natively if an executable resolves (`MANIFOLD_BIN` / config / `$PATH`),
+  otherwise in the `decbench/manifold` image (`docker/manifold.Dockerfile`,
+  built by `decbench decompiler-build manifold`), so a host that only has
+  Docker needs nothing else installed.
 - **declib** (`declib_dec.py`, registered as `angr-declib`/`ghidra-declib`/…):
   the original declib-driven backends, kept for comparison.
 - **Dockerized** (`dockerized.py`: `reko`/`retdec`/`r2dec`): run a tool in a

--- a/tests/test_manifold_backend.py
+++ b/tests/test_manifold_backend.py
@@ -1,0 +1,216 @@
+"""Unit tests for the manifold backend's binary resolution + TU splitting.
+
+The real decompilation shells out to the ``manifold`` executable (a Rust
+binary), so these tests exercise the parts that do NOT need it installed:
+executable resolution, availability gating, splitting one whole-program
+translation unit into per-function definitions, and the address mapping --
+the last through a fake ``manifold`` that emits a canned translation unit.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import decbench.decompilers  # noqa: F401  (registers the raw backends)
+from decbench.decompilers.raw.manifold_raw import (
+    ManifoldDecompiler,
+    parse_translation_unit,
+    split_functions,
+)
+from decbench.decompilers.registry import DecompilerRegistry
+
+TINY_C_SOURCE = """
+int add_nums(int a, int b) {
+    return a + b;
+}
+
+int main(void) {
+    return add_nums(1, 2);
+}
+"""
+
+# A translation unit in manifold's own shape: preprocessor lines, a struct, file
+# scope globals, prototypes, then Allman-braced definitions.
+SAMPLE_TU = """#include <stdint.h>
+
+struct struct_1 {
+    long f_0;
+    struct struct_2 *f_8;
+};
+
+struct struct_2 {
+    int f_0;
+};
+
+long L_1f27b;
+extern unsigned char __TMC_END__;
+
+long FUN_401136(void *p0, long p1);
+int FUN_4011a0(struct struct_1 *p0);
+
+long FUN_401136(void *p0, long p1)
+{
+    /* a comment with an unbalanced brace { */
+    char *var_0 = "a string with } and { braces";
+    return p1;
+}
+
+int FUN_4011a0(struct struct_1 *p0)
+{
+    return (int)(p0->f_0 + L_1f27b);
+}
+"""
+
+
+def test_manifold_is_registered() -> None:
+    dec = DecompilerRegistry.get("manifold")
+    assert isinstance(dec, ManifoldDecompiler)
+    assert dec.id == "manifold"
+    assert dec.display_name == "Manifold"
+    # is_available must never raise, whether or not the tool is installed.
+    assert isinstance(dec.is_available(), bool)
+
+
+def test_unavailable_without_binary(monkeypatch) -> None:
+    monkeypatch.setenv("MANIFOLD_BIN", "/nonexistent/manifold")
+    assert ManifoldDecompiler().is_available() is False
+
+
+def test_env_override_wins(monkeypatch, tmp_path: Path) -> None:
+    exe = tmp_path / "manifold"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(0o755)
+    monkeypatch.setenv("MANIFOLD_BIN", str(exe))
+    assert ManifoldDecompiler().is_available() is True
+
+
+def test_split_functions_finds_definitions_not_prototypes() -> None:
+    funcs = dict(split_functions(SAMPLE_TU))
+    assert sorted(funcs) == ["FUN_401136", "FUN_4011a0"]
+
+
+def test_split_functions_ignores_braces_in_strings_and_comments() -> None:
+    funcs = dict(split_functions(SAMPLE_TU))
+    body = funcs["FUN_401136"]
+    # The definition must be complete: a brace inside the string literal or the
+    # comment must not have closed the body early.
+    assert body.rstrip().endswith("}")
+    assert "return p1;" in body
+
+
+def test_each_function_carries_the_file_scope_it_references() -> None:
+    funcs = dict(split_functions(SAMPLE_TU))
+    # FUN_4011a0 dereferences struct_1 and reads L_1f27b, so both must ride along
+    # -- and struct_1 names struct_2, so the preamble is transitive.
+    a0 = funcs["FUN_4011a0"]
+    assert "struct struct_1 {" in a0
+    assert "struct struct_2 {" in a0
+    assert "long L_1f27b;" in a0
+    # ... but not the unrelated global.
+    assert "__TMC_END__" not in a0
+    # Preprocessor lines ride along with every function.
+    assert "#include <stdint.h>" in a0
+
+
+def test_parse_translation_unit_classifies_entities() -> None:
+    entities = parse_translation_unit(SAMPLE_TU)
+    functions = [e for e in entities if e.is_function]
+    assert len(functions) == 2
+    # struct definitions and prototypes are not functions
+    assert any("struct struct_1" in e.text and not e.is_function for e in entities)
+
+
+@pytest.fixture(scope="module")
+def tiny_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    cc = shutil.which("cc") or shutil.which("gcc")
+    if cc is None:
+        pytest.skip("no C compiler available")
+    build_dir = tmp_path_factory.mktemp("manifold_bin")
+    src = build_dir / "tiny.c"
+    src.write_text(TINY_C_SOURCE)
+    binary = build_dir / "tiny"
+    subprocess.run([cc, "-g", "-O0", "-fno-inline", "-o", str(binary), str(src)], check=True)
+    return binary
+
+
+def _func_address(binary: Path, name: str) -> int:
+    """The ELF-file-space entry address of ``name`` from the symbol table."""
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+
+    with open(binary, "rb") as f:
+        for sec in ELFFile(f).iter_sections():
+            if isinstance(sec, SymbolTableSection):
+                for sym in sec.iter_symbols():
+                    if sym.name == name and sym["st_value"]:
+                        return int(sym["st_value"])
+    raise AssertionError(f"no symbol {name} in {binary}")
+
+
+def test_decompile_binary_maps_fun_names_to_addresses(
+    monkeypatch, tiny_binary: Path, tmp_path: Path
+) -> None:
+    """A fake manifold emits a TU; the backend must key it by ELF-space address."""
+    # Use the fixture's own function addresses so the .text-range filter (which
+    # correctly drops anything outside .text) sees real targets.
+    add_nums = _func_address(tiny_binary, "add_nums")
+    main = _func_address(tiny_binary, "main")
+    tu = SAMPLE_TU.replace("FUN_401136", f"FUN_{add_nums:x}").replace("FUN_4011a0", f"FUN_{main:x}")
+
+    fake = tmp_path / "manifold"
+    out_tu = tmp_path / "tu.c"
+    out_tu.write_text(tu)
+    # manifold's CLI is `manifold <input> <output.c>`; copy the canned TU there.
+    fake.write_text(f'#!/bin/sh\ncat "{out_tu}" > "$2"\n')
+    fake.chmod(0o755)
+    monkeypatch.setenv("MANIFOLD_BIN", str(fake))
+
+    dec = ManifoldDecompiler()
+    result = dec.decompile_binary(tiny_binary, output_dir=tmp_path)
+
+    assert result.decompiler.decompiler_name == "manifold"
+    assert sorted(result.functions) == sorted([f"FUN_{add_nums:x}", f"FUN_{main:x}"])
+    # FUN_<hex> is manifold's name for the function entering at that vaddr, and
+    # manifold reports the ELF's own addresses -- so no rebasing is applied.
+    assert result.functions[f"FUN_{add_nums:x}"].address == add_nums
+    assert result.functions[f"FUN_{main:x}"].address == main
+    assert result.functions[f"FUN_{add_nums:x}"].decompiled_code.strip()
+    assert (tmp_path / f"manifold_{tiny_binary.stem}.c").exists()
+
+
+def test_decompile_binary_narrows_to_requested_addresses(
+    monkeypatch, tiny_binary: Path, tmp_path: Path
+) -> None:
+    """``function_names`` carries target ADDRESSES; only those survive."""
+    add_nums = _func_address(tiny_binary, "add_nums")
+    main = _func_address(tiny_binary, "main")
+    tu = SAMPLE_TU.replace("FUN_401136", f"FUN_{add_nums:x}").replace("FUN_4011a0", f"FUN_{main:x}")
+    fake = tmp_path / "manifold"
+    out_tu = tmp_path / "tu.c"
+    out_tu.write_text(tu)
+    fake.write_text(f'#!/bin/sh\ncat "{out_tu}" > "$2"\n')
+    fake.chmod(0o755)
+    monkeypatch.setenv("MANIFOLD_BIN", str(fake))
+
+    result = ManifoldDecompiler().decompile_binary(tiny_binary, function_names={add_nums})
+
+    assert sorted(result.functions) == [f"FUN_{add_nums:x}"]
+
+
+def test_decompile_binary_reports_failure_without_output(
+    monkeypatch, tiny_binary: Path, tmp_path: Path
+) -> None:
+    fake = tmp_path / "manifold-fail"
+    fake.write_text('#!/bin/sh\necho "unsupported architecture" >&2\nexit 1\n')
+    fake.chmod(0o755)
+    monkeypatch.setenv("MANIFOLD_BIN", str(fake))
+
+    result = ManifoldDecompiler().decompile_binary(tiny_binary)
+
+    assert result.functions == {}
+    assert result.decompiler.failed_functions == ["all"]
+    assert "unsupported architecture" in result.decompiler.extra["error"]

--- a/tests/test_manifold_backend.py
+++ b/tests/test_manifold_backend.py
@@ -390,6 +390,49 @@ def test_build_image_builds_the_dockerfile_with_the_docker_dir_as_context(
     assert Path(build[-1]) == dockerfile.parent
 
 
+def test_build_passes_a_resolved_sha_so_a_rebuild_is_not_stale(
+    monkeypatch, fake_docker: Path, tmp_path: Path
+) -> None:
+    """The whole point of resolving the ref: docker keys the clone layer on the
+    command string, so a bare `master` rebuilds the revision already cached."""
+    monkeypatch.setenv("MANIFOLD_REF", "master")
+    calls: list[list[str]] = []
+
+    def fake_ls_remote(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "fb5b1bfdeadbeef\trefs/heads/master\n", "")
+
+    import decbench.decompilers.raw.manifold_raw as mr
+
+    monkeypatch.setattr(mr, "_resolve_ref", lambda repo, ref: "fb5b1bfdeadbeef")
+    assert ManifoldDecompiler.build_image() == 0
+
+    build = next(c for c in _docker_calls(fake_docker) if c[0] == "build")
+    assert "MANIFOLD_REF=fb5b1bfdeadbeef" in build, "must pin the SHA, not the branch name"
+    assert "--no-cache" not in build, "an unchanged upstream should still hit the cache"
+
+
+def test_build_falls_back_to_no_cache_when_the_ref_cannot_be_resolved(
+    monkeypatch, fake_docker: Path
+) -> None:
+    """Offline or a bad ref: a slow honest build beats a fast stale one."""
+    import decbench.decompilers.raw.manifold_raw as mr
+
+    monkeypatch.setattr(mr, "_resolve_ref", lambda repo, ref: None)
+    assert ManifoldDecompiler.build_image() == 0
+
+    build = next(c for c in _docker_calls(fake_docker) if c[0] == "build")
+    assert "--no-cache" in build
+
+
+def test_resolve_ref_passes_through_a_sha_without_touching_the_network(monkeypatch) -> None:
+    import decbench.decompilers.raw.manifold_raw as mr
+
+    monkeypatch.setattr(mr.shutil, "which", lambda n: None)  # no git available
+    assert mr._resolve_ref("https://example/repo", "fb5b1bf") == "fb5b1bf"
+    assert mr._resolve_ref("https://example/repo", "master") is None
+
+
 def test_registry_backend_exposes_the_build_hook() -> None:
     """The CLI finds the builder by getattr, so it must live on the instance."""
     assert callable(getattr(DecompilerRegistry.get("manifold"), "build_image", None))

--- a/tests/test_manifold_backend.py
+++ b/tests/test_manifold_backend.py
@@ -1,14 +1,16 @@
-"""Unit tests for the manifold backend's binary resolution + TU splitting.
+"""Unit tests for the manifold backend's path selection + TU splitting.
 
-The real decompilation shells out to the ``manifold`` executable (a Rust
-binary), so these tests exercise the parts that do NOT need it installed:
-executable resolution, availability gating, splitting one whole-program
-translation unit into per-function definitions, and the address mapping --
-the last through a fake ``manifold`` that emits a canned translation unit.
+The real decompilation runs manifold (a Rust binary) either natively or in its
+Docker image, so these tests exercise the parts that do NOT need either
+installed: executable resolution, native-over-Docker path selection,
+availability gating, splitting one whole-program translation unit into
+per-function definitions, and the address mapping -- the last two through a
+fake ``manifold`` and a fake ``docker`` that emit a canned translation unit.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -75,8 +77,11 @@ def test_manifold_is_registered() -> None:
     assert isinstance(dec.is_available(), bool)
 
 
-def test_unavailable_without_binary(monkeypatch) -> None:
+def test_unavailable_without_binary_or_image(monkeypatch) -> None:
+    """Unavailable needs BOTH paths absent -- so the image has to be neutralized
+    too, or this passes only on machines that never ran `decompiler-build`."""
     monkeypatch.setenv("MANIFOLD_BIN", "/nonexistent/manifold")
+    monkeypatch.setenv("MANIFOLD_IMAGE", "decbench/manifold:no-such-tag")
     assert ManifoldDecompiler().is_available() is False
 
 
@@ -214,3 +219,177 @@ def test_decompile_binary_reports_failure_without_output(
     assert result.functions == {}
     assert result.decompiler.failed_functions == ["all"]
     assert "unsupported architecture" in result.decompiler.extra["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Docker path
+# --------------------------------------------------------------------------- #
+
+# A stand-in for the docker CLI covering the three calls the backend makes:
+# `image inspect` (availability), `build` (decompiler-build), and `run` -- both
+# the decompile run, which writes the canned TU into the /work bind mount, and
+# the `--entrypoint cat` read of the image's baked-in revision.
+FAKE_DOCKER = """#!/usr/bin/env python3
+import os
+import pathlib
+import sys
+
+argv = sys.argv[1:]
+log = os.environ.get("FAKE_DOCKER_LOG")
+if log:
+    with open(log, "a") as fh:
+        fh.write("\\0".join(argv) + "\\n")
+
+if argv[:2] == ["image", "inspect"]:
+    sys.exit(int(os.environ.get("FAKE_DOCKER_INSPECT_RC", "0")))
+if argv[:1] == ["build"]:
+    sys.exit(0)
+if argv[:1] == ["run"]:
+    if "--entrypoint" in argv:
+        sys.stdout.write(os.environ.get("FAKE_DOCKER_REV", "abc1234") + "\\n")
+        sys.exit(0)
+    work = next(
+        argv[i + 1].rsplit(":", 1)[0]
+        for i, a in enumerate(argv)
+        if a == "-v" and argv[i + 1].endswith(":/work")
+    )
+    dest = pathlib.Path(work) / pathlib.Path(argv[-1]).name
+    dest.write_text(pathlib.Path(os.environ["FAKE_DOCKER_TU"]).read_text())
+    sys.exit(0)
+sys.exit(2)
+"""
+
+
+@pytest.fixture
+def fake_docker(monkeypatch, tmp_path: Path) -> Path:
+    """Put a fake ``docker`` first on PATH and force the native path unavailable.
+
+    ``MANIFOLD_BIN`` pointing at a nonexistent file is the documented way to say
+    "no native manifold": the env override wins outright, so no config entry or
+    stray ``$PATH`` manifold on the test host can leak in. Returns the path the
+    fake logs its argv to, one NUL-joined call per line.
+    """
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    docker = bindir / "docker"
+    docker.write_text(FAKE_DOCKER)
+    docker.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+    monkeypatch.setenv("MANIFOLD_BIN", str(tmp_path / "no-such-manifold"))
+    monkeypatch.setenv("FAKE_DOCKER_LOG", str(tmp_path / "docker-argv.log"))
+    monkeypatch.delenv("MANIFOLD_VERSION", raising=False)
+    monkeypatch.delenv("MANIFOLD_IMAGE", raising=False)
+    monkeypatch.delenv("MANIFOLD_THREADS", raising=False)
+    return tmp_path / "docker-argv.log"
+
+
+def _docker_calls(log: Path) -> list[list[str]]:
+    if not log.exists():
+        return []
+    return [line.split("\0") for line in log.read_text().splitlines() if line]
+
+
+def test_docker_image_makes_it_available_without_a_binary(fake_docker: Path) -> None:
+    dec = ManifoldDecompiler()
+    assert dec.is_available() is True
+    assert dec._select_path() == ("docker", None)
+    # Availability must never build the image (a multi-minute side effect) nor
+    # run it -- inspecting is the only docker call it is allowed to make.
+    assert {tuple(c[:2]) for c in _docker_calls(fake_docker)} == {("image", "inspect")}
+
+
+def test_unavailable_when_neither_binary_nor_image(monkeypatch, fake_docker: Path) -> None:
+    monkeypatch.setenv("FAKE_DOCKER_INSPECT_RC", "1")
+    dec = ManifoldDecompiler()
+    assert dec.is_available() is False
+    assert dec._select_path() == ("none", None)
+
+
+def test_native_binary_wins_over_the_image(monkeypatch, fake_docker: Path, tmp_path: Path) -> None:
+    """A resolvable executable skips the container round-trip entirely."""
+    native = tmp_path / "manifold"
+    native.write_text("#!/bin/sh\nexit 0\n")
+    native.chmod(0o755)
+    monkeypatch.setenv("MANIFOLD_BIN", str(native))
+
+    mode, exe = ManifoldDecompiler()._select_path()
+
+    assert mode == "native"
+    assert exe == native
+    assert _docker_calls(fake_docker) == []
+
+
+def test_docker_run_mounts_the_binary_and_reads_back_the_unit(
+    monkeypatch, fake_docker: Path, tiny_binary: Path, tmp_path: Path
+) -> None:
+    """The container path must produce the same result as the native one."""
+    add_nums = _func_address(tiny_binary, "add_nums")
+    main = _func_address(tiny_binary, "main")
+    tu = tmp_path / "tu.c"
+    tu.write_text(
+        SAMPLE_TU.replace("FUN_401136", f"FUN_{add_nums:x}").replace("FUN_4011a0", f"FUN_{main:x}")
+    )
+    monkeypatch.setenv("FAKE_DOCKER_TU", str(tu))
+    monkeypatch.setenv("MANIFOLD_THREADS", "4")
+
+    result = ManifoldDecompiler().decompile_binary(tiny_binary)
+
+    assert sorted(result.functions) == sorted([f"FUN_{add_nums:x}", f"FUN_{main:x}"])
+    assert result.functions[f"FUN_{main:x}"].address == main
+    assert result.decompiler.extra["run_via"] == "docker"
+    assert result.decompiler.extra["image"] == "decbench/manifold:latest"
+
+    run = next(c for c in _docker_calls(fake_docker) if c[0] == "run" and "--entrypoint" not in c)
+    assert f"{tiny_binary.resolve()}:/in/{tiny_binary.name}:ro" in run
+    assert "decbench/manifold:latest" in run
+    assert run[-2:] == [f"/in/{tiny_binary.name}", f"/work/{tiny_binary.stem}.c"]
+    # MANIFOLD_THREADS caps the container's rayon pool, as it does a native run.
+    assert "RAYON_NUM_THREADS=4" in run
+
+
+def test_docker_version_reports_the_image_revision(monkeypatch, fake_docker: Path) -> None:
+    """A dockerized run reports the same ``git-<rev>`` shape a native one does."""
+    monkeypatch.setenv("FAKE_DOCKER_REV", "90fa808")
+
+    assert ManifoldDecompiler().get_version() == "git-90fa808"
+
+    read = next(c for c in _docker_calls(fake_docker) if "--entrypoint" in c)
+    assert read[-2:] == ["decbench/manifold:latest", "/opt/manifold.rev"]
+
+
+def test_docker_version_is_probed_once_per_instance(fake_docker: Path) -> None:
+    """Reading the revision spawns a container, so a corpus run must not repeat
+    it per binary -- and it must not be charged to a decompile's reported time."""
+    dec = ManifoldDecompiler()
+    assert dec.get_version() == dec.get_version() == "git-abc1234"
+
+    assert len([c for c in _docker_calls(fake_docker) if "--entrypoint" in c]) == 1
+
+
+def test_image_env_override_retags_every_docker_call(monkeypatch, fake_docker: Path) -> None:
+    monkeypatch.setenv("MANIFOLD_IMAGE", "local/manifold:dev")
+
+    assert ManifoldDecompiler().is_available() is True
+
+    inspect = next(c for c in _docker_calls(fake_docker) if c[:2] == ["image", "inspect"])
+    assert inspect[-1] == "local/manifold:dev"
+
+
+def test_build_image_builds_the_dockerfile_with_the_docker_dir_as_context(
+    fake_docker: Path,
+) -> None:
+    """``decbench decompiler-build manifold`` reaches this through build_image."""
+    assert ManifoldDecompiler.build_image() == 0
+
+    build = next(c for c in _docker_calls(fake_docker) if c[0] == "build")
+    dockerfile = Path(build[build.index("-f") + 1])
+    assert dockerfile.name == "manifold.Dockerfile"
+    assert dockerfile.is_file(), "the Dockerfile build_image points at must exist"
+    assert build[build.index("-t") + 1] == "decbench/manifold:latest"
+    # Build context is docker/, matching the other container-backed backends.
+    assert Path(build[-1]) == dockerfile.parent
+
+
+def test_registry_backend_exposes_the_build_hook() -> None:
+    """The CLI finds the builder by getattr, so it must live on the instance."""
+    assert callable(getattr(DecompilerRegistry.get("manifold"), "build_image", None))


### PR DESCRIPTION
## Summary

Adds a raw backend for **[Manifold](https://github.com/changliu98/manifold)**, an open-source decompiler that runs CompCert's compilation pipeline in reverse: a binary is raised through Mach → Linear → RTL → Cminor → Csharpminor → Clight and printed as C. Manifold's v1 numbers are already on the board from an external eval-kit submission; this PR is the harness, so a maintainer can run it on the **full corpus** instead of only scoring a submitted zip.

```bash
decbench decompiler-build manifold          # builds the image; nothing else to install
decbench run projects/sailr/<proj>.toml -O O0 -d manifold
```

Per @mahaloz's request, **installing manifold is now automated**: `docker/manifold.Dockerfile`
builds it from source, and the backend falls back to that image when no native executable
resolves. A host needs Docker and nothing else. A native manifold still wins if one is
present (`MANIFOLD_BIN` / `decompilers.toml` / `$PATH`), so a developer can benchmark a
working tree without rebuilding an image.

It is the first backend of a shape decbench hasn't had: **whole-binary, no per-function entry point**. One process call decompiles the entire binary into a single translation unit, so the per-function structure decbench needs is recovered from that unit rather than requested from the tool.

## Backend design

- **Invocation**: one `manifold <binary> <out.c>` subprocess per binary, under `config.binary_timeout_seconds`. A timeout or a missing output file becomes a `DecompilationResult` with `failed_functions=["all"]` and `timeout_occurred` set, never an exception that takes down a run.
- **Splitting the translation unit**: a brace-depth scanner over a copy of the text with comments and string/char literals blanked to spaces (offsets preserved, so slices still index the original). The text since the last top-level `;`/`}` is the declarator; a braced group whose declarator ends in a parameter list is a function, while `struct`/`union`/`enum` definitions run on to their `;`. This is why the backend does not just regex for `name(...) {`.
- **Addresses**: `FUN_<hex>` is manifold's name for an entry it has no symbol for, so the address is read straight out of the name; unstripped binaries fall back to `.symtab`/`.dynsym` via pyelftools. Anything that resolves to neither is reported in `failed_functions` rather than guessed at.
- **No rebasing**: manifold reports the ELF's own vaddrs, which is already the ELF-file space the metrics expect. Verified against ground truth below.
- **Per-function preamble**: each stored snippet is prefixed with the file-scope structs and globals its body transitively references (a struct's fields can name other structs), so a function decbench stores and recompiles stands on its own — the same shape as angr's per-function artifacts.
- **Variables are deliberately left unset**: manifold's C carries declared types but no stack offsets, so `type_match` scores it through the `parse_c_variables` text path (arguments by ABI position, locals by name), the footing #28 established for code-only backends.
- **Config**: `MANIFOLD_BIN` is an explicit override and wins outright (a bad value is a misconfiguration to report, not a reason to silently run some other build); otherwise `binary` from the decompilers config — per-version, then the tool's default section — then `$PATH`. `MANIFOLD_LD_LIBRARY_PATH` is merged into the child's `LD_LIBRARY_PATH` (manifold links libz3 dynamically), and `MANIFOLD_THREADS` caps its rayon pool so a parallel driver can keep N binaries from each grabbing every core. `get_version()` reports `git-<short rev>` of the checkout the executable sits in, since manifold has no `--version`.

## Docker image (`docker/manifold.Dockerfile`)

Multi-stage: the build stage clones manifold, initializes its Ascent submodule and compiles
it; the runtime stage carries out only the stripped binary and libz3, so the image is 247 MB
rather than the multi-GB builder. Selection order mirrors `R2DecDecompiler._select_path`:
native > this image.

Three things worth knowing before you bump it:

- **Z3** — the `z3` crate finds libz3 through pkg-config, and Ubuntu's packaged 4.8 is too old
  for the `z3-sys` 0.11 bindings, so a pinned upstream release is unpacked to `/opt/z3` with a
  hand-written `z3.pc`. `Z3_DIST` names the glibc the release was built for and must match the
  base image, so bump it together with `Z3_VERSION`.
- **`MANIFOLD_REF`** defaults to `master`; pass a SHA or tag to freeze a run. The image records
  what it actually built at `/opt/manifold.rev` and `get_version()` reads it back, so results
  always name the exact revision even though the ref floats.
- **Rebuild through `decompiler-build`, not a bare `docker build`.** Docker keys the `git clone`
  layer on the command string, which does not change when a branch moves — so a plain rebuild
  after manifold gains commits reuses the cached clone and silently ships the *same* revision,
  in about a second, reporting no error. `build_image()` resolves `MANIFOLD_REF` to a SHA via
  `git ls-remote` and passes that as the build arg, so the clone layer is invalidated exactly
  when upstream moved and stays cached when it did not (the apt/Z3/rustup layers survive
  either way). If the ref cannot be resolved — offline, no `git`, bad ref — it falls back to
  `--no-cache` and says so. By hand, pass `--build-arg MANIFOLD_REF=<sha>` or `--no-cache`.
- **Build cost** — ~29 min and **~8.5 GB peak `rustc` RSS**, because manifold is one enormous
  `ascent!`-generated module. Worth checking your build host has the headroom.

The release profile is overridden to `opt-level 3` + thin LTO via cargo's environment
interface, leaving the manifold checkout untouched — manifold's own profile is tuned for build
speed (`opt-level 0`), which is right for a working tree and wrong for an image built once and
run over a corpus. Measured on a quiet host, same revision both sides:

| binary | opt-level 0 | -O3 + thin | speedup | emitted C |
|---|---|---|---|---|
| 14 KB | 2.2s | 1.3s | 1.72x | identical |
| 35 KB (`cat`) | 8.2s | 3.8s | 2.16x | identical |
| 138 KB (`ls`) | 33.8s | 11.1s | 3.03x | identical |
| 150 KB (`du`) | 66.4s | 19.0s | 3.50x | identical |

Build cost is 10m28s → 28m36s, paid once. **Fat LTO was measured and rejected**: 0.99–1.06x
(noise) for 49m and 25.2 GB peak RSS — one giant generated module leaves whole-program merging
almost no cross-module inlining to find. It stays reachable via
`--build-arg CARGO_PROFILE_RELEASE_LTO=fat`. Every variant emits byte-identical C.

## Site content

`site/data/aggregates.json` on `main` already renders Manifold with a display name, URL, logo, and `sample_set_only`, but **no source file carries any of it** — 24cc9a6 published the built tree only, so a re-render from `content/` would drop the registry entry and start showing Manifold's sample-set row on the full-corpus presets. This PR adds the matching `decompilers.toml` entry (including `logo = true`, whose `.dlogo-manifold` CSS you already landed in 24cc9a6) and appends `manifold` to `sample_set_only` in `site.toml`. Happy to drop that second hunk if you'd rather keep it a local edit — and it should come out once a full-corpus run covers manifold.

## Verification

- `pytest tests/test_manifold_backend.py`: **22 passed** (was 10). The new ones cover
  native-over-Docker selection, availability gating on the image alone, the `docker run` mount
  layout, `MANIFOLD_THREADS` → `RAYON_NUM_THREADS`, `MANIFOLD_IMAGE` retagging, the
  `build_image()` hook, and version memoization — all through a **fake `docker`**, so they run
  with neither manifold nor Docker installed. One pre-existing test was quietly
  environment-dependent (it only neutralized `MANIFOLD_BIN`, so it passed by accident on hosts
  that had never built the image, and failed once one existed); it now neutralizes both paths.
  Three more cover the rebuild-staleness fix: a resolvable ref is pinned as a SHA without
  forcing `--no-cache`, an unresolvable one forces it, and a ref that is already a SHA
  short-circuits without needing `git`.
- Full suite: **377 passed, 7 skipped, 5 failed** — the 5 are pre-existing `test_content.py`
  rendering assertions, identical on clean `main` in a separate worktree.
- `ruff` and `black --check` clean on all touched files; `mypy --follow-imports=skip
  decbench/decompilers/raw/manifold_raw.py` clean. (Repo-wide `ruff check decbench/` reports 21
  pre-existing findings on `main`; none are in files this PR touches.)
- **End-to-end with no native manifold on the host** (`MANIFOLD_BIN` deliberately pointed at a
  nonexistent path, so the run is forced through the image):
  - `decbench list-decompilers` → `manifold | Y | git-d9291ad`
  - `decbench run projects/sailr/bzip2.toml -O O0 -d manifold` → completes clean; **120
    functions across 2 binaries, `failed_functions` empty on both**, all three metrics scored
    (GED 50.8%, byte_match 3.3%, type_match 7.4%).
  - Both address routes exercised: `FUN_<hex>` on a stripped binary (`add_two 0x401136`,
    `classify 0x40113e`, `main 0x401153`, matching `nm` on the unstripped twin) and the ELF
    symbol table on bzip2's unstripped output.

## Maintainer notes

- **Installing manifold** is now `decbench decompiler-build manifold` — no Rust, mold, libclang or z3 on the host. Building it *natively* still needs all of those plus a `--recursive` clone, and `MANIFOLD_LD_LIBRARY_PATH=<z3>/lib` if z3 is not on the default loader path; that path is now optional.
- **It is whole-binary**, so `binary_timeout_seconds` is the knob that matters, not a per-function budget, and a large binary can run long. On the 224-binary eval kit, 12 concurrent jobs × 10 threads each was a good balance on a 128-core box.
- **CHANGELOG**: `docs/agents.md` says agents must not edit it, so this PR doesn't. Suggested entry under `### 2026-07-27`:
  > - Added a `manifold` decompiler backend (`decbench/decompilers/raw/manifold_raw.py`) plus a `docker/manifold.Dockerfile`, so Manifold can be installed with `decbench decompiler-build manifold` and run on the full corpus rather than only submitted as a sample-set result.
- **Not done**: no full-corpus run and no overlay refresh — publishing full-corpus numbers still needs the usual `reeval_*` + `finalize_results.py` pass on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JquMXzqYHQTS62SnP98Pg1


