### PR TITLE
Escape raw control bytes in string literals before Joern parsing

### DIFF
--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -26,12 +26,47 @@ _AGG_RETURN = re.compile(r"^([A-Za-z_][\w ]*?)\s*\[\d+\]\s+([A-Za-z_]\w*\s*\()",
 # ``@`` is not legal C and breaks Joern's parse for the whole function.
 _REG_ANNOTATION = re.compile(r"\s*@\s*[a-z]\w+\b")
 
+# Tab and newline are the emitted source's own layout, not literal payload.
+_KEEP_RAW_BYTES = frozenset({0x09, 0x0A})
+
+
+def escape_literal_control_bytes(text: str) -> str:
+    """Escape raw control bytes appearing inside string/char literals.
+
+    A decompiler that inlines ``.rodata`` verbatim emits e.g. an ANSI colour
+    sequence as a raw ``0x1B``. That is valid C, but it makes pyjoern's fast
+    parser emit non-JSON, which fails the whole invocation rather than the one
+    function. Only literal interiors are rewritten, and ``\\x1b`` is the same
+    bytes to the compiler, so control flow is untouched.
+    """
+    out: list[str] = []
+    in_string = in_char = pending_escape = False
+    for char in text:
+        code = ord(char)
+        if pending_escape:
+            out.append(char)
+            pending_escape = False
+            continue
+        if char == "\\" and (in_string or in_char):
+            out.append(char)
+            pending_escape = True
+            continue
+        if char == '"' and not in_char:
+            in_string = not in_string
+        elif char == "'" and not in_string:
+            in_char = not in_char
+        if (in_string or in_char) and code not in _KEEP_RAW_BYTES and (code < 0x20 or code == 0x7F):
+            out.append(f"\\x{code:02x}")
+        else:
+            out.append(char)
+    return "".join(out)
+
 
 def sanitize_decompiled_c(text: str) -> str:
     """Clean decompiler-specific C quirks that break Joern's parser.
 
     GED only cares about CFG *structure*, so these edits are purely to make the
-    body parseable — they never touch control flow. Three tool-specific quirks:
+    body parseable — they never touch control flow. Four tool-specific quirks:
 
     * **Aggregate/array return type** (angr/ghidra): ``T [N] name(...)``
       is rewritten to ``T name(...)``. Anchored to the start of a line so a real
@@ -40,11 +75,13 @@ def sanitize_decompiled_c(text: str) -> str:
       is not valid C.
     * **128-bit types** (ida): ``__int128`` is widened to ``long long`` (the exact
       width is irrelevant to the CFG).
+    * **Raw control bytes in literals**: escaped, so a verbatim ``.rodata`` string
+      cannot make pyjoern's fast parser emit non-JSON and void the invocation.
     """
     text = _AGG_RETURN.sub(r"\1 \2", text)
     text = _REG_ANNOTATION.sub("", text)
     text = text.replace("unsigned __int128", "unsigned long long").replace("__int128", "long long")
-    return text
+    return escape_literal_control_bytes(text)
 
 
 def _is_system_header(path: str) -> bool:

--- a/tests/test_cfg_sanitize.py
+++ b/tests/test_cfg_sanitize.py
@@ -1,0 +1,57 @@
+"""Tests for decompiled-C sanitization ahead of Joern parsing."""
+
+from __future__ import annotations
+
+from decbench.utils.cfg import escape_literal_control_bytes, sanitize_decompiled_c
+
+
+class TestEscapeLiteralControlBytes:
+    def test_escapes_esc_inside_string_literal(self) -> None:
+        out = escape_literal_control_bytes('fputs("\x1b[31mred\x1b[0m", stderr);')
+        assert out == 'fputs("\\x1b[31mred\\x1b[0m", stderr);'
+
+    def test_escapes_inside_char_literal(self) -> None:
+        assert escape_literal_control_bytes("c = '\x07';") == "c = '\\x07';"
+
+    def test_escapes_del(self) -> None:
+        assert escape_literal_control_bytes('s = "\x7f";') == 's = "\\x7f";'
+
+    def test_preserves_code_layout_outside_literals(self) -> None:
+        code = "int f(void)\n{\n\treturn 1;\n}\n"
+        assert escape_literal_control_bytes(code) == code
+
+    def test_keeps_tab_and_newline_inside_literal(self) -> None:
+        assert escape_literal_control_bytes('s = "a\tb";') == 's = "a\tb";'
+
+    def test_already_escaped_text_is_unchanged(self) -> None:
+        code = 's = "\\x1b[0m";'
+        assert escape_literal_control_bytes(code) == code
+
+    def test_escaped_quote_does_not_end_the_literal(self) -> None:
+        out = escape_literal_control_bytes('s = "a\\"\x1b";')
+        assert out == 's = "a\\"\\x1b";'
+
+    def test_apostrophe_inside_string_does_not_open_a_char_literal(self) -> None:
+        out = escape_literal_control_bytes('s = "it\'s";\nt = "\x1b";')
+        assert out == 's = "it\'s";\nt = "\\x1b";'
+
+    def test_idempotent(self) -> None:
+        once = escape_literal_control_bytes('s = "\x1b";')
+        assert escape_literal_control_bytes(once) == once
+
+
+class TestSanitizeDecompiledC:
+    def test_applies_control_byte_escaping(self) -> None:
+        assert sanitize_decompiled_c('s = "\x1b";') == 's = "\\x1b";'
+
+    def test_still_rewrites_aggregate_return_type(self) -> None:
+        assert sanitize_decompiled_c("char [16] f(void)\n{\n}\n").startswith("char f(void)")
+
+    def test_does_not_rewrite_in_body_array_declaration(self) -> None:
+        assert "char buf[16];" in sanitize_decompiled_c("int f(void)\n{\n    char buf[16];\n}\n")
+
+    def test_still_strips_register_annotation(self) -> None:
+        assert sanitize_decompiled_c("int f(char arg3 @ rax)") == "int f(char arg3)"
+
+    def test_still_widens_int128(self) -> None:
+        assert sanitize_decompiled_c("unsigned __int128 x;") == "unsigned long long x;"


### PR DESCRIPTION
Fixes the control-byte half of #50.

## Problem

A decompiler that inlines `.rodata` verbatim can emit a raw control byte inside a string literal — most commonly the `0x1B` of an ANSI colour sequence:

```c
fputs("<ESC>[31;1mNo end-of-line character at the end of file<ESC>[0m", stderr);
```

That is valid C and compiles fine, but it makes pyjoern's fast parser emit non-JSON, so `extract_cfgs_from_source` raises:

```
Fast parser script made non-json compliant output: {
    "ddg": [
"digraph \"&lt;...
```

Because decompiled CFGs are extracted for a whole binary in **one** Joern invocation, a single such byte costs **every function in that binary** its GED score, and there is no per-function signal that anything went wrong — the functions just quietly leave GED's denominator. In our corpus one artifact lost all 59 of its functions to two `0x1B` bytes in a single `fputs`.

## Fix

`sanitize_decompiled_c` now escapes control bytes that sit inside string or char literals. Tab and newline are left alone — they are the emitted source's own layout, not literal payload.

## Why this is safe

- `\x1b` and a raw `0x1B` are the **same bytes to the compiler**, so `byte_match` is unaffected. We re-measured across our corpus: byte_match perfects were identical before and after (4,970 either way).
- A string literal is an expression, so its contents cannot change control flow. **No existing GED value can move** — the change only converts "invocation returned nothing" into a normal parse.
- Only literal interiors are rewritten. A bare control byte outside a literal would not be valid C anyway.

I have deliberately **not** bumped GED's `cache_version`: no already-scored function's value can change, and bumping would invalidate every cached GED entry for no benefit. Happy to add it if you would rather be conservative.

## Verification

Before/after on a real single-function artifact containing two raw `0x1B` bytes:

```
BEFORE: Fast parser script made non-json compliant output: {"ddg": ["digraph \"&lt;...
        functions parsed: 0
AFTER:  functions parsed: 1 ['list_cmd']
```

Adds `tests/test_cfg_sanitize.py` — 14 unit tests covering ESC/BEL/DEL in string and char literals, tab/newline preservation, code layout outside literals, escaped-quote and apostrophe edge cases, idempotence, and regression cover for the three existing quirk rewrites (aggregate return type, register annotation, `__int128`). All pass; `ruff check` and `ruff format` are clean on both changed files.

## Scope notes

- No `CHANGELOG.md` edit, per `AGENTS.md`. Suggested entry if you want one: *"GED: escape raw control bytes in decompiled string literals so one such byte no longer voids a whole binary's CFG extraction."*
- The docs do not enumerate the sanitizer's quirk list, so nothing in `docs/` needed updating; the list in the function's own docstring is extended from three entries to four.
- Two pre-existing `ruff` findings in `decbench/utils/cfg.py` (an implicit string concat in the pyjoern `ImportError`) are left untouched to keep this PR to one change.

## On scale

Worth being straight about this, since you asked in #50 whether it affects other decompilers: we scanned every decompiled artifact we have and found **zero** raw control bytes across angr, binja, dewolf, ghidra, ida, kuna, r2dec, codex and claude-code, versus 28 bytes in 14 of our own 696 artifacts. So on our evidence this only bites decompilers that inline `.rodata` verbatim, and it is a robustness fix for the harness rather than something that is currently distorting published numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
