### PR TITLE
Fix GED scoring for large isomorphic CFGs

### DIFF
--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -115,10 +115,12 @@ def _is_isomorphic(source_cfg: DiGraph, decompiled_cfg: DiGraph) -> bool:
         ("role", "iso_color"),
         ((False, False), -1),
     )
-    return nx.is_isomorphic(
-        source_graph,
-        decompiled_graph,
-        node_match=node_match,
+    return bool(
+        nx.is_isomorphic(
+            source_graph,
+            decompiled_graph,
+            node_match=node_match,
+        )
     )
 
 

--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -15,9 +15,120 @@ if TYPE_CHECKING:
     from decbench.models.decompilation import FunctionDecompilation
 
 
-# Exact GED is super-polynomial, so graphs above this node count fall back to a
-# cheap structural distance. Tunable via DECBENCH_GED_MAX_NODES.
-GED_MAX_NODES = int(os.environ.get("DECBENCH_GED_MAX_NODES") or "60")
+# VJ-GED becomes expensive on large cost matrices, so non-isomorphic graphs above
+# this node count fall back to a cheap structural distance.
+GED_MAX_NODES = int(os.environ.get("DECBENCH_GED_MAX_NODES") or "200")
+
+
+def _node_role(node: Any) -> tuple[bool, bool]:
+    return (
+        bool(getattr(node, "is_entrypoint", False)),
+        bool(getattr(node, "is_exitpoint", False)),
+    )
+
+
+def _role_graph(cfg: DiGraph) -> DiGraph:
+    import networkx as nx
+
+    graph = nx.DiGraph()
+    graph.add_nodes_from((node, {"role": _node_role(node)}) for node in cfg.nodes())
+    graph.add_edges_from(cfg.edges())
+    return graph
+
+
+def _add_joint_refinement_colors(
+    source_graph: DiGraph,
+    decompiled_graph: DiGraph,
+    *,
+    rounds: int = 8,
+) -> None:
+    graphs = (source_graph, decompiled_graph)
+    colors: list[dict[Any, int]] = [{}, {}]
+
+    def assign(signatures: list[dict[Any, tuple[Any, ...]]]) -> list[dict[Any, int]]:
+        palette: dict[tuple[Any, ...], int] = {}
+        assigned: list[dict[Any, int]] = [{}, {}]
+        for graph_index, graph in enumerate(graphs):
+            for node in graph.nodes():
+                signature = signatures[graph_index][node]
+                assigned[graph_index][node] = palette.setdefault(
+                    signature,
+                    len(palette),
+                )
+        return assigned
+
+    initial = [
+        {
+            node: (
+                graph.nodes[node]["role"],
+                graph.in_degree(node),
+                graph.out_degree(node),
+            )
+            for node in graph.nodes()
+        }
+        for graph in graphs
+    ]
+    colors = assign(initial)
+
+    for _ in range(rounds):
+        refined = [
+            {
+                node: (
+                    colors[graph_index][node],
+                    tuple(
+                        sorted(
+                            colors[graph_index][predecessor]
+                            for predecessor in graph.predecessors(node)
+                        )
+                    ),
+                    tuple(
+                        sorted(
+                            colors[graph_index][successor] for successor in graph.successors(node)
+                        )
+                    ),
+                )
+                for node in graph.nodes()
+            }
+            for graph_index, graph in enumerate(graphs)
+        ]
+        new_colors = assign(refined)
+        if all(
+            len(set(new_colors[index].values())) == len(set(colors[index].values()))
+            for index in range(2)
+        ):
+            colors = new_colors
+            break
+        colors = new_colors
+
+    for graph_index, graph in enumerate(graphs):
+        for node, color in colors[graph_index].items():
+            graph.nodes[node]["iso_color"] = color
+
+
+def _is_isomorphic(source_cfg: DiGraph, decompiled_cfg: DiGraph) -> bool:
+    import networkx as nx
+
+    source_graph = _role_graph(source_cfg)
+    decompiled_graph = _role_graph(decompiled_cfg)
+    _add_joint_refinement_colors(source_graph, decompiled_graph)
+    node_match = nx.algorithms.isomorphism.categorical_node_match(
+        ("role", "iso_color"),
+        ((False, False), -1),
+    )
+    return nx.is_isomorphic(
+        source_graph,
+        decompiled_graph,
+        node_match=node_match,
+    )
+
+
+def _graph_cache_input(cfg: DiGraph) -> dict[str, list[Any]]:
+    nodes = list(cfg.nodes())
+    node_ids = {node: index for index, node in enumerate(nodes)}
+    return {
+        "roles": [_node_role(node) for node in nodes],
+        "edges": sorted((node_ids[src], node_ids[dst]) for src, dst in cfg.edges()),
+    }
 
 
 @register_metric("ged")
@@ -40,7 +151,7 @@ class GEDMetric(Metric):
     requires_source_cfg = True
     requires_decompiled_cfg = True
 
-    cache_version = "2"
+    cache_version = "3"
 
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)
@@ -49,13 +160,14 @@ class GEDMetric(Metric):
     def _get_vj_ged(self):  # type: ignore
         if self._vj_ged is None:
             try:
-                from cfgutils.similarity import vj_ged
+                from decbench.metrics.vj_ged import vj_ged
 
                 self._vj_ged = vj_ged
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
-                    "cfgutils is required for GED metric. " "Install with: pip install cfgutils"
-                )
+                    "cfgutils and scipy are required for GED metric. "
+                    "Install with: pip install cfgutils scipy"
+                ) from e
         return self._vj_ged
 
     def compute_for_function(
@@ -89,10 +201,8 @@ class GEDMetric(Metric):
             )
 
         key_inputs = [
-            sorted(str(n) for n in source_cfg.nodes()),
-            sorted((str(u), str(v)) for u, v in source_cfg.edges()),
-            sorted(str(n) for n in decompiled_cfg.nodes()),
-            sorted((str(u), str(v)) for u, v in decompiled_cfg.edges()),
+            _graph_cache_input(source_cfg),
+            _graph_cache_input(decompiled_cfg),
             GED_MAX_NODES,
         ]
         return self._cached_value(
@@ -118,26 +228,47 @@ class GEDMetric(Metric):
             "decompiled_size": decomp_size,
         }
 
-        # The size delta is a sound LOWER BOUND, so a 0 here only means equal node and
-        # edge counts. Consumers tell it apart via the "approximated" metadata flag.
+        if _is_isomorphic(source_cfg, decompiled_cfg):
+            return MetricValue(
+                value=0.0,
+                raw_value=0.0,
+                metadata={**base_meta, "method": "isomorphism", "isomorphic": True},
+            )
+
         if s_nodes > GED_MAX_NODES or d_nodes > GED_MAX_NODES:
-            approx = float(
-                abs(s_nodes - d_nodes)
-                + abs(source_cfg.number_of_edges() - decompiled_cfg.number_of_edges())
+            approx = max(
+                1.0,
+                float(
+                    abs(s_nodes - d_nodes)
+                    + abs(source_cfg.number_of_edges() - decompiled_cfg.number_of_edges())
+                ),
             )
             return MetricValue(
                 value=approx,
                 raw_value=approx,
-                metadata={**base_meta, "approximated": True},
+                metadata={
+                    **base_meta,
+                    "method": "size_lower_bound",
+                    "isomorphic": False,
+                    "approximated": True,
+                },
             )
 
         vj_ged = self._get_vj_ged()
         try:
-            ged_value = vj_ged(source_cfg, decompiled_cfg)
+            raw_ged = float(vj_ged(source_cfg, decompiled_cfg))
+            ged_value = max(1.0, raw_ged)
+            metadata = {
+                **base_meta,
+                "method": "vj_ged",
+                "isomorphic": False,
+            }
+            if raw_ged != ged_value:
+                metadata["vj_ged_raw"] = raw_ged
             return MetricValue(
-                value=float(ged_value),
-                raw_value=ged_value,
-                metadata=base_meta,
+                value=ged_value,
+                raw_value=raw_ged,
+                metadata=metadata,
             )
         except Exception as e:
             return MetricValue(

--- a/decbench/metrics/vj_ged.py
+++ b/decbench/metrics/vj_ged.py
@@ -1,0 +1,58 @@
+"""Accelerated VJ graph edit distance."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from networkx import DiGraph
+
+
+def _node_role(node: object) -> tuple[bool, bool]:
+    return (
+        bool(getattr(node, "is_entrypoint", False)),
+        bool(getattr(node, "is_exitpoint", False)),
+    )
+
+
+def vj_ged(source_cfg: DiGraph, decompiled_cfg: DiGraph) -> float:
+    """Compute cfgutils' VJ-GED cost with a compiled assignment solver."""
+    import numpy as np
+    from cfgutils.similarity.ged import INVALID_CHOICE_PENALTY
+    from scipy.optimize import linear_sum_assignment
+
+    source_nodes = list(source_cfg.nodes)
+    decompiled_nodes = list(decompiled_cfg.nodes)
+    source_roles = [_node_role(node) for node in source_nodes]
+    decompiled_roles = [_node_role(node) for node in decompiled_nodes]
+    source_count = len(source_nodes)
+    decompiled_count = len(decompiled_nodes)
+    matrix_size = source_count + decompiled_count
+    cost_matrix = np.zeros((matrix_size, matrix_size), dtype=float)
+
+    cost_matrix[source_count:, :decompiled_count] = np.inf
+    cost_matrix[:source_count, decompiled_count:] = np.inf
+
+    for index, node in enumerate(decompiled_nodes):
+        cost_matrix[source_count + index, index] = (
+            1 + decompiled_cfg.in_degree(node) + decompiled_cfg.out_degree(node)
+        )
+    for index, node in enumerate(source_nodes):
+        cost_matrix[index, decompiled_count + index] = (
+            1 + source_cfg.in_degree(node) + source_cfg.out_degree(node)
+        )
+
+    for source_index, source_node in enumerate(source_nodes):
+        for decompiled_index, decompiled_node in enumerate(decompiled_nodes):
+            cost = abs(
+                source_cfg.out_degree(source_node) - decompiled_cfg.out_degree(decompiled_node)
+            )
+            cost += abs(
+                source_cfg.in_degree(source_node) - decompiled_cfg.in_degree(decompiled_node)
+            )
+            if source_roles[source_index] != decompiled_roles[decompiled_index]:
+                cost += INVALID_CHOICE_PENALTY
+            cost_matrix[source_index, decompiled_index] = cost
+
+    row_indices, column_indices = linear_sum_assignment(cost_matrix)
+    return float(cost_matrix[row_indices, column_indices].sum())

--- a/decbench/publish/cfg_export.py
+++ b/decbench/publish/cfg_export.py
@@ -1,18 +1,19 @@
 """Source-CFG serialization for the published dataset (contract §5).
 
-The GED metric (``cfgutils.similarity.vj_ged``) is almost purely structural — it
-scores from per-node parent/child counts — but it also reads each node's
-``is_entrypoint`` / ``is_exitpoint`` flags (an entry/exit mismatch penalty). So a
-lossless serialization needs the graph topology **plus** those two flags, and
-nothing else (labels are not used by GED). This module writes, per binary, the
-``function -> CFG`` map that ``pipeline/evaluate.py`` scores that binary
-against: the project's ``.i`` CFGs parsed **per translation unit** and then
-resolved through :func:`decbench.utils.cfg.resolved_source_for_binary` — the
-binary's own TU wins, other TUs are the fallback, and empty prototypes never
-displace a real body. Each DiGraph is relabeled to ``0..n-1`` with the
-entry/exit node ids and the degeneracy verdict recorded. :func:`rebuild_cfg`
-reconstructs a GED-ready ``nx.DiGraph`` from one serialized function, so the
-exact GED value is reproducible offline.
+The GED metric is almost purely structural: it checks directed isomorphism,
+then uses either the VJ-GED cost model or a large-graph size lower bound. Those
+paths read graph topology and each node's ``is_entrypoint`` /
+``is_exitpoint`` flags. So a lossless serialization needs the graph topology
+**plus** those two flags, and nothing else (labels are not used by GED). This
+module writes, per binary, the ``function -> CFG`` map that
+``pipeline/evaluate.py`` scores that binary against: the project's ``.i`` CFGs
+parsed **per translation unit** and then resolved through
+:func:`decbench.utils.cfg.resolved_source_for_binary` — the binary's own TU wins,
+other TUs are the fallback, and empty prototypes never displace a real body.
+Each DiGraph is relabeled to ``0..n-1`` with the entry/exit node ids and the
+degeneracy verdict recorded. :func:`rebuild_cfg` reconstructs a GED-ready
+``nx.DiGraph`` from one serialized function, so the exact GED value is
+reproducible offline through :class:`decbench.metrics.ged.GEDMetric`.
 
 A project-wide, name-keyed, last-writer-wins union is NOT a valid export: a
 declaration-only view of a function (Joern emits a single ``Nop`` block for it)
@@ -73,7 +74,7 @@ class RealStatement:
 
 
 class CfgNode:
-    """A minimal CFG node exposing the two flags ``vj_ged`` reads.
+    """A minimal CFG node exposing the two role flags GED reads.
 
     Rebuilt graphs use these so GED reproduces exactly; identity is the node id.
     """
@@ -124,9 +125,9 @@ def rebuild_cfg(func_cfg: dict) -> DiGraph:  # type: ignore[type-arg]
     """Reconstruct a GED-ready ``nx.DiGraph`` from one serialized function CFG.
 
     Nodes are :class:`CfgNode` instances carrying the stored entry/exit flags, so
-    ``cfgutils.similarity.vj_ged`` runs on the result and reproduces the exact
-    GED value the pipeline computed. A CFG recorded as non-degenerate also gets
-    :class:`RealStatement` markers so
+    :class:`decbench.metrics.ged.GEDMetric` can reproduce the pipeline's score
+    when given this source graph and the corresponding decompiled CFG. A CFG
+    recorded as non-degenerate also gets :class:`RealStatement` markers so
     :func:`decbench.utils.cfg.is_degenerate_source_cfg` agrees offline (JSONs
     written before that field existed simply keep the old behaviour).
     """

--- a/decbench/rendering/content/about.md
+++ b/decbench/rendering/content/about.md
@@ -377,9 +377,10 @@ This also allows LLMs to compete, which may have no way to return to you somethi
 This can inject error because things like variables may be hard to align across samples, which has been [explored in prior work](https://arxiv.org/abs/2502.04536).
 
 ### Graph Edit Distance
-The Graph Edit Distance (GED) algorithm we use is the [Vujosevic Janicic](https://github.com/mahaloz/cfgutils/blob/main/cfgutils/similarity/ged/vujosevic_janicic_ged.py) algorithm (VJ-GED).
-Like most GED algorithms, this is an approximation, and in some cases can inject error (more distance than actually exists).
-However, the guarantee here is that a perfect graph will always be scored correctly since we do an isomorphic test first. 
+Every CFG pair receives an exact isomorphism test first, with no size limit, so a perfect graph is always scored correctly.
+Non-isomorphic graphs up to 200 nodes use the [Vujosevic Janicic](https://github.com/mahaloz/cfgutils/blob/main/cfgutils/similarity/ged/vujosevic_janicic_ged.py) algorithm (VJ-GED).
+Like most GED algorithms, VJ-GED is an approximation and can report more distance than actually exists.
+Larger non-isomorphic graphs use a nonzero lower bound from their node and edge count differences.
 
 There are other ways to inject error here.
 We largely use [Joern](https://joern.io/) to parse the decompilation of each project.

--- a/decbench/results_store.py
+++ b/decbench/results_store.py
@@ -117,21 +117,17 @@ def read_ged_overlay(root: Path) -> tuple[dict[str, dict] | None, set[Slice] | N
     """Load ``ged_new.json`` plus the set of slices the GED reeval EVALUATED.
 
     Returns ``(payload, covered)``; ``payload`` is None when there is no overlay.
-    ``covered`` is the union of three sources so an evaluated-but-empty slice
-    still clears its stale inline values (the exact class that silently
-    re-inflated 219 slices before this was hardened):
+    ``covered`` uses the sidecar when present so an evaluated-but-empty slice
+    still clears its stale inline values without allowing retired checkpoint
+    filenames to expand a current overlay's scope:
 
     * ``ged_new.slices.json`` — the authoritative list the new ``reeval_ged.py``
       writes (every evaluated slice, empty ones included);
-    * every per-slice checkpoint filename under ``reeval_ged/`` — the reeval
-      cache IS the evaluated-slice record, present even on trees whose overlay
-      predates the sidecar (the same ``__``↔``::`` stem convention the reeval
-      uses to build the sidecar);
     * the payload's own entry keys — a slice with entries is always covered.
 
-    Only when NONE of these exist (a bare ``ged_new.json`` with no reeval cache)
-    does coverage reduce to the entry keys — conservative: an unlisted empty
-    slice then keeps its inline value.
+    On older trees without a sidecar, per-slice checkpoint filenames under
+    ``reeval_ged/`` are also used as the evaluated-slice record. A bare
+    ``ged_new.json`` reduces coverage to its entry keys.
     """
     path = root / "ged_new.json"
     if not path.exists():
@@ -141,11 +137,13 @@ def read_ged_overlay(root: Path) -> tuple[dict[str, dict] | None, set[Slice] | N
     sidecar = root / "ged_new.slices.json"
     if sidecar.exists():
         covered |= {tuple(k.split("::", 3)) for k in json.loads(sidecar.read_text())}  # type: ignore[misc]
-    reeval_dir = root / "reeval_ged"
-    if reeval_dir.is_dir():
-        covered |= {
-            tuple(cp.stem.replace("__", "::").split("::", 3)) for cp in reeval_dir.glob("*.json")
-        }  # type: ignore[misc]
+    else:
+        reeval_dir = root / "reeval_ged"
+        if reeval_dir.is_dir():
+            covered |= {
+                tuple(cp.stem.replace("__", "::").split("::", 3))
+                for cp in reeval_dir.glob("*.json")
+            }  # type: ignore[misc]
     return payload, covered
 
 

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -372,7 +372,7 @@ def extract_cfgs_from_source(
             "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
         ) from e
 
-    cfgs = {}
+    cfgs: dict[str, DiGraph] = {}
     # Joern names its workspace after the input basename, so a unique temp name is
     # what keeps concurrent parses of the same filename from colliding.
     temp_c_path = Path(tempfile.mktemp(suffix=".c"))
@@ -431,7 +431,7 @@ def extract_cfgs_from_decompilation(
             "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
         ) from e
 
-    cfgs = {}
+    cfgs: dict[str, DiGraph] = {}
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
         marked_sources = [

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -25,6 +27,15 @@ _AGG_RETURN = re.compile(r"^([A-Za-z_][\w ]*?)\s*\[\d+\]\s+([A-Za-z_]\w*\s*\()",
 
 # ``@`` is not legal C and breaks Joern's parse for the whole function.
 _REG_ANNOTATION = re.compile(r"\s*@\s*[a-z]\w+\b")
+_PREPROCESSOR_CONTROL = re.compile(
+    r"^\s*#\s*(?:define|undef|if|ifdef|ifndef|elif|else|endif)\b",
+    re.M,
+)
+_INCLUDE_DIRECTIVE = re.compile(r"^\s*#\s*include\b[^\n]*(?:\n|$)", re.M)
+_FUNCTION_MARKER = re.compile(
+    r"^// Function: ([A-Za-z_]\w*)(?: @ 0x[0-9a-fA-F]+)?\s*$",
+    re.M,
+)
 
 # Tab and newline are the emitted source's own layout, not literal payload.
 _KEEP_RAW_BYTES = frozenset({0x09, 0x0A})
@@ -82,6 +93,138 @@ def sanitize_decompiled_c(text: str) -> str:
     text = _REG_ANNOTATION.sub("", text)
     text = text.replace("unsigned __int128", "unsigned long long").replace("__int128", "long long")
     return escape_literal_control_bytes(text)
+
+
+def needs_decompiled_preprocessing(text: str) -> bool:
+    """Whether decompiled C contains directives whose expansion can change its CFG."""
+    return _PREPROCESSOR_CONTROL.search(text) is not None
+
+
+def _mask_c_noncode(text: str) -> str:
+    masked = list(text)
+    state = "code"
+    index = 0
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if state == "code":
+            if char == "/" and next_char == "/":
+                masked[index] = masked[index + 1] = " "
+                state = "line_comment"
+                index += 2
+                continue
+            if char == "/" and next_char == "*":
+                masked[index] = masked[index + 1] = " "
+                state = "block_comment"
+                index += 2
+                continue
+            if char in {'"', "'"}:
+                masked[index] = " "
+                state = "string" if char == '"' else "character"
+        elif state == "line_comment":
+            if char == "\n":
+                state = "code"
+            else:
+                masked[index] = " "
+        elif state == "block_comment":
+            if char == "*" and next_char == "/":
+                masked[index] = masked[index + 1] = " "
+                state = "code"
+                index += 2
+                continue
+            if char != "\n":
+                masked[index] = " "
+        else:
+            if char == "\\" and next_char:
+                masked[index] = masked[index + 1] = " "
+                index += 2
+                continue
+            masked[index] = " " if char != "\n" else "\n"
+            if state == "string" and char == '"' or state == "character" and char == "'":
+                state = "code"
+        index += 1
+    return "".join(masked)
+
+
+def _definition_name_span(segment: str, name: str) -> tuple[int, int] | None:
+    code = _mask_c_noncode(segment)
+    for match in re.finditer(rf"\b{re.escape(name)}\s*\(", code):
+        line_start = code.rfind("\n", 0, match.start()) + 1
+        if code[line_start : match.start()].lstrip().startswith("#"):
+            continue
+        depth = 0
+        for index in range(code.find("(", match.start()), len(code)):
+            char = code[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    suffix = code[index + 1 :]
+                    brace = suffix.find("{")
+                    semicolon = suffix.find(";")
+                    if brace >= 0 and (semicolon < 0 or brace < semicolon):
+                        return match.start(), match.start() + len(name)
+                    break
+    return None
+
+
+def _protect_macro_colliding_definitions(text: str) -> tuple[str, dict[str, str]]:
+    markers = list(_FUNCTION_MARKER.finditer(text))
+    replacements: list[tuple[int, int, str]] = []
+    restore: dict[str, str] = {}
+    for index, marker in enumerate(markers):
+        name = marker.group(1)
+        segment_start = marker.end()
+        segment_end = markers[index + 1].start() if index + 1 < len(markers) else len(text)
+        span = _definition_name_span(text[segment_start:segment_end], name)
+        if span is None:
+            continue
+        sentinel = f"__decbench_function_{index}_macro_guard"
+        if sentinel in text:
+            raise ValueError(f"reserved preprocessing sentinel already present: {sentinel}")
+        start, end = span
+        replacements.append((segment_start + start, segment_start + end, sentinel))
+        restore[sentinel] = name
+    for start, end, sentinel in reversed(replacements):
+        text = f"{text[:start]}{sentinel}{text[end:]}"
+    return text, restore
+
+
+def preprocess_decompiled_c(text: str) -> str:
+    """Expand locally defined macros before Joern parses decompiled C."""
+    if not needs_decompiled_preprocessing(text):
+        return text
+
+    compiler = shutil.which("gcc") or shutil.which("cc")
+    if compiler is None:
+        logger.warning("Cannot preprocess decompiled C: no host C preprocessor found")
+        return text
+
+    safe_text = _INCLUDE_DIRECTIVE.sub("\n", text)
+    safe_text, restore = _protect_macro_colliding_definitions(safe_text)
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".c") as source:
+            source.write(safe_text)
+            source.flush()
+            result = subprocess.run(
+                [compiler, "-E", "-x", "c", source.name],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.warning("Cannot preprocess decompiled C: %s", e)
+        return text
+
+    if result.returncode != 0:
+        logger.warning("Cannot preprocess decompiled C: %s", result.stderr.strip())
+        return text
+    preprocessed = strip_system_headers(result.stdout)
+    for sentinel, name in restore.items():
+        preprocessed = preprocessed.replace(sentinel, name)
+    return preprocessed if preprocessed.strip() else text
 
 
 def _is_system_header(path: str) -> bool:
@@ -196,7 +339,10 @@ def resolved_source_for_binary(
 
 
 def extract_cfgs_from_source(
-    source_path: Path, sanitize_decompiled: bool = False
+    source_path: Path,
+    sanitize_decompiled: bool = False,
+    preprocess_decompiled: bool = True,
+    raise_on_error: bool = False,
 ) -> dict[str, DiGraph]:
     """Extract CFGs from a C source file using pyjoern.
 
@@ -210,16 +356,21 @@ def extract_cfgs_from_source(
             :func:`sanitize_decompiled_c` before parsing so decompiler-specific
             quirks don't drop the function from GED. Never applied to ``.i`` files
             — sanitizing ground truth would be wrong.
+        preprocess_decompiled: Expand local preprocessing directives after
+            sanitization. Disable only to reproduce historical decompiled-side
+            CFG inputs for an audit.
+        raise_on_error: Propagate parser failures instead of treating them as an
+            empty parse. Batch reevaluation uses this to keep failed work pending.
 
     Returns:
         Dictionary mapping function names to CFG DiGraphs
     """
     try:
         from pyjoern import parse_source
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
-        )
+        ) from e
 
     cfgs = {}
     # Joern names its workspace after the input basename, so a unique temp name is
@@ -231,6 +382,8 @@ def extract_cfgs_from_source(
         text = source_path.read_text(errors="replace")
         if sanitize_decompiled:
             text = sanitize_decompiled_c(text)
+            if preprocess_decompiled:
+                text = preprocess_decompiled_c(text)
         temp_c_path.write_text(text)
     parse_path = temp_c_path
 
@@ -238,6 +391,8 @@ def extract_cfgs_from_source(
         parsed = parse_source(parse_path)
 
         if parsed is None:
+            if raise_on_error:
+                raise RuntimeError(f"Joern returned no parse result for {source_path}")
             return cfgs
 
         for key, func in parsed.items():
@@ -249,6 +404,8 @@ def extract_cfgs_from_source(
 
     except Exception as e:
         logger.warning("CFG extraction from source %s failed: %s", source_path, e)
+        if raise_on_error:
+            raise
     finally:
         if temp_c_path is not None:
             temp_c_path.unlink(missing_ok=True)
@@ -269,18 +426,19 @@ def extract_cfgs_from_decompilation(
     """
     try:
         from pyjoern import parse_source
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "pyjoern is required for CFG extraction. " "Install with: pip install pyjoern"
-        )
+        ) from e
 
     cfgs = {}
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
-        for func in decompilation.functions.values():
-            f.write(f"// Function: {func.name}\n")
-            f.write(sanitize_decompiled_c(func.decompiled_code))
-            f.write("\n\n")
+        marked_sources = [
+            (f"// Function: {func.name}\n" f"{sanitize_decompiled_c(func.decompiled_code)}")
+            for func in decompilation.functions.values()
+        ]
+        f.write(preprocess_decompiled_c("\n\n".join(marked_sources)))
 
         temp_path = Path(f.name)
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -265,6 +265,9 @@ and sanitized candidate text and uses published candidate coverage, the old
 the parse mode for each slice. Conflicting evidence aborts the refresh;
 indistinguishable modes remain explicit and are replayed both ways by the
 historical-isomorphism audit.
+The promotion projection always includes the built-in decompilers plus any
+external IDs explicitly named by `DECBENCH_REEVAL_DECOMPILERS`; its exact slice
+set is written to `ged_new.slices.json` and hash-bound into the audit.
 After a complete refresh, `scripts/audit_historical_ged_iso.py <tree>
 [workers]` classifies historical isomorphism for every pair reconstructed as
 crossing the old 60-node cutoff. Every pair is reparsed with the historical

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -190,7 +190,7 @@ DECBENCH_WORKERS=40 GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1 \
 
 - `DECBENCH_DECOMPILERS` (default `angr,ghidra`)
 - `DECBENCH_DECOMPILE_TIMEOUT` (s, default 300)
-- `DECBENCH_GED_MAX_NODES` (60; read in `metrics/ged.py`, takes effect during
+- `DECBENCH_GED_MAX_NODES` (200; read in `metrics/ged.py`, takes effect during
   runs)
 - `DECBENCH_OPT_LEVELS` (comma list, e.g. `"O0"` to narrow the run)
 - `DECBENCH_METRICS` (comma list, e.g. `"ged"` for a GED-only run)
@@ -245,10 +245,42 @@ to the project's own source functions via DWARF `decl_file`
 (`project_source_functions`), (b) imposes a hard per-binary timeout via
 killable subprocess, (c) recovers partial results on timeout
 (`decompile_binary(progress_path=...)` pickles after each function), and
-(d) caps exact GED to CFGs ≤ `DECBENCH_GED_MAX_NODES` nodes
-(super-polynomial; a few huge optimized CFGs otherwise dominate). These make
-angr tractable and bound the run; default in-process `decbench run` does none
-of them.
+(d) runs directed graph isomorphism for every CFG pair, then caps VJ-GED to
+non-isomorphic CFGs ≤ `DECBENCH_GED_MAX_NODES` nodes. VJ-GED uses a compiled
+linear-assignment solver with the same cost model as cfgutils' pure-Python
+Munkres implementation. A few still-larger optimized CFGs otherwise dominate.
+These make angr tractable and bound the run; default in-process `decbench run`
+does none of them.
+
+`scripts/reeval_ged.py` requires `DECBENCH_GED_BASELINE` to name a frozen
+published FunctionData JSON and `DECBENCH_GED_HISTORICAL_SLICES` to name the
+matching frozen `ged_new.slices.json`. The score aggregate cannot distinguish
+overlay values from inline values, so it is not a substitute for the sidecar.
+The driver validates both files before writing, records their
+paths and hashes in the audit, and binds each checkpoint to its historical
+source basis plus a digest of that slice's frozen scores. Legacy overlays span
+both sides of the decompiled-C sanitizer change, so the driver parses both raw
+and sanitized candidate text and uses published candidate coverage, the old
+60-node fallback identity, and the exact pre-cutoff VJ-GED identity to recover
+the parse mode for each slice. Conflicting evidence aborts the refresh;
+indistinguishable modes remain explicit and are replayed both ways by the
+historical-isomorphism audit.
+After a complete refresh, `scripts/audit_historical_ged_iso.py <tree>
+[workers]` classifies historical isomorphism for every pair reconstructed as
+crossing the old 60-node cutoff. Every pair is reparsed with the historical
+generated-C preprocessing behavior and passed to directed role-aware NetworkX
+isomorphism, including pairs whose unequal node or edge counts let NetworkX
+reject them immediately. Each record also compares its reconstructed size
+fallback with the frozen published score. A missing replayed graph or fallback
+mismatch aborts the exact audit instead of fabricating evidence or claiming
+that today's parser reproduced the historical graph sizes.
+Legacy-overlay candidates use the evidence-reconciled
+raw/sanitized mode stored in the score checkpoint. If the frozen outputs cannot
+distinguish the two modes, both graphs must give the same directed role-aware
+isomorphism result. Newer, inline-only candidates retain the sanitizer used by
+their original evaluation. The pass is resumable under
+`reeval_ged_historical_iso/`, verifies the score overlay and audit projection
+before promotion, and enriches only `ged_large_graph_audit.json`.
 
 Other driver facts:
 
@@ -329,6 +361,19 @@ inline values — and `function_results.json` is only ever written through
 corrected values (sanitized decompiled parses, per-TU source matching,
 non-finite dropped, compilability fixup); the per-project checkpoints still
 hold the ORIGINAL inline values from each decompiler's first evaluation.
+
+`reeval_ged.py` signs each per-slice checkpoint with the GED cache version,
+node limit, audit schema, historical source basis, and frozen-score evidence
+digest, so a metric, provenance, or baseline change invalidates the old
+reevaluation instead of silently reusing it. A semantic refresh promotes
+`ged_new.json` only after every current artifact slice has a matching
+checkpoint. Its source CFG caches are keyed by optimization level and by the
+content of the stripped `.i` input; O0 source CFGs must never be reused for O2
+or O2-noinline merely because the project is the same. It also writes
+`ged_large_graph_audit.json`, containing separate per-decompiler censuses for
+the CFG inputs seen by the historical 60-node evaluator and the corrected
+same-optimization/macro-expanded inputs, graph sizes and methods, and old/new
+score changes against the required frozen `DECBENCH_GED_BASELINE`.
 
 The canonical rebuild is `scripts/finalize_results.py <tree>` (also what
 `run_benchmark.py`'s finalize calls): ALL checkpoints (never scoped — a

--- a/docs/dataset-publishing.md
+++ b/docs/dataset-publishing.md
@@ -290,6 +290,11 @@ rebuilds from these JSONs are structurally identical to the ones
 binaries, and every one of the 97 scored functions has a scorable source CFG
 (the published union managed 76).
 
+For score reproduction, pass the rebuilt graph and the decompiled CFG through
+`GEDMetric.compute_for_function`; do not call `cfgutils.similarity.vj_ged`
+directly. `GEDMetric` owns the isomorphism-first fast path, the VJ-GED size
+limit, and the non-isomorphic large-graph fallback used for stored scores.
+
 ## 6. `.gitattributes` (LFS)
 
 The published binaries have no extension, so the publisher adds its own rules so

--- a/docs/dataset-publishing.md
+++ b/docs/dataset-publishing.md
@@ -220,13 +220,14 @@ Counts come from the actual walk (do not hardcode). Config descriptions mirror
 
 ## 5. Source-CFG serialization — `pipeline_data/source_cfgs/<opt>/<project>/<stem>.json`
 
-**GED is almost purely structural** — `cfgutils.similarity.vj_ged` (the
-metric's engine) scores from graph topology (per-node parent/child counts via a
-positional `GraphCache`) **plus** each node's `is_entrypoint` / `is_exitpoint`
-flags (an entry/exit mismatch penalty); it never reads labels or any other
-attribute. So a lossless serialization is the topology plus the entry/exit node
-ids, and nothing else. Store, per binary, the `function → CFG` map the pipeline
-used:
+**GED is almost purely structural** — the metric first performs directed
+NetworkX isomorphism over graph topology plus each node's `is_entrypoint` /
+`is_exitpoint` roles. Non-isomorphic graphs within the configured size limit
+then use DecBench's compiled linear-assignment implementation of cfgutils's
+VJ-GED cost model, whose node costs use parent/child counts plus those same
+entry/exit roles; labels and other attributes are never read.
+So a lossless serialization is the topology plus the entry/exit node ids, and
+nothing else. Store, per binary, the `function → CFG` map the pipeline used:
 
 ```jsonc
 {

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -650,6 +650,8 @@ numbers are the overlays, not the checkpoint inline values — see
 # 1. Refresh the GED + byte_match overlays, extending each script's default
 #    decompiler list with the new id (DECBENCH_REEVAL_DECOMPILERS overrides the
 #    hardcoded tuple; keep the defaults, add yours):
+DECBENCH_GED_BASELINE=/path/to/frozen-function-results.json \
+DECBENCH_GED_HISTORICAL_SLICES=/path/to/frozen-ged-overlay-slices.json \
 DECBENCH_REEVAL_DECOMPILERS=angr,ghidra,ida,binja,kuna,r2dec,dewolf,codex,claude-code,mydec \
   python scripts/reeval_ged.py results/full_run 16
 DECBENCH_REEVAL_DECOMPILERS=angr,ghidra,ida,binja,kuna,r2dec,dewolf,mydec \

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,16 +8,32 @@ before changing any of them — and bump the metric's `cache_version` if you do
 
 ## Structural Correctness — GED (`metrics/ged.py`)
 
-CFG Graph Edit Distance between source and decompiled code. The engine is
-`cfgutils.similarity.vj_ged`, which is almost purely structural: it scores
-graph topology plus each node's `is_entrypoint`/`is_exitpoint` flags and never
-reads labels (which is what makes the published source-CFG serialization
+CFG Graph Edit Distance between source and decompiled code. A directed
+NetworkX isomorphism check handles perfect matches; non-isomorphic graphs use
+the cfgutils VJ-GED cost model or the large-graph lower bound. DecBench solves
+VJ-GED's assignment matrix with SciPy's compiled linear-assignment solver
+instead of cfgutils' equivalent pure-Python Munkres implementation. All three
+paths read graph topology plus each node's `is_entrypoint`/`is_exitpoint` roles
+and never read labels (which makes the published source-CFG serialization
 lossless — see [dataset-publishing.md](dataset-publishing.md)).
 
-- Decompiled-side CFGs are parsed from the decompiled C via pyjoern.
-- Exact GED is super-polynomial, so runs cap it to CFGs ≤
-  `DECBENCH_GED_MAX_NODES` nodes (default 60, read in `metrics/ged.py`) — a
-  few huge optimized CFGs would otherwise dominate a run.
+- Decompiled-side CFGs are parsed from the decompiled C via pyjoern after
+  syntax sanitization and expansion of macros defined in that output. This
+  mirrors the source side's macro-expanded input; includes are removed before
+  the host preprocessor runs, and preprocessing failure falls back to the
+  sanitized text.
+- Every pair first receives a directed graph-isomorphism check that includes
+  entry/exit roles. An isomorphic pair is always GED 0, regardless of graph
+  size. Joint isomorphism-invariant neighborhood colors are attached before
+  the same NetworkX check to prune VF2's search on large, structurally similar
+  CFGs; they do not filter or approximate any pair.
+- Non-isomorphic pairs up to `DECBENCH_GED_MAX_NODES` nodes (default 200,
+  read in `metrics/ged.py`) use VJ-GED. Its compiled assignment solver is
+  score-equivalent to cfgutils' implementation and makes the 200-node default
+  practical. Larger pairs use the nonzero lower bound from their
+  node/edge-count differences so a few huge optimized CFGs cannot dominate a
+  run. The lower bound is floored at 1 after isomorphism fails, preserving the
+  contract that GED 0 means graph-isomorphic.
 
 ### Preprocessed `.i` files are REQUIRED — source CFGs come EXCLUSIVELY from them
 
@@ -25,11 +41,13 @@ lossless — see [dataset-publishing.md](dataset-publishing.md)).
 `scripts/run_benchmark.py`, and `pipeline/executor.py` (which globs
 `compiled_dir/*.i`) all build the source-side CFGs by feeding `.i` files to
 `utils/cfg.py extract_cfgs_from_source` (system headers stripped, then pyjoern
-`parse_source`). `.i` over `.c` is deliberate: Joern needs macro-expanded,
-ifdef-resolved code to parse completely — raw `.c` with unexpanded includes
-parses incompletely. Without `.i` the pipeline takes the "No preprocessed
-sources" branch and **GED is silently None for every function of the run — no
-error**.
+`parse_source`). The extractor writes that stripped `.i` text to a temporary
+file with a `.c` suffix because Joern's C frontend expects C input; it does not
+read or fall back to the project's original `.c`. `.i` over `.c` is deliberate:
+Joern needs macro-expanded, ifdef-resolved code to parse completely — raw `.c`
+with unexpanded includes parses incompletely. Without `.i` the pipeline takes
+the "No preprocessed sources" branch and **GED is silently None for every
+function of the run — no error**.
 
 byte_match/type_match don't use `.i` (`requires_source_cfg = False`;
 gcc-recompile and DWARF respectively), and sample source extraction only
@@ -42,8 +60,10 @@ cannot score type_match.
 
 Source-side matching is per-TU: `pipeline/evaluate.py` matches a binary's OWN
 translation unit first, cross-TU best-by-name only as fallback (avoids
-same-name collisions across TUs). The old JOERN_FAILURES.md failure analysis
-lives in git history; Joern parse-health stats render on the site's data page.
+same-name collisions across TUs). It is also per optimization level: an O0
+source CFG is not valid ground truth for O2 merely because both inputs came
+from the same project. The old JOERN_FAILURES.md failure analysis lives in git
+history; Joern parse-health stats render on the site's data page.
 
 ## Type Correctness — `metrics/type_match.py`
 

--- a/scripts/audit_historical_ged_iso.py
+++ b/scripts/audit_historical_ged_iso.py
@@ -34,7 +34,6 @@ from decbench.utils.cfg import (
 
 if __package__:
     from scripts.reeval_ged import (
-        CANONICAL_DECOMPILERS,
         INLINE_SANITIZED,
         LEGACY_AMBIGUOUS,
         LEGACY_RAW,
@@ -52,7 +51,6 @@ if __package__:
     )
 else:
     from reeval_ged import (  # type: ignore[no-redef]
-        CANONICAL_DECOMPILERS,
         INLINE_SANITIZED,
         LEGACY_AMBIGUOUS,
         LEGACY_RAW,
@@ -537,6 +535,40 @@ def audit_bound_inputs(audit: dict[str, Any]) -> set[str]:
     return slices
 
 
+def audit_bound_promoted_slices(root: Path, audit: dict[str, Any]) -> set[str]:
+    """Verify and load the exact slice set projected into the score overlay."""
+    descriptor = audit.get("promoted_slice_manifest")
+    if not isinstance(descriptor, dict):
+        raise RuntimeError("GED audit is missing its promoted slice manifest descriptor")
+    sidecar_path = root / "ged_new.slices.json"
+    path_value = descriptor.get("path")
+    expected_sha256 = descriptor.get("sha256")
+    if (
+        not isinstance(path_value, str)
+        or Path(path_value).resolve() != sidecar_path.resolve()
+        or not isinstance(expected_sha256, str)
+        or not sidecar_path.is_file()
+        or file_sha256(sidecar_path) != expected_sha256
+    ):
+        raise RuntimeError("GED audit promoted slice manifest no longer matches")
+    slices = load_historical_slice_manifest(sidecar_path)
+    if descriptor.get("slice_count") != len(slices):
+        raise RuntimeError("GED audit promoted slice manifest count differs")
+    return slices
+
+
+def promoted_artifacts(root: Path, promoted_slices: set[str]) -> list[Artifact]:
+    """Resolve exactly the artifacts named by the promoted slice sidecar."""
+    decompilers = tuple(sorted({slice_key.split("::", 3)[3] for slice_key in promoted_slices}))
+    rows = build_artifacts(root, decompilers, None)
+    selected = [row for row in rows if f"{row[0]}::{row[1]}::{row[2]}::{row[3]}" in promoted_slices]
+    observed = {f"{row[0]}::{row[1]}::{row[2]}::{row[3]}" for row in selected}
+    if observed != promoted_slices:
+        missing = sorted(promoted_slices - observed)
+        raise RuntimeError(f"promoted GED artifacts are missing: {missing[:10]}")
+    return selected
+
+
 def verify_overlay_projection(
     root: Path,
     slice_keys: set[str],
@@ -874,9 +906,10 @@ def run_audit(root: Path, workers: int) -> dict[str, Any]:
     audit_sha256 = file_sha256(audit_path)
     audit = json.loads(audit_path.read_text())
     historical_overlay_slices = audit_bound_inputs(audit)
+    promoted_slices = audit_bound_promoted_slices(root, audit)
     baseline_path = Path(audit["comparison_baseline"]["path"])
     old_scores = load_published_ged_scores(root, baseline_path)
-    artifact_rows = build_artifacts(root, CANONICAL_DECOMPILERS, None)
+    artifact_rows = promoted_artifacts(root, promoted_slices)
     artifacts = {
         f"{opt}::{project}::{stem}::{decompiler}": Path(c_path)
         for opt, project, stem, decompiler, c_path in artifact_rows

--- a/scripts/audit_historical_ged_iso.py
+++ b/scripts/audit_historical_ged_iso.py
@@ -1,0 +1,949 @@
+#!/usr/bin/env python
+"""Prove historical large-CFG isomorphism and enrich the GED audit.
+
+This pass is intentionally independent of GED scoring. It reads canonical
+schema-6 score checkpoints, replays every reconstructable historical pair
+through directed role-aware NetworkX isomorphism, and writes resumable proof
+checkpoints below ``reeval_ged_historical_iso/``. It never changes GED score
+checkpoints, overlays, or their slice sidecar.
+
+Usage:
+    python scripts/audit_historical_ged_iso.py results/full_run [workers]
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import multiprocessing as mp
+import pickle
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from decbench.metrics.ged import _is_isomorphic
+from decbench.utils.cfg import (
+    best_source_by_name,
+    extract_cfgs_from_source,
+    resolved_source_for_binary,
+)
+
+if __package__:
+    from scripts.reeval_ged import (
+        CANONICAL_DECOMPILERS,
+        INLINE_SANITIZED,
+        LEGACY_AMBIGUOUS,
+        LEGACY_RAW,
+        LEGACY_SANITIZED,
+        SOURCE_CACHE_SCHEMA_VERSION,
+        build_artifacts,
+        checkpoint_large_graphs,
+        checkpoint_metadata,
+        checkpoint_scores,
+        checkpoint_signature,
+        load_historical_slice_manifest,
+        load_published_ged_scores,
+        source_cache_path,
+        write_json_atomic,
+    )
+else:
+    from reeval_ged import (  # type: ignore[no-redef]
+        CANONICAL_DECOMPILERS,
+        INLINE_SANITIZED,
+        LEGACY_AMBIGUOUS,
+        LEGACY_RAW,
+        LEGACY_SANITIZED,
+        SOURCE_CACHE_SCHEMA_VERSION,
+        build_artifacts,
+        checkpoint_large_graphs,
+        checkpoint_metadata,
+        checkpoint_scores,
+        checkpoint_signature,
+        load_historical_slice_manifest,
+        load_published_ged_scores,
+        source_cache_path,
+        write_json_atomic,
+    )
+
+HISTORICAL_ISO_SCHEMA_VERSION = 4
+HISTORICAL_ISO_SEMANTICS = "directed-role-aware-networkx-all-large-pairs-v3"
+_MARKER = re.compile(r"^// Function: (\S+) @ 0x[0-9a-fA-F]+\s*$", re.M)
+
+Artifact = tuple[str, str, str, str, str]
+ReplayTask = tuple[str, str, str, str, dict[str, dict[str, Any]], dict[str, Any]]
+
+
+def file_sha256(path: Path, cache: dict[Path, str] | None = None) -> str:
+    """Hash a dependency, optionally memoizing repeated source-cache paths."""
+    if cache is not None and path in cache:
+        return cache[path]
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    value = digest.hexdigest()
+    if cache is not None:
+        cache[path] = value
+    return value
+
+
+def checkpoint_path(root: Path, slice_key: str) -> Path:
+    """Return the schema-6 GED checkpoint path for a slice."""
+    return root / "reeval_ged" / f"{slice_key.replace('::', '__')}.json"
+
+
+def replay_checkpoint_path(root: Path, slice_key: str) -> Path:
+    """Return the historical-isomorphism checkpoint path for a slice."""
+    return root / "reeval_ged_historical_iso" / f"{slice_key.replace('::', '__')}.json"
+
+
+def full_key_parts(key: str) -> tuple[str, str, str, str, str]:
+    """Split a function key, rejecting malformed keys."""
+    parts = key.split("::", 4)
+    if len(parts) != 5:
+        raise ValueError(f"malformed GED function key: {key}")
+    return parts[0], parts[1], parts[2], parts[3], parts[4]
+
+
+def graph_sizes(record: dict[str, Any], prefix: str) -> tuple[int, int]:
+    """Read and validate one historical graph's node and edge counts."""
+    nodes = record.get(f"historical_{prefix}_nodes")
+    edges = record.get(f"historical_{prefix}_edges")
+    if not isinstance(nodes, int) or not isinstance(edges, int):
+        raise ValueError(f"missing historical {prefix} graph sizes")
+    if nodes < 0 or edges < 0:
+        raise ValueError(f"negative historical {prefix} graph sizes")
+    return nodes, edges
+
+
+def historical_fallback_provenance(
+    record: dict[str, Any],
+    old_value: Any,
+) -> tuple[int, bool | None, str]:
+    """Compare reconstructed sizes with the published 60-node fallback score."""
+    source_size = graph_sizes(record, "source")
+    decompiled_size = graph_sizes(record, "decompiled")
+    expected = abs(source_size[0] - decompiled_size[0]) + abs(source_size[1] - decompiled_size[1])
+    if old_value is None:
+        return expected, None, "no_published_baseline"
+    if (
+        isinstance(old_value, bool)
+        or not isinstance(old_value, (int, float))
+        or not math.isfinite(old_value)
+        or old_value < 0
+    ):
+        raise ValueError(f"invalid published historical GED value: {old_value!r}")
+    if float(old_value) == float(expected):
+        return expected, True, "published_fallback_matches_reconstructed_sizes"
+    return expected, False, "published_fallback_differs_from_reconstructed_sizes"
+
+
+def historical_iso_targets(
+    large_graph_records: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Group every historical-large pair into a literal replay slice."""
+    replay: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+    for key, record in sorted(large_graph_records.items()):
+        if not record.get("historical_over_60"):
+            continue
+        source_size = graph_sizes(record, "source")
+        decompiled_size = graph_sizes(record, "decompiled")
+        if max(source_size[0], decompiled_size[0]) <= 60:
+            raise ValueError(f"historical_over_60 has no graph over 60: {key}")
+        opt, project, stem, decompiler, function = full_key_parts(key)
+        slice_key = f"{opt}::{project}::{stem}::{decompiler}"
+        replay[slice_key][function] = record
+    return dict(replay)
+
+
+def source_paths_for_targets(
+    root: Path,
+    slice_key: str,
+    targets: dict[str, dict[str, Any]],
+) -> dict[str, Path]:
+    """Resolve every source-cache basis needed by a replay slice."""
+    opt, project, _stem, _decompiler = slice_key.split("::", 3)
+    paths: dict[str, Path] = {}
+    bases = {record.get("historical_source_basis") for record in targets.values()}
+    unknown = bases - {"legacy_overlay", "same_opt_inline"}
+    if unknown:
+        raise ValueError(f"{slice_key} has unknown historical source basis: {unknown}")
+    if "legacy_overlay" in bases:
+        paths["legacy_overlay"] = root / "ged_src" / f"{project}.pkl"
+    if "same_opt_inline" in bases:
+        paths["same_opt_inline"] = source_cache_path(
+            root / "ged_src" / f"v{SOURCE_CACHE_SCHEMA_VERSION}",
+            opt,
+            project,
+        )
+    for basis, path in paths.items():
+        if not path.is_file():
+            raise FileNotFoundError(f"{slice_key} missing {basis} source cache: {path}")
+    return paths
+
+
+def replay_dependency_meta(
+    root: Path,
+    slice_key: str,
+    artifact: Path,
+    score_checkpoint: Path,
+    targets: dict[str, dict[str, Any]],
+    hash_cache: dict[Path, str] | None = None,
+) -> dict[str, Any]:
+    """Build content-hash metadata controlling replay checkpoint reuse."""
+    source_paths = source_paths_for_targets(root, slice_key, targets)
+    return {
+        "schema_version": HISTORICAL_ISO_SCHEMA_VERSION,
+        "isomorphism_semantics": HISTORICAL_ISO_SEMANTICS,
+        "ged_checkpoint_signature": checkpoint_signature(),
+        "ged_checkpoint_sha256": file_sha256(score_checkpoint, hash_cache),
+        "artifact_sha256": file_sha256(artifact, hash_cache),
+        "source_cache_sha256": {
+            basis: file_sha256(path, hash_cache) for basis, path in sorted(source_paths.items())
+        },
+        "target_functions": sorted(targets),
+    }
+
+
+def load_source_map(path: Path, stem: str) -> dict[str, Any]:
+    """Load and TU-resolve one historical source-CFG cache."""
+    payload = pickle.loads(path.read_bytes())
+    if not isinstance(payload, dict):
+        raise ValueError(f"invalid source cache payload: {path}")
+    per_stem = payload.get("per_stem", payload)
+    if not isinstance(per_stem, dict):
+        raise ValueError(f"invalid per-stem source cache payload: {path}")
+    return resolved_source_for_binary(stem, per_stem, best_source_by_name(per_stem))
+
+
+def eval_historical_iso_one(task: ReplayTask) -> tuple[str, dict[str, dict], dict[str, Any]]:
+    """Strictly replay every historical-large pair in one slice."""
+    slice_key, c_path, same_opt_path, legacy_path, targets, metadata = task
+    _opt, _project, stem, _decompiler = slice_key.split("::", 3)
+    artifact = Path(c_path)
+    text = artifact.read_text(errors="replace")
+    markers = set(_MARKER.findall(text))
+    missing_markers = set(targets) - markers
+    if missing_markers:
+        raise RuntimeError(f"{slice_key} missing function markers: {sorted(missing_markers)}")
+
+    parse_modes = {record.get("historical_decompiled_parse_mode") for record in targets.values()}
+    unknown_modes = parse_modes - {
+        LEGACY_RAW,
+        LEGACY_SANITIZED,
+        LEGACY_AMBIGUOUS,
+        INLINE_SANITIZED,
+    }
+    if unknown_modes:
+        raise ValueError(f"{slice_key} has unknown historical parse modes: {unknown_modes}")
+    decompiled_maps: dict[str, dict[str, Any]] = {}
+    if LEGACY_RAW in parse_modes or LEGACY_AMBIGUOUS in parse_modes:
+        decompiled_maps[LEGACY_RAW] = extract_cfgs_from_source(
+            artifact,
+            sanitize_decompiled=False,
+            preprocess_decompiled=False,
+            raise_on_error=True,
+        )
+    if (
+        LEGACY_SANITIZED in parse_modes
+        or LEGACY_AMBIGUOUS in parse_modes
+        or INLINE_SANITIZED in parse_modes
+    ):
+        sanitized_map = extract_cfgs_from_source(
+            artifact,
+            sanitize_decompiled=True,
+            preprocess_decompiled=False,
+            raise_on_error=True,
+        )
+        decompiled_maps[LEGACY_SANITIZED] = sanitized_map
+        decompiled_maps[INLINE_SANITIZED] = sanitized_map
+    source_maps: dict[str, dict[str, Any]] = {}
+    if any(r["historical_source_basis"] == "same_opt_inline" for r in targets.values()):
+        source_maps["same_opt_inline"] = load_source_map(Path(same_opt_path), stem)
+    if any(r["historical_source_basis"] == "legacy_overlay" for r in targets.values()):
+        source_maps["legacy_overlay"] = load_source_map(Path(legacy_path), stem)
+
+    proofs: dict[str, dict] = {}
+    for function, record in sorted(targets.items()):
+        source_cfg = source_maps[record["historical_source_basis"]].get(function)
+        parse_mode = record["historical_decompiled_parse_mode"]
+        if parse_mode == LEGACY_AMBIGUOUS:
+            candidate_cfgs = [
+                decompiled_maps[LEGACY_RAW].get(function),
+                decompiled_maps[LEGACY_SANITIZED].get(function),
+            ]
+        else:
+            candidate_cfgs = [decompiled_maps[parse_mode].get(function)]
+        decompiled_cfg = candidate_cfgs[0]
+        if source_cfg is None or decompiled_cfg is None:
+            raise RuntimeError(f"{slice_key}::{function} missing replayed historical CFG")
+        expected_source = graph_sizes(record, "source")
+        expected_decompiled = graph_sizes(record, "decompiled")
+        actual_source = (source_cfg.number_of_nodes(), source_cfg.number_of_edges())
+        actual_decompiled = (
+            decompiled_cfg.number_of_nodes(),
+            decompiled_cfg.number_of_edges(),
+        )
+        if actual_source != expected_source:
+            raise RuntimeError(
+                f"{slice_key}::{function} source sizes changed: "
+                f"{actual_source} != {expected_source}"
+            )
+        if actual_decompiled != expected_decompiled:
+            raise RuntimeError(
+                f"{slice_key}::{function} decompiled sizes changed: "
+                f"{actual_decompiled} != {expected_decompiled}"
+            )
+        if parse_mode == LEGACY_AMBIGUOUS:
+            if candidate_cfgs[1] is None:
+                raise RuntimeError(f"{slice_key}::{function} missing sanitized ambiguous CFG")
+            alternate_size = (
+                candidate_cfgs[1].number_of_nodes(),
+                candidate_cfgs[1].number_of_edges(),
+            )
+            if alternate_size != expected_decompiled:
+                raise RuntimeError(
+                    f"{slice_key}::{function} ambiguous graph sizes differ: "
+                    f"{actual_decompiled} != {alternate_size}"
+                )
+            isomorphic_results = {
+                bool(_is_isomorphic(source_cfg, candidate)) for candidate in candidate_cfgs
+            }
+            if len(isomorphic_results) != 1:
+                raise RuntimeError(
+                    f"{slice_key}::{function} legacy parse modes disagree on "
+                    "historical isomorphism"
+                )
+            historical_isomorphic = isomorphic_results.pop()
+            proof_method = "directed_role_aware_networkx_replay_both_legacy_modes"
+            networkx_calls = 2
+        else:
+            historical_isomorphic = bool(_is_isomorphic(source_cfg, decompiled_cfg))
+            proof_method = "directed_role_aware_networkx_replay"
+            networkx_calls = 1
+        proofs[function] = {
+            "historical_isomorphic": historical_isomorphic,
+            "historical_iso_proof": proof_method,
+            "historical_replay_verified": True,
+            "historical_networkx_calls": networkx_calls,
+            "historical_graph_counts_match": expected_source == expected_decompiled,
+        }
+    return slice_key, proofs, metadata
+
+
+def valid_replay_checkpoint(
+    path: Path,
+    metadata: dict[str, Any],
+    target_functions: set[str],
+) -> dict[str, dict] | None:
+    """Return proofs from a complete current replay checkpoint."""
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    proofs = payload.get("proofs")
+    if payload.get("_meta") != metadata or not isinstance(proofs, dict):
+        return None
+    if set(proofs) != target_functions:
+        return None
+    for proof in proofs.values():
+        if not isinstance(proof, dict):
+            return None
+        proof_method = proof.get("historical_iso_proof")
+        expected_calls = (
+            2 if proof_method == "directed_role_aware_networkx_replay_both_legacy_modes" else 1
+        )
+        if (
+            not isinstance(proof.get("historical_isomorphic"), bool)
+            or proof_method
+            not in {
+                "directed_role_aware_networkx_replay",
+                "directed_role_aware_networkx_replay_both_legacy_modes",
+            }
+            or proof.get("historical_replay_verified") is not True
+            or proof.get("historical_networkx_calls") != expected_calls
+            or not isinstance(proof.get("historical_graph_counts_match"), bool)
+        ):
+            return None
+    return proofs
+
+
+def verify_audit_projection(
+    audit: dict[str, Any],
+    signature: dict[str, Any],
+    merged_scores: dict[str, dict],
+    large_graph_records: dict[str, dict],
+    old_scores: dict[str, dict],
+) -> None:
+    """Require the frozen-baseline audit to describe the checkpoint projection."""
+    if audit.get("new_evaluator") != signature:
+        raise RuntimeError("GED audit evaluator signature does not match checkpoints")
+    coverage = audit.get("coverage") or {}
+    if coverage.get("published_scores_before") != len(old_scores):
+        raise RuntimeError("GED audit baseline coverage does not match frozen scores")
+    if coverage.get("scores_after_reevaluation") != len(merged_scores):
+        raise RuntimeError("GED audit score coverage does not match checkpoints")
+    audit_records = audit.get("records")
+    if not isinstance(audit_records, dict) or set(audit_records) != set(large_graph_records):
+        raise RuntimeError("GED audit large-graph keys do not match checkpoints")
+
+    aliases = {
+        "isomorphic": "corrected_isomorphic",
+        "method": "corrected_method",
+        "approximated": "corrected_approximated",
+    }
+    for key, expected in large_graph_records.items():
+        actual = audit_records[key]
+        for field, value in expected.items():
+            alias = aliases.get(field)
+            if field in actual:
+                observed = actual[field]
+            elif alias is not None and alias in actual:
+                observed = actual[alias]
+            else:
+                raise RuntimeError(f"GED audit record {key} is missing {field}")
+            if observed != value:
+                raise RuntimeError(f"GED audit record {key} differs at {field}")
+        score = merged_scores.get(key)
+        expected_value = float(score["value"]) if score is not None else None
+        if actual.get("new_value") != expected_value:
+            raise RuntimeError(f"GED audit record {key} has a stale new score")
+        old_score = old_scores.get(key)
+        expected_old_value = float(old_score["value"]) if old_score is not None else None
+        expected_old_perfect = expected_old_value == 0.0 if expected_old_value is not None else None
+        if actual.get("old_value") != expected_old_value:
+            raise RuntimeError(f"GED audit record {key} has a stale old score")
+        if actual.get("old_perfect") != expected_old_perfect:
+            raise RuntimeError(f"GED audit record {key} has stale old perfectness")
+
+
+def checkpoint_projection(
+    root: Path,
+    artifacts: list[Artifact],
+    signature: dict[str, Any],
+    historical_overlay_slices: set[str],
+    old_scores: dict[str, dict],
+) -> tuple[dict[str, Path], dict[str, dict], dict[str, dict]]:
+    """Load and validate every canonical schema-6 checkpoint."""
+    old_values_by_slice: dict[str, dict[str, float]] = defaultdict(dict)
+    for key, score in old_scores.items():
+        slice_key, function = key.rsplit("::", 1)
+        old_values_by_slice[slice_key][function] = float(score["value"])
+    checkpoints: dict[str, Path] = {}
+    merged: dict[str, dict] = {}
+    large: dict[str, dict] = {}
+    for opt, project, stem, decompiler, c_path in artifacts:
+        slice_key = f"{opt}::{project}::{stem}::{decompiler}"
+        if slice_key in checkpoints:
+            raise RuntimeError(f"duplicate canonical artifact slice: {slice_key}")
+        path = checkpoint_path(root, slice_key)
+        if not path.is_file():
+            raise RuntimeError(f"missing schema-6 GED checkpoint: {slice_key}")
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, ValueError) as error:
+            raise RuntimeError(f"unreadable GED checkpoint: {path}") from error
+        historical_overlay_covered = slice_key in historical_overlay_slices
+        if payload.get("_meta") != checkpoint_metadata(
+            signature,
+            historical_overlay_covered,
+            old_values_by_slice.get(slice_key, {}),
+        ):
+            raise RuntimeError(f"stale GED checkpoint signature: {slice_key}")
+        current_source = source_cache_path(
+            root / "ged_src" / f"v{SOURCE_CACHE_SCHEMA_VERSION}",
+            opt,
+            project,
+        )
+        if not current_source.is_file():
+            raise RuntimeError(f"missing current source cache: {current_source}")
+        dependencies = [Path(c_path), current_source]
+        legacy_source = root / "ged_src" / f"{project}.pkl"
+        if legacy_source.is_file():
+            dependencies.append(legacy_source)
+        if path.stat().st_mtime_ns < max(dep.stat().st_mtime_ns for dep in dependencies):
+            raise RuntimeError(f"GED checkpoint is older than an input: {slice_key}")
+        checkpoints[slice_key] = path
+        for function, score in checkpoint_scores(payload).items():
+            merged[f"{slice_key}::{function}"] = score
+        expected_basis = "legacy_overlay" if historical_overlay_covered else "same_opt_inline"
+        for function, record in checkpoint_large_graphs(payload).items():
+            if record.get("historical_source_basis") != expected_basis:
+                raise RuntimeError(f"incoherent historical source basis: {slice_key}::{function}")
+            parse_mode = record.get("historical_decompiled_parse_mode")
+            allowed_modes = (
+                {LEGACY_RAW, LEGACY_SANITIZED, LEGACY_AMBIGUOUS}
+                if historical_overlay_covered
+                else {INLINE_SANITIZED}
+            )
+            if parse_mode not in allowed_modes:
+                raise RuntimeError(f"incoherent historical parse mode: {slice_key}::{function}")
+            raw_present = record.get("historical_raw_candidate_present")
+            sanitized_present = record.get("historical_sanitized_candidate_present")
+            if not isinstance(raw_present, bool) or not isinstance(sanitized_present, bool):
+                raise RuntimeError(
+                    f"missing historical candidate evidence: {slice_key}::{function}"
+                )
+            historical_candidate_recorded = record.get("historical_decompiled_nodes") is not None
+            if historical_candidate_recorded and parse_mode == LEGACY_RAW and not raw_present:
+                raise RuntimeError(f"raw historical candidate is absent: {slice_key}::{function}")
+            if (
+                historical_candidate_recorded
+                and parse_mode in {LEGACY_SANITIZED, INLINE_SANITIZED}
+                and not sanitized_present
+            ):
+                raise RuntimeError(
+                    f"sanitized historical candidate is absent: {slice_key}::{function}"
+                )
+            if (
+                historical_candidate_recorded
+                and parse_mode == LEGACY_AMBIGUOUS
+                and not (raw_present and sanitized_present)
+            ):
+                raise RuntimeError(
+                    f"ambiguous historical candidates are incomplete: " f"{slice_key}::{function}"
+                )
+            large[f"{slice_key}::{function}"] = record
+    return checkpoints, merged, large
+
+
+def audit_bound_inputs(audit: dict[str, Any]) -> set[str]:
+    """Verify the frozen score baseline and historical overlay manifest."""
+    baseline = audit.get("comparison_baseline")
+    manifest = audit.get("historical_overlay_manifest")
+    for name, descriptor in (
+        ("comparison baseline", baseline),
+        ("historical overlay manifest", manifest),
+    ):
+        if not isinstance(descriptor, dict):
+            raise RuntimeError(f"GED audit is missing its {name} descriptor")
+        path_value = descriptor.get("path")
+        expected_sha256 = descriptor.get("sha256")
+        if not isinstance(path_value, str) or not isinstance(expected_sha256, str):
+            raise RuntimeError(f"GED audit has an invalid {name} descriptor")
+        path = Path(path_value)
+        if not path.is_file() or file_sha256(path) != expected_sha256:
+            raise RuntimeError(f"GED audit {name} no longer matches: {path}")
+    manifest_path = Path(manifest["path"])
+    slices = load_historical_slice_manifest(manifest_path)
+    if manifest.get("slice_count") != len(slices):
+        raise RuntimeError("GED audit historical overlay manifest count differs")
+    return slices
+
+
+def verify_overlay_projection(
+    root: Path,
+    slice_keys: set[str],
+    merged_scores: dict[str, dict],
+) -> None:
+    """Require the canonical overlay and sidecar to match score checkpoints."""
+    overlay_path = root / "ged_new.json"
+    sidecar_path = root / "ged_new.slices.json"
+    if not overlay_path.is_file() or not sidecar_path.is_file():
+        raise RuntimeError("GED overlay or slice sidecar is missing")
+    if json.loads(overlay_path.read_text()) != merged_scores:
+        raise RuntimeError("GED overlay does not match schema-6 checkpoints")
+    if set(json.loads(sidecar_path.read_text())) != slice_keys:
+        raise RuntimeError("GED slice sidecar does not match canonical artifact slices")
+
+
+def build_replay_tasks(
+    root: Path,
+    artifacts: dict[str, Path],
+    score_checkpoints: dict[str, Path],
+    replay_targets: dict[str, dict[str, dict[str, Any]]],
+    hash_cache: dict[Path, str] | None = None,
+) -> tuple[list[ReplayTask], dict[str, dict[str, Any]]]:
+    """Build replay tasks and their exact expected metadata."""
+    tasks: list[ReplayTask] = []
+    metadata_by_slice: dict[str, dict[str, Any]] = {}
+    for slice_key, targets in sorted(replay_targets.items()):
+        artifact = artifacts.get(slice_key)
+        score_checkpoint = score_checkpoints.get(slice_key)
+        if artifact is None or score_checkpoint is None:
+            raise RuntimeError(f"replay target is outside canonical slices: {slice_key}")
+        source_paths = source_paths_for_targets(root, slice_key, targets)
+        metadata = replay_dependency_meta(
+            root,
+            slice_key,
+            artifact,
+            score_checkpoint,
+            targets,
+            hash_cache,
+        )
+        metadata_by_slice[slice_key] = metadata
+        tasks.append(
+            (
+                slice_key,
+                str(artifact),
+                str(source_paths.get("same_opt_inline", "")),
+                str(source_paths.get("legacy_overlay", "")),
+                targets,
+                metadata,
+            )
+        )
+    return tasks, metadata_by_slice
+
+
+def collect_historical_iso_proofs(
+    root: Path,
+    artifacts: dict[str, Path],
+    score_checkpoints: dict[str, Path],
+    large_graph_records: dict[str, dict],
+    workers: int,
+) -> tuple[dict[str, dict], dict[str, int]]:
+    """Resume literal NetworkX replays and return proofs for every historical pair."""
+    replay_targets = historical_iso_targets(large_graph_records)
+    proof_dir = root / "reeval_ged_historical_iso"
+    proof_dir.mkdir(exist_ok=True)
+    tasks, metadata_by_slice = build_replay_tasks(
+        root,
+        artifacts,
+        score_checkpoints,
+        replay_targets,
+        {},
+    )
+    pending = [
+        task
+        for task in tasks
+        if valid_replay_checkpoint(
+            replay_checkpoint_path(root, task[0]),
+            task[5],
+            set(task[4]),
+        )
+        is None
+    ]
+    print(
+        f"[ged/historical-iso] {len(replay_targets)} all-pair slices, {len(pending)} pending",
+        flush=True,
+    )
+    if pending:
+        context = mp.get_context("spawn")
+        with context.Pool(processes=workers, maxtasksperchild=8) as pool:
+            for slice_key, proofs, metadata in pool.imap_unordered(
+                eval_historical_iso_one,
+                pending,
+            ):
+                write_json_atomic(
+                    replay_checkpoint_path(root, slice_key),
+                    {"_meta": metadata, "proofs": proofs},
+                )
+
+    _, final_metadata = build_replay_tasks(
+        root,
+        artifacts,
+        score_checkpoints,
+        replay_targets,
+        {},
+    )
+    if final_metadata != metadata_by_slice:
+        raise RuntimeError("historical-isomorphism inputs changed during replay")
+
+    proofs: dict[str, dict] = {}
+    for slice_key, targets in sorted(replay_targets.items()):
+        replayed = valid_replay_checkpoint(
+            replay_checkpoint_path(root, slice_key),
+            final_metadata[slice_key],
+            set(targets),
+        )
+        if replayed is None:
+            raise RuntimeError(f"historical-isomorphism replay is incomplete: {slice_key}")
+        for function, proof in replayed.items():
+            proofs[f"{slice_key}::{function}"] = proof
+
+    historical_keys = {
+        key for key, record in large_graph_records.items() if record.get("historical_over_60")
+    }
+    if set(proofs) != historical_keys:
+        raise RuntimeError("historical-isomorphism proof coverage is incomplete")
+    for key, proof in proofs.items():
+        record = large_graph_records[key]
+        source_size = graph_sizes(record, "source")
+        decompiled_size = graph_sizes(record, "decompiled")
+        if proof["historical_graph_counts_match"] != (source_size == decompiled_size):
+            raise RuntimeError(f"historical graph-count diagnostic differs: {key}")
+        ambiguous = record["historical_decompiled_parse_mode"] == LEGACY_AMBIGUOUS
+        expected_calls = 2 if ambiguous else 1
+        expected_proof = (
+            "directed_role_aware_networkx_replay_both_legacy_modes"
+            if ambiguous
+            else "directed_role_aware_networkx_replay"
+        )
+        if (
+            proof["historical_networkx_calls"] != expected_calls
+            or proof["historical_iso_proof"] != expected_proof
+        ):
+            raise RuntimeError(f"historical replay mode differs: {key}")
+    count_mismatch_replays = sum(
+        not proof["historical_graph_counts_match"] for proof in proofs.values()
+    )
+    counts = {
+        "historical_large_pairs": len(historical_keys),
+        "networkx_replayed_pairs": len(proofs),
+        "networkx_isomorphism_calls": sum(
+            proof["historical_networkx_calls"] for proof in proofs.values()
+        ),
+        "networkx_replay_slices": len(replay_targets),
+        "count_mismatch_networkx_replays": count_mismatch_replays,
+    }
+    return proofs, counts
+
+
+def _iso_summary_counts() -> dict[str, int]:
+    return {
+        "historical_confirmed_isomorphic": 0,
+        "historical_confirmed_nonisomorphic": 0,
+        "historical_isomorphism_unavailable": 0,
+        "historical_false_perfect": 0,
+        "historical_networkx_replayed_pairs": 0,
+        "historical_networkx_isomorphism_calls": 0,
+        "historical_count_mismatch_networkx_replays": 0,
+        "historical_reconstructed_fallback_matches_published": 0,
+        "historical_reconstructed_fallback_mismatches_published": 0,
+        "historical_reconstructed_fallback_without_published_score": 0,
+        "corrected_isomorphic_for_historical_over_60": 0,
+        "corrected_nonisomorphic_for_historical_over_60": 0,
+        "corrected_isomorphism_unavailable_for_historical_over_60": 0,
+    }
+
+
+def enrich_audit(
+    audit: dict[str, Any],
+    large_graph_records: dict[str, dict],
+    proofs: dict[str, dict],
+    proof_counts: dict[str, int],
+) -> dict[str, Any]:
+    """Return an audit with unambiguous historical and corrected iso fields."""
+    enriched = copy.deepcopy(audit)
+    records = enriched["records"]
+    per_decompiler: dict[str, dict[str, int]] = defaultdict(_iso_summary_counts)
+    total = _iso_summary_counts()
+
+    for key, graph_record in large_graph_records.items():
+        record = records[key]
+        corrected_isomorphic = graph_record.get("isomorphic")
+        corrected_method = graph_record.get("method")
+        corrected_approximated = graph_record.get("approximated")
+        record.pop("isomorphic", None)
+        record.pop("method", None)
+        record.pop("approximated", None)
+        record["corrected_isomorphic"] = corrected_isomorphic
+        record["corrected_method"] = corrected_method
+        record["corrected_approximated"] = corrected_approximated
+
+        proof = proofs.get(key)
+        historical_over_60 = graph_record.get("historical_over_60") is True
+        fallback_matches: bool | None = None
+        if historical_over_60:
+            if proof is None:
+                raise RuntimeError(f"missing historical isomorphism proof: {key}")
+            expected, fallback_matches, provenance = historical_fallback_provenance(
+                graph_record,
+                record.get("old_value"),
+            )
+            record["historical_size_fallback_expected_from_reconstruction"] = expected
+            record["historical_size_fallback_matches_published"] = fallback_matches
+            record["historical_size_reconstruction_provenance"] = provenance
+        else:
+            record["historical_size_fallback_expected_from_reconstruction"] = None
+            record["historical_size_fallback_matches_published"] = None
+            record["historical_size_reconstruction_provenance"] = "not_historical_over_60"
+        record["historical_isomorphic"] = (
+            proof["historical_isomorphic"] if proof is not None else None
+        )
+        record["historical_iso_proof"] = (
+            proof["historical_iso_proof"] if proof is not None else None
+        )
+        record["historical_replay_verified"] = (
+            proof["historical_replay_verified"] if proof is not None else None
+        )
+        record["historical_networkx_calls"] = (
+            proof["historical_networkx_calls"] if proof is not None else None
+        )
+        record["historical_graph_counts_match"] = (
+            proof["historical_graph_counts_match"] if proof is not None else None
+        )
+
+        decompiler = full_key_parts(key)[3]
+        increments = _iso_summary_counts()
+        if historical_over_60:
+            increments["historical_confirmed_isomorphic"] = int(
+                proof is not None and proof["historical_isomorphic"] is True
+            )
+            increments["historical_confirmed_nonisomorphic"] = int(
+                proof is not None and proof["historical_isomorphic"] is False
+            )
+            increments["historical_isomorphism_unavailable"] = int(
+                proof is not None and proof["historical_isomorphic"] is None
+            )
+            increments["historical_false_perfect"] = int(
+                proof is not None
+                and proof["historical_isomorphic"] is False
+                and record.get("old_value") == 0.0
+                and fallback_matches is True
+            )
+            increments["historical_networkx_replayed_pairs"] = int(
+                proof is not None and proof["historical_replay_verified"] is True
+            )
+            increments["historical_networkx_isomorphism_calls"] = (
+                proof["historical_networkx_calls"] if proof is not None else 0
+            )
+            increments["historical_count_mismatch_networkx_replays"] = int(
+                proof is not None
+                and proof["historical_graph_counts_match"] is False
+                and proof["historical_replay_verified"] is True
+            )
+            increments["historical_reconstructed_fallback_matches_published"] = int(
+                fallback_matches is True
+            )
+            increments["historical_reconstructed_fallback_mismatches_published"] = int(
+                fallback_matches is False
+            )
+            increments["historical_reconstructed_fallback_without_published_score"] = int(
+                fallback_matches is None
+            )
+            increments["corrected_isomorphic_for_historical_over_60"] = int(
+                corrected_isomorphic is True
+            )
+            increments["corrected_nonisomorphic_for_historical_over_60"] = int(
+                corrected_isomorphic is False
+            )
+            increments["corrected_isomorphism_unavailable_for_historical_over_60"] = int(
+                corrected_isomorphic is None
+            )
+        for name, increment in increments.items():
+            per_decompiler[decompiler][name] += increment
+            total[name] += increment
+
+    historical_classifications = (
+        total["historical_confirmed_isomorphic"]
+        + total["historical_confirmed_nonisomorphic"]
+        + total["historical_isomorphism_unavailable"]
+    )
+    if historical_classifications != proof_counts["historical_large_pairs"]:
+        raise RuntimeError("historical isomorphism summary coverage is incomplete")
+    if (
+        total["historical_networkx_replayed_pairs"] != proof_counts["networkx_replayed_pairs"]
+        or total["historical_networkx_isomorphism_calls"]
+        != proof_counts["networkx_isomorphism_calls"]
+        or total["historical_count_mismatch_networkx_replays"]
+        != proof_counts["count_mismatch_networkx_replays"]
+    ):
+        raise RuntimeError("historical NetworkX replay summary is inconsistent")
+    fallback_classifications = (
+        total["historical_reconstructed_fallback_matches_published"]
+        + total["historical_reconstructed_fallback_mismatches_published"]
+        + total["historical_reconstructed_fallback_without_published_score"]
+    )
+    if fallback_classifications != proof_counts["historical_large_pairs"]:
+        raise RuntimeError("historical fallback provenance coverage is incomplete")
+
+    summary = enriched["summary"]
+    summary["total"].pop("confirmed_isomorphic", None)
+    summary["total"].update(total)
+    for decompiler, counts in summary["by_decompiler"].items():
+        counts.pop("confirmed_isomorphic", None)
+        counts.update(per_decompiler[decompiler])
+
+    enriched.setdefault("census_basis", {})["historical"] = (
+        "Published evaluator inputs: legacy project cache for overlay scores, "
+        "same-optimization source for inline scores, evidence-reconciled raw or "
+        "sanitized generated C for legacy-overlay scores, and sanitized generated "
+        "C without local macro expansion for inline-only scores"
+    )
+    enriched["historical_isomorphism_audit"] = {
+        "schema_version": HISTORICAL_ISO_SCHEMA_VERSION,
+        "isomorphism_semantics": HISTORICAL_ISO_SEMANTICS,
+        **proof_counts,
+    }
+    return enriched
+
+
+def run_audit(root: Path, workers: int) -> dict[str, Any]:
+    """Run the standalone historical-isomorphism audit."""
+    signature = checkpoint_signature()
+    audit_path = root / "ged_large_graph_audit.json"
+    if not audit_path.is_file():
+        raise RuntimeError(f"GED large-graph audit is missing: {audit_path}")
+    audit_sha256 = file_sha256(audit_path)
+    audit = json.loads(audit_path.read_text())
+    historical_overlay_slices = audit_bound_inputs(audit)
+    baseline_path = Path(audit["comparison_baseline"]["path"])
+    old_scores = load_published_ged_scores(root, baseline_path)
+    artifact_rows = build_artifacts(root, CANONICAL_DECOMPILERS, None)
+    artifacts = {
+        f"{opt}::{project}::{stem}::{decompiler}": Path(c_path)
+        for opt, project, stem, decompiler, c_path in artifact_rows
+    }
+    if len(artifacts) != len(artifact_rows):
+        raise RuntimeError("canonical artifact list contains duplicate slices")
+    score_checkpoints, merged_scores, large_graph_records = checkpoint_projection(
+        root,
+        artifact_rows,
+        signature,
+        historical_overlay_slices,
+        old_scores,
+    )
+    verify_overlay_projection(root, set(artifacts), merged_scores)
+
+    verify_audit_projection(
+        audit,
+        signature,
+        merged_scores,
+        large_graph_records,
+        old_scores,
+    )
+    proofs, proof_counts = collect_historical_iso_proofs(
+        root,
+        artifacts,
+        score_checkpoints,
+        large_graph_records,
+        workers,
+    )
+    enriched = enrich_audit(
+        audit,
+        large_graph_records,
+        proofs,
+        proof_counts,
+    )
+    if enriched["summary"]["total"]["historical_reconstructed_fallback_mismatches_published"]:
+        raise RuntimeError(
+            "historical fallback reconstruction differs from frozen published scores"
+        )
+    verify_audit_projection(
+        enriched,
+        signature,
+        merged_scores,
+        large_graph_records,
+        old_scores,
+    )
+    if file_sha256(audit_path) != audit_sha256:
+        raise RuntimeError("GED large-graph audit changed during historical replay")
+    write_json_atomic(audit_path, enriched, indent=2)
+    print(
+        f"[ged/historical-iso] enriched {audit_path} with "
+        f"{proof_counts['historical_large_pairs']} classifications",
+        flush=True,
+    )
+    return enriched
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tree", type=Path)
+    parser.add_argument("workers", nargs="?", type=int, default=12)
+    args = parser.parse_args()
+    if args.workers < 1:
+        parser.error("workers must be at least 1")
+    run_audit(args.tree, args.workers)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -10,25 +10,47 @@ functions. This re-scores GED to reflect that.
 
 Two stages, both parallel via the 'spawn' context (fork deadlocks once angr's
 threads are live):
-  A. source CFGs per project (from the O0 .i — source is identical across opt
-     levels), cached to <results>/ged_src/<project>.pkl
+  A. source CFGs per (optimization, project), content-deduplicated across
+     identical stripped .i files and cached below <results>/ged_src/v*/
   B. per (opt, project, binary, dec): parse the stored decompiled .c, compute GED
      for every function whose source CFG exists -> <results>/ged_new.json mapping
      opt::project::binary::dec::func -> {"value": float, "perfect": bool}.
 
+The pass also writes ged_large_graph_audit.json. It separately records the
+historical CFG inputs that crossed the published 60-node cutoff and the
+corrected same-optimization/macro-expanded inputs, plus old/new score changes
+for the whole published GED column.
+
 Usage:  python scripts/reeval_ged.py results/full_run [workers] [only-projects...]
+
+Requires DECBENCH_GED_BASELINE and DECBENCH_GED_HISTORICAL_SLICES so every
+checkpoint is bound to immutable published score and overlay provenance.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 import multiprocessing as mp
 import os
 import pickle
 import sys
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
-DECOMPILERS = (
+PREVIOUS_GED_MAX_NODES = 60
+CHECKPOINT_SCHEMA_VERSION = 6
+SOURCE_CACHE_SCHEMA_VERSION = 1
+HISTORICAL_CANDIDATE_PARSE = "legacy-overlay-evidence-reconciled-v3"
+
+LEGACY_RAW = "legacy_raw"
+LEGACY_SANITIZED = "legacy_sanitized"
+LEGACY_AMBIGUOUS = "legacy_raw_or_sanitized_same_fallback"
+INLINE_SANITIZED = "sanitized_without_macro_expansion"
+
+CANONICAL_DECOMPILERS = (
     "angr",
     "ghidra",
     "ida",
@@ -38,70 +60,696 @@ DECOMPILERS = (
     "dewolf",
     "codex",
     "claude-code",
+    "manifold",
 )
+SELECTED_DECOMPILERS = CANONICAL_DECOMPILERS
 if os.environ.get("DECBENCH_REEVAL_DECOMPILERS"):
-    DECOMPILERS = tuple(
+    SELECTED_DECOMPILERS = tuple(
         d.strip() for d in os.environ["DECBENCH_REEVAL_DECOMPILERS"].split(",") if d.strip()
     )
 OPT_LEVELS = ("O0", "O2", "O2-noinline")
 SRC_OPT = "O0"
 
 
+def checkpoint_signature() -> dict[str, int | str]:
+    from decbench.metrics.ged import GED_MAX_NODES, GEDMetric
+
+    return {
+        "schema_version": CHECKPOINT_SCHEMA_VERSION,
+        "source_cache_schema": SOURCE_CACHE_SCHEMA_VERSION,
+        "metric_cache_version": GEDMetric.cache_version,
+        "ged_max_nodes": GED_MAX_NODES,
+        "audit_threshold": PREVIOUS_GED_MAX_NODES,
+        "historical_candidate_parse": HISTORICAL_CANDIDATE_PARSE,
+    }
+
+
+def checkpoint_metadata(
+    signature: dict[str, int | str],
+    historical_overlay_covered: bool,
+    old_values: dict[str, float] | None = None,
+) -> dict[str, int | str]:
+    metadata: dict[str, int | str] = {
+        **signature,
+        "historical_source_basis": (
+            "legacy_overlay" if historical_overlay_covered else "same_opt_inline"
+        ),
+    }
+    if historical_overlay_covered:
+        encoded = json.dumps(
+            sorted((old_values or {}).items()),
+            separators=(",", ":"),
+        ).encode()
+        metadata["historical_score_evidence_sha256"] = hashlib.sha256(encoded).hexdigest()
+    else:
+        metadata["historical_score_evidence_sha256"] = "not_applicable"
+    return metadata
+
+
+def _size_fallback_value(source_cfg: Any, decompiled_cfg: Any) -> int | None:
+    if source_cfg is None or decompiled_cfg is None:
+        return None
+    if (
+        source_cfg.number_of_nodes() <= PREVIOUS_GED_MAX_NODES
+        and decompiled_cfg.number_of_nodes() <= PREVIOUS_GED_MAX_NODES
+    ):
+        return None
+    return abs(source_cfg.number_of_nodes() - decompiled_cfg.number_of_nodes()) + abs(
+        source_cfg.number_of_edges() - decompiled_cfg.number_of_edges()
+    )
+
+
+def _vj_candidate_signature(cfg: Any) -> tuple[tuple[bool, bool, int, int], ...]:
+    return tuple(
+        sorted(
+            (
+                bool(getattr(node, "is_entrypoint", False)),
+                bool(getattr(node, "is_exitpoint", False)),
+                cfg.in_degree(node),
+                cfg.out_degree(node),
+            )
+            for node in cfg.nodes()
+        )
+    )
+
+
+def _historical_ged_value(source_cfg: Any, decompiled_cfg: Any) -> tuple[float, str]:
+    fallback = _size_fallback_value(source_cfg, decompiled_cfg)
+    if fallback is not None:
+        return float(fallback), "fallback"
+
+    from decbench.metrics.vj_ged import vj_ged
+
+    return float(vj_ged(source_cfg, decompiled_cfg)), "vj_ged"
+
+
+def select_legacy_parse_mode(
+    slice_key: str,
+    source_cfgs: dict,
+    raw_cfgs: dict,
+    sanitized_cfgs: dict,
+    old_values: dict[str, float],
+    *,
+    sanitizer_changed: bool,
+) -> tuple[str, str]:
+    """Recover which legacy candidate parse produced a published slice."""
+    if not sanitizer_changed:
+        return LEGACY_RAW, "sanitizer_noop"
+
+    raw_evidence: list[str] = []
+    sanitized_evidence: list[str] = []
+    for function, old_value in old_values.items():
+        source_cfg = source_cfgs.get(function)
+        if source_cfg is None:
+            continue
+        raw_cfg = raw_cfgs.get(function)
+        sanitized_cfg = sanitized_cfgs.get(function)
+        if raw_cfg is None and sanitized_cfg is not None:
+            sanitized_evidence.append(f"{function}:published_candidate_coverage")
+            continue
+        if sanitized_cfg is None and raw_cfg is not None:
+            raw_evidence.append(f"{function}:published_candidate_coverage")
+            continue
+        if raw_cfg is None or sanitized_cfg is None:
+            continue
+        raw_fallback = _size_fallback_value(source_cfg, raw_cfg)
+        sanitized_fallback = _size_fallback_value(source_cfg, sanitized_cfg)
+        if (
+            raw_fallback is None
+            and sanitized_fallback is None
+            and _vj_candidate_signature(raw_cfg) == _vj_candidate_signature(sanitized_cfg)
+        ):
+            continue
+        raw_score, raw_method = _historical_ged_value(source_cfg, raw_cfg)
+        sanitized_score, sanitized_method = _historical_ged_value(
+            source_cfg,
+            sanitized_cfg,
+        )
+        raw_matches = raw_score == old_value
+        sanitized_matches = sanitized_score == old_value
+        if raw_matches and not sanitized_matches:
+            raw_evidence.append(f"{function}:published_{raw_method}_identity")
+        elif sanitized_matches and not raw_matches:
+            sanitized_evidence.append(f"{function}:published_{sanitized_method}_identity")
+
+    if raw_evidence and sanitized_evidence:
+        raise RuntimeError(
+            f"{slice_key} has conflicting legacy parse evidence: "
+            f"raw={raw_evidence[:5]}, sanitized={sanitized_evidence[:5]}"
+        )
+    if sanitized_evidence:
+        return LEGACY_SANITIZED, sanitized_evidence[0]
+    if raw_evidence:
+        return LEGACY_RAW, raw_evidence[0]
+    return LEGACY_AMBIGUOUS, "published_outputs_do_not_distinguish_parse_mode"
+
+
+def select_ambiguous_legacy_cfg(
+    full_key: str,
+    source_cfg: Any,
+    raw_cfg: Any,
+    sanitized_cfg: Any,
+    old_value: float | None,
+) -> Any:
+    """Choose a count-equivalent graph while preserving parse ambiguity."""
+    if raw_cfg is None:
+        return sanitized_cfg
+    if sanitized_cfg is None:
+        return raw_cfg
+    raw_size = (raw_cfg.number_of_nodes(), raw_cfg.number_of_edges())
+    sanitized_size = (
+        sanitized_cfg.number_of_nodes(),
+        sanitized_cfg.number_of_edges(),
+    )
+    historical_sizes = (
+        (
+            source_cfg.number_of_nodes(),
+            raw_cfg.number_of_nodes(),
+            sanitized_cfg.number_of_nodes(),
+        )
+        if source_cfg is not None
+        else ()
+    )
+    if (
+        raw_size != sanitized_size
+        and historical_sizes
+        and max(historical_sizes) > PREVIOUS_GED_MAX_NODES
+    ):
+        raise RuntimeError(
+            f"{full_key} has ambiguous legacy graph sizes for published fallback "
+            f"{old_value}: raw={raw_size}, sanitized={sanitized_size}"
+        )
+    raw_fallback = _size_fallback_value(source_cfg, raw_cfg)
+    sanitized_fallback = _size_fallback_value(source_cfg, sanitized_cfg)
+    if old_value is not None and (raw_fallback is not None or sanitized_fallback is not None):
+        raw_matches = raw_fallback is not None and float(raw_fallback) == old_value
+        sanitized_matches = (
+            sanitized_fallback is not None and float(sanitized_fallback) == old_value
+        )
+        if raw_matches != sanitized_matches:
+            return raw_cfg if raw_matches else sanitized_cfg
+        if not raw_matches:
+            raise RuntimeError(
+                f"{full_key} cannot reconstruct published fallback {old_value}: "
+                f"raw={raw_fallback}, sanitized={sanitized_fallback}"
+            )
+    return raw_cfg
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_historical_slice_manifest(path: Path) -> set[str]:
+    if not path.is_file():
+        raise FileNotFoundError(f"historical GED slice manifest is missing: {path}")
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, list) or any(
+        not isinstance(value, str) or len(value.split("::")) != 4 for value in payload
+    ):
+        raise ValueError(f"invalid historical GED slice manifest: {path}")
+    slices = set(payload)
+    if len(slices) != len(payload):
+        raise ValueError(f"duplicate slices in historical GED manifest: {path}")
+    return slices
+
+
+def checkpoint_scores(payload: dict) -> dict:
+    if payload.get("_meta") and isinstance(payload.get("scores"), dict):
+        return payload["scores"]
+    return payload
+
+
+def checkpoint_large_graphs(payload: dict) -> dict:
+    if payload.get("_meta") and isinstance(payload.get("over_previous_limit"), dict):
+        return payload["over_previous_limit"]
+    return {}
+
+
+def write_json_atomic(path: Path, payload: Any, *, indent: int | None = None) -> None:
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_text(json.dumps(payload, indent=indent))
+    temp_path.replace(path)
+
+
+def empty_audit_counts() -> dict[str, int]:
+    return {
+        "pairs_over_60": 0,
+        "graphs_over_60": 0,
+        "source_graphs_over_60": 0,
+        "decompiled_graphs_over_60": 0,
+        "both_graphs_over_60": 0,
+        "corrected_pairs_over_60": 0,
+        "corrected_graphs_over_60": 0,
+        "corrected_source_graphs_over_60": 0,
+        "corrected_decompiled_graphs_over_60": 0,
+        "corrected_both_graphs_over_60": 0,
+        "historical_only_over_60": 0,
+        "corrected_only_over_60": 0,
+        "historical_and_corrected_over_60": 0,
+        "historical_legacy_raw": 0,
+        "historical_legacy_sanitized": 0,
+        "historical_legacy_parse_ambiguous": 0,
+        "historical_same_opt_inline": 0,
+        "old_score_present": 0,
+        "old_score_missing": 0,
+        "new_score_missing": 0,
+        "changed_scores": 0,
+        "unchanged_scores": 0,
+        "improved_scores": 0,
+        "worsened_scores": 0,
+        "became_perfect": 0,
+        "lost_perfect": 0,
+        "confirmed_isomorphic": 0,
+        "new_vj_ged": 0,
+        "new_size_lower_bound": 0,
+    }
+
+
+def empty_change_counts() -> dict[str, int]:
+    return {
+        "comparable_scores": 0,
+        "unchanged_scores": 0,
+        "changed_scores": 0,
+        "improved_scores": 0,
+        "worsened_scores": 0,
+        "became_perfect": 0,
+        "lost_perfect": 0,
+        "new_scores": 0,
+        "missing_scores": 0,
+    }
+
+
+def build_large_graph_audit(
+    old_scores: dict[str, dict],
+    new_scores: dict[str, dict],
+    large_graphs: dict[str, dict],
+    signature: dict[str, int | str],
+) -> dict[str, Any]:
+    per_decompiler: dict[str, dict[str, int]] = defaultdict(empty_audit_counts)
+    total = empty_audit_counts()
+    records: dict[str, dict[str, Any]] = {}
+
+    for key, graph_record in sorted(large_graphs.items()):
+        _opt, _project, _binary, decompiler, _function = key.split("::", 4)
+        old_record = old_scores.get(key)
+        new_record = new_scores.get(key)
+        old_value = float(old_record["value"]) if old_record is not None else None
+        new_value = float(new_record["value"]) if new_record is not None else None
+        old_perfect = old_value == 0.0 if old_value is not None else None
+        new_perfect = new_value == 0.0 if new_value is not None else None
+        changed = old_value is not None and new_value is not None and old_value != new_value
+
+        historical_large = bool(graph_record["historical_over_60"])
+        corrected_large = bool(graph_record["corrected_over_60"])
+        historical_source_large = (
+            graph_record.get("historical_source_nodes") is not None
+            and graph_record["historical_source_nodes"] > PREVIOUS_GED_MAX_NODES
+        )
+        historical_decompiled_large = (
+            graph_record.get("historical_decompiled_nodes") is not None
+            and graph_record["historical_decompiled_nodes"] > PREVIOUS_GED_MAX_NODES
+        )
+        corrected_source_large = (
+            graph_record.get("corrected_source_nodes") is not None
+            and graph_record["corrected_source_nodes"] > PREVIOUS_GED_MAX_NODES
+        )
+        corrected_decompiled_large = (
+            graph_record.get("corrected_decompiled_nodes") is not None
+            and graph_record["corrected_decompiled_nodes"] > PREVIOUS_GED_MAX_NODES
+        )
+        increments = {
+            "pairs_over_60": int(historical_large),
+            "graphs_over_60": int(historical_large)
+            * (int(historical_source_large) + int(historical_decompiled_large)),
+            "source_graphs_over_60": int(historical_large and historical_source_large),
+            "decompiled_graphs_over_60": int(historical_large and historical_decompiled_large),
+            "both_graphs_over_60": int(
+                historical_large and historical_source_large and historical_decompiled_large
+            ),
+            "corrected_pairs_over_60": int(corrected_large),
+            "corrected_graphs_over_60": int(corrected_large)
+            * (int(corrected_source_large) + int(corrected_decompiled_large)),
+            "corrected_source_graphs_over_60": int(corrected_large and corrected_source_large),
+            "corrected_decompiled_graphs_over_60": int(
+                corrected_large and corrected_decompiled_large
+            ),
+            "corrected_both_graphs_over_60": int(
+                corrected_large and corrected_source_large and corrected_decompiled_large
+            ),
+            "historical_only_over_60": int(historical_large and not corrected_large),
+            "corrected_only_over_60": int(corrected_large and not historical_large),
+            "historical_and_corrected_over_60": int(historical_large and corrected_large),
+            "historical_legacy_raw": int(
+                historical_large
+                and graph_record.get("historical_decompiled_parse_mode") == LEGACY_RAW
+            ),
+            "historical_legacy_sanitized": int(
+                historical_large
+                and graph_record.get("historical_decompiled_parse_mode") == LEGACY_SANITIZED
+            ),
+            "historical_legacy_parse_ambiguous": int(
+                historical_large
+                and graph_record.get("historical_decompiled_parse_mode") == LEGACY_AMBIGUOUS
+            ),
+            "historical_same_opt_inline": int(
+                historical_large
+                and graph_record.get("historical_decompiled_parse_mode") == INLINE_SANITIZED
+            ),
+            "old_score_present": int(historical_large and old_value is not None),
+            "old_score_missing": int(historical_large and old_value is None),
+            "new_score_missing": int(historical_large and new_value is None),
+            "changed_scores": int(historical_large and changed),
+            "unchanged_scores": int(
+                historical_large and old_value is not None and new_value is not None and not changed
+            ),
+            "improved_scores": int(historical_large and changed and new_value < old_value),
+            "worsened_scores": int(historical_large and changed and new_value > old_value),
+            "became_perfect": int(historical_large and changed and new_perfect),
+            "lost_perfect": int(
+                historical_large and changed and old_perfect is True and not new_perfect
+            ),
+            "confirmed_isomorphic": int(
+                historical_large and graph_record.get("isomorphic") is True
+            ),
+            "new_vj_ged": int(historical_large and graph_record["method"] == "vj_ged"),
+            "new_size_lower_bound": int(
+                historical_large and graph_record["method"] == "size_lower_bound"
+            ),
+        }
+        for name, increment in increments.items():
+            per_decompiler[decompiler][name] += increment
+            total[name] += increment
+
+        records[key] = {
+            **graph_record,
+            "old_value": old_value,
+            "old_perfect": old_perfect,
+            "new_value": new_value,
+            "new_perfect": new_perfect,
+            "changed": changed,
+        }
+
+    missing_old_keys = sorted(set(old_scores) - set(new_scores))
+    missing_by_decompiler: dict[str, int] = defaultdict(int)
+    for key in missing_old_keys:
+        missing_by_decompiler[key.split("::", 4)[3]] += 1
+
+    all_change_total = empty_change_counts()
+    all_changes_by_decompiler: dict[str, dict[str, int]] = defaultdict(empty_change_counts)
+    changed_records: dict[str, dict[str, Any]] = {}
+    for key in sorted(set(old_scores) | set(new_scores)):
+        decompiler = key.split("::", 4)[3]
+        counts = all_changes_by_decompiler[decompiler]
+        old_record = old_scores.get(key)
+        new_record = new_scores.get(key)
+        if old_record is None:
+            increments = {"new_scores": 1}
+        elif new_record is None:
+            increments = {"missing_scores": 1}
+        else:
+            old_value = float(old_record["value"])
+            new_value = float(new_record["value"])
+            changed = old_value != new_value
+            increments = {
+                "comparable_scores": 1,
+                "unchanged_scores": int(not changed),
+                "changed_scores": int(changed),
+                "improved_scores": int(changed and new_value < old_value),
+                "worsened_scores": int(changed and new_value > old_value),
+                "became_perfect": int(changed and new_value == 0.0),
+                "lost_perfect": int(changed and old_value == 0.0 and new_value != 0.0),
+            }
+            if changed:
+                changed_records[key] = {
+                    "old_value": old_value,
+                    "new_value": new_value,
+                    "old_perfect": old_value == 0.0,
+                    "new_perfect": new_value == 0.0,
+                    "over_previous_limit": key in large_graphs,
+                }
+        for name, increment in increments.items():
+            counts[name] += increment
+            all_change_total[name] += increment
+
+    return {
+        "previous_ged_max_nodes": PREVIOUS_GED_MAX_NODES,
+        "new_evaluator": signature,
+        "census_basis": {
+            "historical": (
+                "Published evaluator inputs: legacy project cache for overlay scores, "
+                "same-optimization source for inline scores, evidence-reconciled raw "
+                "or sanitized generated C for legacy-overlay scores, and sanitized "
+                "generated C without local macro expansion for inline-only scores"
+            ),
+            "corrected": (
+                "Same-optimization source CFGs and sanitized generated C with local "
+                "macro expansion"
+            ),
+        },
+        "coverage": {
+            "published_scores_before": len(old_scores),
+            "scores_after_reevaluation": len(new_scores),
+            "published_scores_missing_after_reevaluation": len(missing_old_keys),
+            "missing_by_decompiler": dict(sorted(missing_by_decompiler.items())),
+            "missing_keys": missing_old_keys,
+        },
+        "all_score_changes": {
+            "total": all_change_total,
+            "by_decompiler": {
+                decompiler: all_changes_by_decompiler[decompiler]
+                for decompiler in sorted(all_changes_by_decompiler)
+            },
+            "changed_records": changed_records,
+        },
+        "summary": {
+            "total": total,
+            "by_decompiler": {
+                decompiler: per_decompiler[decompiler] for decompiler in sorted(per_decompiler)
+            },
+        },
+        "records": records,
+    }
+
+
+def load_published_ged_scores(
+    root: Path,
+    baseline_path: Path | None = None,
+) -> dict[str, dict]:
+    path = baseline_path or root / "function_results.json"
+    if not path.exists():
+        return {}
+    function_data = json.loads(path.read_text())
+    scores: dict[str, dict] = {}
+    for group in function_data.get("groups", []):
+        prefix = f"{group['opt_level']}::{group['project']}::{group['binary']}"
+        for function in group.get("functions", []):
+            name = function["function"]
+            for decompiler, values in function.get("values", {}).items():
+                value = values.get("ged")
+                if value is None or not math.isfinite(value):
+                    continue
+                key = f"{prefix}::{decompiler}::{name}"
+                perfect = function.get("perfects", {}).get(decompiler, {}).get("ged", value == 0.0)
+                scores[key] = {"value": float(value), "perfect": bool(perfect)}
+    return scores
+
+
+def historical_overlay_slices(root: Path) -> set[str]:
+    """Slices whose published GED column was replaced by the pre-update overlay."""
+    sidecar = root / "ged_new.slices.json"
+    if sidecar.exists():
+        return load_historical_slice_manifest(sidecar)
+    overlay = root / "ged_new.json"
+    if not overlay.exists():
+        return set()
+    return {"::".join(key.split("::", 4)[:4]) for key in json.loads(overlay.read_text())}
+
+
 def src_cfgs_for_i(i_path: str) -> tuple[str, dict]:
     """Worker: extract (stripped) source CFGs for one .i file."""
     from decbench.utils.cfg import extract_cfgs_from_source
 
-    try:
-        cfgs = extract_cfgs_from_source(Path(i_path)) or {}
-    except Exception:  # noqa: BLE001
-        cfgs = {}
+    cfgs = extract_cfgs_from_source(Path(i_path), raise_on_error=True) or {}
     return i_path, cfgs
 
 
-def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
-    """Extract + cache source CFGs per project (one pickle each)."""
-    src_dir = root / "ged_src"
-    src_dir.mkdir(exist_ok=True)
-    todo: dict[str, list[str]] = {}
-    for proj in projects:
-        if (src_dir / f"{proj}.pkl").exists():
+def source_cache_path(src_dir: Path, opt: str, project: str) -> Path:
+    return src_dir / "projects" / opt / f"{project}.pkl"
+
+
+def _source_inputs(root: Path, opt: str, project: str) -> list[Path]:
+    compiled = root / opt / project / "compiled"
+    if not compiled.is_dir():
+        return []
+    return [
+        path
+        for path in sorted(compiled.glob("*.i"))
+        if "conftest" not in path.name and not path.name.startswith("a-")
+    ]
+
+
+def _stripped_source_sha(path: Path) -> str:
+    from decbench.utils.cfg import strip_system_headers
+
+    text = strip_system_headers(path.read_text(errors="replace"))
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def _write_pickle_atomic(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_suffix(path.suffix + ".tmp")
+    temp_path.write_bytes(pickle.dumps(payload))
+    temp_path.replace(path)
+
+
+def _project_cache_is_current(path: Path, inputs: dict[str, str]) -> bool:
+    if not path.exists():
+        return False
+    try:
+        payload = pickle.loads(path.read_bytes())
+    except Exception:  # noqa: BLE001
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("_meta")
+        == {
+            "source_cache_schema": SOURCE_CACHE_SCHEMA_VERSION,
+            "inputs": inputs,
+        }
+        and isinstance(payload.get("per_stem"), dict)
+    )
+
+
+def _seed_content_cache_from_legacy(
+    root: Path,
+    src_dir: Path,
+    inputs: dict[tuple[str, str], dict[str, tuple[Path, str]]],
+) -> int:
+    """Reuse current legacy O0 project caches without carrying their cross-opt bug."""
+    seeded = 0
+    projects = sorted({project for _opt, project in inputs})
+    content_dir = src_dir / "by_content"
+    content_dir.mkdir(parents=True, exist_ok=True)
+    for project in projects:
+        legacy_path = root / "ged_src" / f"{project}.pkl"
+        if not legacy_path.exists():
             continue
-        comp = root / SRC_OPT / proj / "compiled"
-        if not comp.is_dir():
+        legacy_opt = next(
+            (
+                opt
+                for opt in (
+                    SRC_OPT,
+                    *(level for level in OPT_LEVELS if level != SRC_OPT),
+                )
+                if _source_inputs(root, opt, project)
+            ),
+            None,
+        )
+        if legacy_opt is None or (legacy_opt, project) not in inputs:
             continue
-        ifiles = [
-            str(f)
-            for f in sorted(comp.glob("*.i"))
-            if "conftest" not in f.name and not f.name.startswith("a-")
-        ]
-        if ifiles:
-            todo[proj] = ifiles
-    if not todo:
-        print("[ged/src] all source-CFG caches present", flush=True)
+        try:
+            payload = pickle.loads(legacy_path.read_bytes())
+        except Exception:  # noqa: BLE001
+            continue
+        per_stem = payload.get("per_stem", payload) if isinstance(payload, dict) else {}
+        for stem, (source_path, digest) in inputs[(legacy_opt, project)].items():
+            content_path = content_dir / f"{digest}.pkl"
+            if (
+                content_path.exists()
+                or stem not in per_stem
+                or legacy_path.stat().st_mtime < source_path.stat().st_mtime
+            ):
+                continue
+            _write_pickle_atomic(content_path, per_stem[stem])
+            seeded += 1
+    return seeded
+
+
+def build_source_cfgs(
+    root: Path,
+    required: set[tuple[str, str]],
+    workers: int,
+) -> Path:
+    """Build optimization-specific source caches, deduplicated by stripped `.i` content."""
+    src_dir = root / "ged_src" / f"v{SOURCE_CACHE_SCHEMA_VERSION}"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    inputs: dict[tuple[str, str], dict[str, tuple[Path, str]]] = {}
+    rebuild: set[tuple[str, str]] = set()
+    for opt, project in sorted(required):
+        paths = _source_inputs(root, opt, project)
+        stem_inputs = {path.stem: (path, _stripped_source_sha(path)) for path in paths}
+        inputs[(opt, project)] = stem_inputs
+        digests = {stem: digest for stem, (_path, digest) in stem_inputs.items()}
+        if not _project_cache_is_current(
+            source_cache_path(src_dir, opt, project),
+            digests,
+        ):
+            rebuild.add((opt, project))
+
+    if not rebuild:
+        print("[ged/src] all optimization-specific source-CFG caches present", flush=True)
         return src_dir
-    owner = {p: proj for proj, paths in todo.items() for p in paths}
-    all_paths = list(owner)
+
+    seeded = _seed_content_cache_from_legacy(root, src_dir, inputs)
+    content_dir = src_dir / "by_content"
+    representatives: dict[str, Path] = {}
+    for pair in rebuild:
+        for path, digest in inputs[pair].values():
+            if not (content_dir / f"{digest}.pkl").exists():
+                representatives.setdefault(digest, path)
     print(
-        f"[ged/src] extracting source CFGs: {len(all_paths)} files over "
-        f"{len(todo)} projects, {workers} workers",
+        f"[ged/src] {len(rebuild)} opt/project caches need assembly; "
+        f"seeded {seeded} TUs from valid legacy caches; "
+        f"parsing {len(representatives)} unique source files with {workers} workers",
         flush=True,
     )
-    # Source CFGs stay PER-TU (not a project-wide name-keyed union) so stage B can
-    # pair each binary against its own translation unit — otherwise main/usage/static
-    # helpers score against an arbitrary same-named function from another binary.
-    acc: dict[str, dict] = {proj: {} for proj in todo}
-    ctx = mp.get_context("spawn")
-    done = 0
-    with ctx.Pool(processes=workers) as pool:
-        for ipath, cfgs in pool.imap_unordered(src_cfgs_for_i, all_paths):
-            acc[owner[ipath]][Path(ipath).stem] = cfgs
-            done += 1
-            if done % 50 == 0 or done == len(all_paths):
-                print(f"[ged/src] {done}/{len(all_paths)} source files", flush=True)
-    for proj, per_stem in acc.items():
-        (src_dir / f"{proj}.pkl").write_bytes(pickle.dumps(per_stem))
-        nfun = sum(len(c) for c in per_stem.values())
-        print(f"[ged/src] {proj}: {len(per_stem)} TUs, {nfun} source functions cached", flush=True)
+
+    if representatives:
+        digest_by_path = {str(path): digest for digest, path in representatives.items()}
+        ctx = mp.get_context("spawn")
+        done = 0
+        with ctx.Pool(processes=workers, maxtasksperchild=8) as pool:
+            for source_path, cfgs in pool.imap_unordered(
+                src_cfgs_for_i,
+                list(digest_by_path),
+            ):
+                digest = digest_by_path[source_path]
+                _write_pickle_atomic(content_dir / f"{digest}.pkl", cfgs)
+                done += 1
+                if done % 50 == 0 or done == len(representatives):
+                    print(
+                        f"[ged/src] {done}/{len(representatives)} unique source files",
+                        flush=True,
+                    )
+
+    for opt, project in sorted(rebuild):
+        stem_inputs = inputs[(opt, project)]
+        per_stem = {
+            stem: pickle.loads((content_dir / f"{digest}.pkl").read_bytes())
+            for stem, (_path, digest) in stem_inputs.items()
+        }
+        digests = {stem: digest for stem, (_path, digest) in stem_inputs.items()}
+        path = source_cache_path(src_dir, opt, project)
+        _write_pickle_atomic(
+            path,
+            {
+                "_meta": {
+                    "source_cache_schema": SOURCE_CACHE_SCHEMA_VERSION,
+                    "inputs": digests,
+                },
+                "per_stem": per_stem,
+            },
+        )
+        nfun = sum(len(cfgs) for cfgs in per_stem.values())
+        print(
+            f"[ged/src] {opt}/{project}: {len(per_stem)} TUs, " f"{nfun} source functions cached",
+            flush=True,
+        )
     return src_dir
 
 
@@ -112,64 +760,273 @@ def _load_src(src_pkl: str) -> tuple[dict, dict]:
     if src_pkl not in _SRC_CACHE:
         from decbench.utils.cfg import best_source_by_name
 
-        per_stem = pickle.loads(Path(src_pkl).read_bytes())
+        payload = pickle.loads(Path(src_pkl).read_bytes())
+        per_stem = payload.get("per_stem", payload)
         _SRC_CACHE[src_pkl] = (per_stem, best_source_by_name(per_stem))
     return _SRC_CACHE[src_pkl]
 
 
-def eval_one(task: tuple[str, str, str, str, str, str]) -> tuple[str, dict]:
+def eval_one(
+    task: tuple[str, str, str, str, str, str, str, bool, dict[str, float]],
+) -> tuple[str, dict, dict]:
     """Worker: recompute GED for every function of one (binary, dec).
 
-    ``task`` = (opt, project, stem, dec, decompiled_c_path, src_pkl_path).
+    ``task`` = (opt, project, stem, dec, decompiled_c_path,
+    corrected_src_pkl_path, historical_src_pkl_path, historical_overlay_covered,
+    published_old_values).
     Resolves each function's source CFG TU-aware (own TU first, cross-TU fallback)
     and DROPS non-finite (empty-prototype/degenerate source) results so they are
     excluded from GED's denominator instead of counting as failures.
     """
-    import math
     import re
 
-    opt, project, stem, dec, c_path, src_pkl = task
+    (
+        opt,
+        project,
+        stem,
+        dec,
+        c_path,
+        src_pkl,
+        historical_src_pkl,
+        historical_overlay_covered,
+        old_values,
+    ) = task
     from decbench.metrics.ged import GEDMetric
-    from decbench.utils.cfg import extract_cfgs_from_source, resolved_source_for_binary
+    from decbench.utils.cfg import (
+        extract_cfgs_from_source,
+        needs_decompiled_preprocessing,
+        resolved_source_for_binary,
+        sanitize_decompiled_c,
+    )
 
     per_stem, best_by_name = _load_src(src_pkl)
     src_cfgs = resolved_source_for_binary(stem, per_stem, best_by_name)
-    try:
-        dec_cfgs = extract_cfgs_from_source(Path(c_path), sanitize_decompiled=True) or {}
-    except Exception:  # noqa: BLE001
-        dec_cfgs = {}
+    historical_src_cfgs: dict = {}
+    if historical_src_pkl:
+        historical_per_stem, historical_best = _load_src(historical_src_pkl)
+        historical_src_cfgs = resolved_source_for_binary(
+            stem,
+            historical_per_stem,
+            historical_best,
+        )
+    decompiled_text = Path(c_path).read_text(errors="replace")
+    sanitizer_changed = sanitize_decompiled_c(decompiled_text) != decompiled_text
+    has_preprocessor_control = needs_decompiled_preprocessing(decompiled_text)
+    dec_cfgs = (
+        extract_cfgs_from_source(
+            Path(c_path),
+            sanitize_decompiled=True,
+            raise_on_error=True,
+        )
+        or {}
+    )
+    raw_dec_cfgs: dict = {}
+    sanitized_dec_cfgs = dec_cfgs
+    historical_parse_mode = INLINE_SANITIZED
+    historical_parse_reason = "same_optimization_inline"
+    if historical_overlay_covered:
+        if not sanitizer_changed and not has_preprocessor_control:
+            raw_dec_cfgs = dec_cfgs
+        else:
+            raw_dec_cfgs = (
+                extract_cfgs_from_source(
+                    Path(c_path),
+                    sanitize_decompiled=False,
+                    preprocess_decompiled=False,
+                    raise_on_error=True,
+                )
+                or {}
+            )
+        if not sanitizer_changed:
+            sanitized_dec_cfgs = raw_dec_cfgs
+        elif has_preprocessor_control:
+            sanitized_dec_cfgs = (
+                extract_cfgs_from_source(
+                    Path(c_path),
+                    sanitize_decompiled=True,
+                    preprocess_decompiled=False,
+                    raise_on_error=True,
+                )
+                or {}
+            )
+        historical_parse_mode, historical_parse_reason = select_legacy_parse_mode(
+            f"{opt}::{project}::{stem}::{dec}",
+            historical_src_cfgs,
+            raw_dec_cfgs,
+            sanitized_dec_cfgs,
+            old_values,
+            sanitizer_changed=sanitizer_changed,
+        )
+    elif has_preprocessor_control:
+        sanitized_dec_cfgs = (
+            extract_cfgs_from_source(
+                Path(c_path),
+                sanitize_decompiled=True,
+                preprocess_decompiled=False,
+                raise_on_error=True,
+            )
+            or {}
+        )
     # Joern keys CFGs by the parsed BODY name, which can differ from the marker name
     # (ida's `_rl_set_screen_size` over a `rl_set_screen_size` body). Emitting only
     # marker-declared functions avoids attributing a row the decompiler never owned.
     markers = set(
         re.findall(
             r"^// Function: (\S+) @ 0x[0-9a-fA-F]+\s*$",
-            Path(c_path).read_text(errors="replace"),
+            decompiled_text,
             re.M,
         )
     )
+    if old_values:
+        selected_source_functions = (
+            set(historical_src_cfgs) if historical_overlay_covered else set(src_cfgs)
+        )
+        if historical_parse_mode == LEGACY_RAW:
+            selected_historical_functions = set(raw_dec_cfgs)
+        elif historical_parse_mode == LEGACY_SANITIZED:
+            selected_historical_functions = set(sanitized_dec_cfgs)
+        elif historical_parse_mode == LEGACY_AMBIGUOUS:
+            selected_historical_functions = set(raw_dec_cfgs) | set(sanitized_dec_cfgs)
+        else:
+            selected_historical_functions = set(sanitized_dec_cfgs)
+        missing_markers = set(old_values) - markers
+        missing_sources = set(old_values) - selected_source_functions
+        missing_candidates = set(old_values) - selected_historical_functions
+        if missing_markers or missing_sources or missing_candidates:
+            raise RuntimeError(
+                f"{opt}::{project}::{stem}::{dec} cannot reconstruct all published "
+                "legacy scores: "
+                f"markers={sorted(missing_markers)[:5]}, "
+                f"sources={sorted(missing_sources)[:5]}, "
+                f"candidates={sorted(missing_candidates)[:5]}"
+            )
     metric = GEDMetric()
     perfect_val = metric.perfect_value
     out: dict[str, dict] = {}
-    for fn, dcfg in dec_cfgs.items():
-        if fn not in markers:
-            continue
+    over_previous_limit: dict[str, dict] = {}
+    parsed_functions = (set(dec_cfgs) | set(raw_dec_cfgs) | set(sanitized_dec_cfgs)) & markers
+    for fn in sorted(parsed_functions):
+        dcfg = dec_cfgs.get(fn)
         scfg = src_cfgs.get(fn)
-        if scfg is None:
-            continue
-        try:
-            mv = metric.compute_for_function(None, source_cfg=scfg, decompiled_cfg=dcfg)
-        except Exception:  # noqa: BLE001
-            continue
-        if not math.isfinite(mv.value):
-            continue
-        out[fn] = {"value": float(mv.value), "perfect": bool(mv.value == perfect_val)}
+        mv = None
+        if scfg is not None and dcfg is not None:
+            try:
+                candidate = metric.compute_for_function(
+                    None,
+                    source_cfg=scfg,
+                    decompiled_cfg=dcfg,
+                )
+            except Exception:  # noqa: BLE001
+                candidate = None
+            if candidate is not None and math.isfinite(candidate.value):
+                mv = candidate
+                out[fn] = {
+                    "value": float(mv.value),
+                    "perfect": bool(mv.value == perfect_val),
+                }
+
+        historical_scfg = (
+            historical_src_cfgs.get(fn) if historical_overlay_covered else src_cfgs.get(fn)
+        )
+        record_parse_mode = historical_parse_mode
+        record_parse_reason = historical_parse_reason
+        if historical_parse_mode == LEGACY_RAW:
+            historical_dcfg = raw_dec_cfgs.get(fn)
+        elif historical_parse_mode == LEGACY_SANITIZED:
+            historical_dcfg = sanitized_dec_cfgs.get(fn)
+        elif historical_parse_mode == LEGACY_AMBIGUOUS:
+            raw_candidate = raw_dec_cfgs.get(fn)
+            sanitized_candidate = sanitized_dec_cfgs.get(fn)
+            old_value = old_values.get(fn)
+            if old_value is None and ((raw_candidate is None) != (sanitized_candidate is None)):
+                historical_dcfg = None
+                record_parse_reason = "one_sided_candidate_without_published_score"
+            else:
+                historical_dcfg = select_ambiguous_legacy_cfg(
+                    f"{opt}::{project}::{stem}::{dec}::{fn}",
+                    historical_scfg,
+                    raw_candidate,
+                    sanitized_candidate,
+                    old_value,
+                )
+        else:
+            historical_dcfg = sanitized_dec_cfgs.get(fn)
+        historical_over = bool(
+            historical_scfg is not None
+            and historical_dcfg is not None
+            and (
+                historical_scfg.number_of_nodes() > PREVIOUS_GED_MAX_NODES
+                or historical_dcfg.number_of_nodes() > PREVIOUS_GED_MAX_NODES
+            )
+        )
+        old_value = old_values.get(fn)
+        if historical_over and old_value is not None:
+            reconstructed_fallback = _size_fallback_value(
+                historical_scfg,
+                historical_dcfg,
+            )
+            if reconstructed_fallback is None or float(reconstructed_fallback) != old_value:
+                raise RuntimeError(
+                    f"{opt}::{project}::{stem}::{dec}::{fn} cannot reproduce "
+                    f"published fallback {old_value}: "
+                    f"reconstructed={reconstructed_fallback}, "
+                    f"parse_mode={record_parse_mode}"
+                )
+        corrected_over = bool(
+            scfg is not None
+            and dcfg is not None
+            and (
+                scfg.number_of_nodes() > PREVIOUS_GED_MAX_NODES
+                or dcfg.number_of_nodes() > PREVIOUS_GED_MAX_NODES
+            )
+        )
+        if historical_over or corrected_over:
+            over_previous_limit[fn] = {
+                "historical_source_nodes": (
+                    historical_scfg.number_of_nodes() if historical_scfg is not None else None
+                ),
+                "historical_source_edges": (
+                    historical_scfg.number_of_edges() if historical_scfg is not None else None
+                ),
+                "historical_decompiled_nodes": (
+                    historical_dcfg.number_of_nodes() if historical_dcfg is not None else None
+                ),
+                "historical_decompiled_edges": (
+                    historical_dcfg.number_of_edges() if historical_dcfg is not None else None
+                ),
+                "historical_over_60": historical_over,
+                "historical_source_basis": (
+                    "legacy_overlay" if historical_overlay_covered else "same_opt_inline"
+                ),
+                "historical_decompiled_parse_mode": (record_parse_mode),
+                "historical_parse_selection_reason": record_parse_reason,
+                "historical_raw_candidate_present": fn in raw_dec_cfgs,
+                "historical_sanitized_candidate_present": fn in sanitized_dec_cfgs,
+                "corrected_source_nodes": (scfg.number_of_nodes() if scfg is not None else None),
+                "corrected_source_edges": (scfg.number_of_edges() if scfg is not None else None),
+                "corrected_decompiled_nodes": (
+                    dcfg.number_of_nodes() if dcfg is not None else None
+                ),
+                "corrected_decompiled_edges": (
+                    dcfg.number_of_edges() if dcfg is not None else None
+                ),
+                "corrected_over_60": corrected_over,
+                "new_value": float(mv.value) if mv is not None else None,
+                "new_perfect": (bool(mv.value == perfect_val) if mv is not None else None),
+                "method": mv.metadata.get("method") if mv is not None else None,
+                "isomorphic": (bool(mv.metadata.get("isomorphic")) if mv is not None else None),
+                "approximated": (bool(mv.metadata.get("approximated")) if mv is not None else None),
+            }
     key = f"{opt}::{project}::{stem}::{dec}"
-    return key, out
+    return key, out, over_previous_limit
 
 
-def build_tasks(root: Path, src_dir: Path, only: set[str] | None) -> list[tuple]:
-    tasks = []
+def build_artifacts(
+    root: Path,
+    decompilers: tuple[str, ...],
+    only: set[str] | None,
+) -> list[tuple[str, str, str, str, str]]:
+    artifacts: list[tuple[str, str, str, str, str]] = []
     for opt in OPT_LEVELS:
         odir = root / opt
         if not odir.is_dir():
@@ -177,70 +1034,327 @@ def build_tasks(root: Path, src_dir: Path, only: set[str] | None) -> list[tuple]
         for proj in sorted(p for p in odir.iterdir() if p.is_dir()):
             if only and proj.name not in only:
                 continue
-            src_pkl = src_dir / f"{proj.name}.pkl"
             dec_dir = proj / "decompiled"
-            if not (src_pkl.exists() and dec_dir.is_dir()):
+            if not dec_dir.is_dir():
                 continue
-            for dec in DECOMPILERS:
+            for dec in decompilers:
                 for cf in sorted(dec_dir.glob(f"{dec}_*.c")):
                     stem = cf.name[len(dec) + 1 : -2]
-                    tasks.append((opt, proj.name, stem, dec, str(cf), str(src_pkl)))
-    return tasks
+                    artifacts.append((opt, proj.name, stem, dec, str(cf)))
+    return artifacts
+
+
+def build_tasks(
+    root: Path,
+    src_dir: Path,
+    artifacts: list[tuple[str, str, str, str, str]],
+    historical_covered: set[str] | None = None,
+    old_scores: dict[str, dict] | None = None,
+) -> tuple[
+    list[tuple[str, str, str, str, str, str, str, bool, dict[str, float]]],
+    list[tuple[str, str]],
+]:
+    tasks: list[tuple[str, str, str, str, str, str, str, bool, dict[str, float]]] = []
+    missing: set[tuple[str, str]] = set()
+    old_values_by_slice: dict[str, dict[str, float]] = defaultdict(dict)
+    for key, record in (old_scores or {}).items():
+        slice_key, function = key.rsplit("::", 1)
+        old_values_by_slice[slice_key][function] = float(record["value"])
+    for opt, project, stem, decompiler, c_path in artifacts:
+        src_pkl = source_cache_path(src_dir, opt, project)
+        if not src_pkl.exists():
+            missing.add((opt, project))
+            continue
+        historical_src = root / "ged_src" / f"{project}.pkl"
+        slice_key = f"{opt}::{project}::{stem}::{decompiler}"
+        tasks.append(
+            (
+                opt,
+                project,
+                stem,
+                decompiler,
+                c_path,
+                str(src_pkl),
+                str(historical_src) if historical_src.exists() else "",
+                slice_key in (historical_covered or set()),
+                old_values_by_slice.get(slice_key, {}),
+            )
+        )
+    return tasks, sorted(missing)
+
+
+def _checkpoint_stale(path: Path, task: tuple) -> bool:
+    return path.stat().st_mtime_ns < max(
+        Path(task[4]).stat().st_mtime_ns,
+        Path(task[5]).stat().st_mtime_ns,
+        Path(task[6]).stat().st_mtime_ns if task[6] else 0,
+    )
+
+
+def migrate_compatible_checkpoints(
+    checkpoint_dir: Path,
+    tasks: list[tuple],
+    signature: dict[str, int | str],
+) -> tuple[int, int]:
+    """Upgrade checkpoints whose stored and requested historical bases agree."""
+    from decbench.utils.cfg import sanitize_decompiled_c
+
+    schema5_signature = dict(signature)
+    schema5_signature["schema_version"] = 5
+    schema5_signature["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    schema4_signature = dict(schema5_signature)
+    schema4_signature["schema_version"] = 4
+    schema4_signature.pop("historical_candidate_parse")
+    migrated = 0
+    require_replay = 0
+    for task in tasks:
+        slice_key = f"{task[0]}::{task[1]}::{task[2]}::{task[3]}"
+        path = checkpoint_dir / f"{slice_key.replace('::', '__')}.json"
+        if not path.is_file() or _checkpoint_stale(path, task):
+            continue
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        expected_basis = "legacy_overlay" if task[7] else "same_opt_inline"
+        schema5_metadata = {
+            **schema5_signature,
+            "historical_source_basis": expected_basis,
+        }
+        schema4_metadata = {
+            **schema4_signature,
+            "historical_source_basis": expected_basis,
+        }
+        allowed_metadata = (
+            schema5_metadata,
+            schema4_metadata,
+            schema5_signature,
+            schema4_signature,
+        )
+        if payload.get("_meta") not in allowed_metadata:
+            continue
+        records = checkpoint_large_graphs(payload)
+        if any(
+            record.get("historical_source_basis") != expected_basis for record in records.values()
+        ):
+            require_replay += 1
+            continue
+        if task[7] and task[8]:
+            require_replay += 1
+            continue
+        fallback_mismatch = False
+        for function, record in records.items():
+            old_value = task[8].get(function)
+            if not record.get("historical_over_60") or old_value is None:
+                continue
+            values = (
+                record.get("historical_source_nodes"),
+                record.get("historical_source_edges"),
+                record.get("historical_decompiled_nodes"),
+                record.get("historical_decompiled_edges"),
+            )
+            if not all(isinstance(value, int) for value in values):
+                fallback_mismatch = True
+                break
+            source_nodes, source_edges, decompiled_nodes, decompiled_edges = values
+            reconstructed = abs(source_nodes - decompiled_nodes) + abs(
+                source_edges - decompiled_edges
+            )
+            if float(reconstructed) != old_value:
+                fallback_mismatch = True
+                break
+        if fallback_mismatch:
+            require_replay += 1
+            continue
+        if task[7]:
+            text = Path(task[4]).read_text(errors="replace")
+            if sanitize_decompiled_c(text) != text:
+                require_replay += 1
+                continue
+        parse_mode = LEGACY_RAW if task[7] else INLINE_SANITIZED
+        parse_reason = "sanitizer_noop" if task[7] else "same_optimization_inline"
+        for record in records.values():
+            record["historical_decompiled_parse_mode"] = parse_mode
+            record["historical_parse_selection_reason"] = parse_reason
+            present = record.get("historical_decompiled_nodes") is not None
+            record["historical_raw_candidate_present"] = bool(task[7] and present)
+            record["historical_sanitized_candidate_present"] = present
+        payload["_meta"] = checkpoint_metadata(signature, task[7], task[8])
+        write_json_atomic(path, payload)
+        migrated += 1
+    return migrated, require_replay
 
 
 def main() -> None:
     root = Path(sys.argv[1] if len(sys.argv) > 1 else "results/full_run")
     workers = int(sys.argv[2]) if len(sys.argv) > 2 else 16
     only = {a for a in sys.argv[3:] if not a.lstrip("-").isdigit()} or None
-
-    projects = sorted(p.name for p in (root / SRC_OPT).iterdir() if p.is_dir())
-    if only:
-        projects = [p for p in projects if p in only]
-    src_dir = build_source_cfgs(root, projects, workers)
+    signature = checkpoint_signature()
+    baseline_env = os.environ.get("DECBENCH_GED_BASELINE")
+    baseline_path = Path(baseline_env) if baseline_env else None
+    historical_manifest_env = os.environ.get("DECBENCH_GED_HISTORICAL_SLICES")
+    historical_manifest_path = Path(historical_manifest_env) if historical_manifest_env else None
+    if baseline_path is None or historical_manifest_path is None:
+        raise RuntimeError(
+            "DECBENCH_GED_BASELINE and DECBENCH_GED_HISTORICAL_SLICES are both "
+            "required for evidence-bound GED reevaluation"
+        )
+    if not baseline_path.is_file():
+        raise FileNotFoundError(f"GED comparison baseline is missing: {baseline_path}")
+    baseline_sha256 = file_sha256(baseline_path)
+    historical_covered = load_historical_slice_manifest(historical_manifest_path)
+    historical_manifest_sha256 = file_sha256(historical_manifest_path)
+    old_scores = load_published_ged_scores(root, baseline_path)
+    selected_artifacts = build_artifacts(root, SELECTED_DECOMPILERS, only)
+    canonical_artifacts = build_artifacts(root, CANONICAL_DECOMPILERS, None)
+    required_sources = {
+        (opt, project) for opt, project, _stem, _decompiler, _path in selected_artifacts
+    }
+    src_dir = build_source_cfgs(root, required_sources, workers)
 
     ckpt_dir = root / "reeval_ged"
     ckpt_dir.mkdir(exist_ok=True)
-    tasks = build_tasks(root, src_dir, only)
+    tasks, missing_selected_sources = build_tasks(
+        root,
+        src_dir,
+        selected_artifacts,
+        historical_covered,
+        old_scores,
+    )
+    all_tasks, missing_canonical_sources = build_tasks(
+        root,
+        src_dir,
+        canonical_artifacts,
+        historical_covered,
+        old_scores,
+    )
+    migrated, require_replay = migrate_compatible_checkpoints(
+        ckpt_dir,
+        all_tasks,
+        signature,
+    )
+    if migrated or require_replay:
+        print(
+            f"[ged] migrated {migrated} compatible legacy checkpoints; "
+            f"{require_replay} need raw historical replay",
+            flush=True,
+        )
+    if missing_selected_sources:
+        print(
+            f"[ged] cannot evaluate: {len(missing_selected_sources)} selected "
+            f"opt/project source caches are missing",
+            flush=True,
+        )
+        return
+    current_slices = {
+        f"{opt}::{project}::{stem}::{decompiler}"
+        for opt, project, stem, decompiler, _c_path in canonical_artifacts
+    }
 
     def _pending(t: tuple) -> bool:
         ckpt = ckpt_dir / (f"{t[0]}::{t[1]}::{t[2]}::{t[3]}".replace("::", "__") + ".json")
         if not ckpt.exists():
             return True
+        try:
+            payload = json.loads(ckpt.read_text())
+        except (OSError, ValueError):
+            return True
+        if payload.get("_meta") != checkpoint_metadata(signature, t[7], t[8]):
+            return True
         # A checkpoint older than its artifact was computed against a PREVIOUS decompile
         # and may reference functions the artifact no longer holds.
-        return ckpt.stat().st_mtime < Path(t[4]).stat().st_mtime
+        return _checkpoint_stale(ckpt, t)
 
     pending = [t for t in tasks if _pending(t)]
-    print(f"[ged] {len(tasks)} tasks, {len(pending)} pending, {workers} workers", flush=True)
+    pending_old_values = {
+        f"{task[0]}::{task[1]}::{task[2]}::{task[3]}": task[8] for task in pending
+    }
+    print(
+        f"[ged] {len(tasks)} tasks, {len(pending)} pending, {workers} workers",
+        flush=True,
+    )
 
     ctx = mp.get_context("spawn")
     done = 0
     # maxtasksperchild bounds the per-worker _SRC_CACHE: without recycling, workers
     # accumulate every project pickle they touch and 40 of them OOM a 256 GB box.
     with ctx.Pool(processes=workers, maxtasksperchild=8) as pool:
-        for key, result in pool.imap_unordered(eval_one, pending):
-            (ckpt_dir / (key.replace("::", "__") + ".json")).write_text(json.dumps(result))
+        for key, result, large_graphs in pool.imap_unordered(eval_one, pending):
+            checkpoint_path = ckpt_dir / (key.replace("::", "__") + ".json")
+            write_json_atomic(
+                checkpoint_path,
+                {
+                    "_meta": checkpoint_metadata(
+                        signature,
+                        key in historical_covered,
+                        pending_old_values[key],
+                    ),
+                    "scores": result,
+                    "over_previous_limit": large_graphs,
+                },
+            )
             done += 1
             if done % 25 == 0 or done == len(pending):
                 print(f"[ged] {done}/{len(pending)} (binary,dec) done", flush=True)
 
+    all_tasks, missing_canonical_sources = build_tasks(
+        root,
+        src_dir,
+        canonical_artifacts,
+        historical_covered,
+        old_scores,
+    )
+    stale_after = [task for task in all_tasks if _pending(task)]
+    if stale_after or missing_canonical_sources:
+        print(
+            f"[ged] semantic refresh incomplete: {len(stale_after)} current slices "
+            f"still use older checkpoints and {len(missing_canonical_sources)} "
+            "opt/project source caches are missing; canonical overlays were not changed",
+            flush=True,
+        )
+        return
+
     merged: dict[str, dict] = {}
+    large_graph_records: dict[str, dict] = {}
     slices: list[str] = []
     for cp in ckpt_dir.glob("*.json"):
         key = cp.stem.replace("__", "::")
+        if key not in current_slices:
+            continue
         slices.append(key)
-        for func, v in json.loads(cp.read_text()).items():
+        payload = json.loads(cp.read_text())
+        for func, v in checkpoint_scores(payload).items():
             merged[f"{key}::{func}"] = v
+        for func, record in checkpoint_large_graphs(payload).items():
+            large_graph_records[f"{key}::{func}"] = record
     out_path = root / "ged_new.json"
-    out_path.write_text(json.dumps(merged))
+    write_json_atomic(out_path, merged)
     # Sidecar of EVERY slice this reeval evaluated, including empty ones, so the
     # overlay merge can tell "evaluated, found nothing" (clears stale inline values)
     # from "never evaluated" (keeps them).
-    (root / "ged_new.slices.json").write_text(json.dumps(sorted(slices)))
+    write_json_atomic(root / "ged_new.slices.json", sorted(slices))
+    audit_path = root / "ged_large_graph_audit.json"
+    audit = build_large_graph_audit(old_scores, merged, large_graph_records, signature)
+    audit["comparison_baseline"] = {
+        "path": str(baseline_path.resolve()),
+        "sha256": baseline_sha256,
+    }
+    audit["historical_overlay_manifest"] = {
+        "path": str(historical_manifest_path.resolve()),
+        "sha256": historical_manifest_sha256,
+        "slice_count": len(historical_covered),
+    }
+    write_json_atomic(audit_path, audit, indent=2)
     perf = sum(1 for v in merged.values() if v.get("perfect"))
     print(
         f"[ged] wrote {out_path} ({len(merged)} funcs over {len(slices)} slices, "
         f"{perf} perfect = {100*perf/max(1,len(merged)):.1f}%)",
+        flush=True,
+    )
+    audit_total = audit["summary"]["total"]
+    print(
+        f"[ged/audit] wrote {audit_path} ({audit_total['pairs_over_60']} pairs over "
+        f"the old 60-node limit, {audit_total['changed_scores']} changed scores)",
         flush=True,
     )
 

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -71,6 +71,14 @@ OPT_LEVELS = ("O0", "O2", "O2-noinline")
 SRC_OPT = "O0"
 
 
+def promoted_decompilers(
+    selected: tuple[str, ...] | None = None,
+) -> tuple[str, ...]:
+    """Return built-in columns plus any explicitly selected external columns."""
+    requested = SELECTED_DECOMPILERS if selected is None else selected
+    return tuple(dict.fromkeys((*CANONICAL_DECOMPILERS, *requested)))
+
+
 def checkpoint_signature() -> dict[str, int | str]:
     from decbench.metrics.ged import GED_MAX_NODES, GEDMetric
 
@@ -1206,7 +1214,7 @@ def main() -> None:
     historical_manifest_sha256 = file_sha256(historical_manifest_path)
     old_scores = load_published_ged_scores(root, baseline_path)
     selected_artifacts = build_artifacts(root, SELECTED_DECOMPILERS, only)
-    canonical_artifacts = build_artifacts(root, CANONICAL_DECOMPILERS, None)
+    canonical_artifacts = build_artifacts(root, promoted_decompilers(), None)
     required_sources = {
         (opt, project) for opt, project, _stem, _decompiler, _path in selected_artifacts
     }
@@ -1332,7 +1340,8 @@ def main() -> None:
     # Sidecar of EVERY slice this reeval evaluated, including empty ones, so the
     # overlay merge can tell "evaluated, found nothing" (clears stale inline values)
     # from "never evaluated" (keeps them).
-    write_json_atomic(root / "ged_new.slices.json", sorted(slices))
+    sidecar_path = root / "ged_new.slices.json"
+    write_json_atomic(sidecar_path, sorted(slices))
     audit_path = root / "ged_large_graph_audit.json"
     audit = build_large_graph_audit(old_scores, merged, large_graph_records, signature)
     audit["comparison_baseline"] = {
@@ -1343,6 +1352,11 @@ def main() -> None:
         "path": str(historical_manifest_path.resolve()),
         "sha256": historical_manifest_sha256,
         "slice_count": len(historical_covered),
+    }
+    audit["promoted_slice_manifest"] = {
+        "path": str(sidecar_path.resolve()),
+        "sha256": file_sha256(sidecar_path),
+        "slice_count": len(slices),
     }
     write_json_atomic(audit_path, audit, indent=2)
     perf = sum(1 for v in merged.values() if v.get("perfect"))

--- a/tests/test_audit_historical_ged_iso.py
+++ b/tests/test_audit_historical_ged_iso.py
@@ -69,6 +69,22 @@ def _sha(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def test_promoted_artifacts_follow_external_sidecar_slice(tmp_path: Path) -> None:
+    artifact = tmp_path / "O0/proj/decompiled/mydec_bin.c"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    promoted = {"O0::proj::bin::mydec"}
+
+    assert historical_iso.promoted_artifacts(tmp_path, promoted) == [
+        ("O0", "proj", "bin", "mydec", str(artifact))
+    ]
+
+
+def test_promoted_artifacts_reject_missing_sidecar_slice(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="promoted GED artifacts are missing"):
+        historical_iso.promoted_artifacts(tmp_path, {"O0::proj::bin::mydec"})
+
+
 def _audit_for_record(key: str, record: dict, old_value: float) -> dict:
     return {
         "summary": {
@@ -733,6 +749,11 @@ def test_standalone_pass_enriches_only_audit(tmp_path: Path) -> None:
                 "historical_overlay_manifest": {
                     "path": str(historical_manifest),
                     "sha256": _sha(historical_manifest),
+                    "slice_count": 1,
+                },
+                "promoted_slice_manifest": {
+                    "path": str(sidecar.resolve()),
+                    "sha256": _sha(sidecar),
                     "slice_count": 1,
                 },
                 "coverage": {

--- a/tests/test_audit_historical_ged_iso.py
+++ b/tests/test_audit_historical_ged_iso.py
@@ -1,0 +1,791 @@
+"""Tests for the standalone historical large-CFG isomorphism audit."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+from pathlib import Path
+
+import networkx as nx
+import pytest
+
+from scripts import audit_historical_ged_iso as historical_iso
+
+
+def _record(
+    *,
+    historical_source: tuple[int, int],
+    historical_decompiled: tuple[int, int],
+    corrected_isomorphic: bool = False,
+) -> dict:
+    return {
+        "historical_source_nodes": historical_source[0],
+        "historical_source_edges": historical_source[1],
+        "historical_decompiled_nodes": historical_decompiled[0],
+        "historical_decompiled_edges": historical_decompiled[1],
+        "historical_over_60": True,
+        "historical_source_basis": "legacy_overlay",
+        "historical_decompiled_parse_mode": "legacy_raw",
+        "historical_parse_selection_reason": "sanitizer_noop",
+        "historical_raw_candidate_present": True,
+        "historical_sanitized_candidate_present": True,
+        "corrected_source_nodes": historical_source[0],
+        "corrected_source_edges": historical_source[1],
+        "corrected_decompiled_nodes": historical_decompiled[0],
+        "corrected_decompiled_edges": historical_decompiled[1],
+        "corrected_over_60": True,
+        "new_value": 0.0 if corrected_isomorphic else 1.0,
+        "new_perfect": corrected_isomorphic,
+        "method": "isomorphism" if corrected_isomorphic else "vj_ged",
+        "isomorphic": corrected_isomorphic,
+        "approximated": False,
+    }
+
+
+def _path_graph(nodes: int) -> nx.DiGraph:
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes))
+    graph.add_edges_from((index, index + 1) for index in range(nodes - 1))
+    return graph
+
+
+def _cycle_partition(nodes: int, split: int) -> nx.DiGraph:
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes))
+    first = list(range(split))
+    second = list(range(split, nodes))
+    graph.add_edges_from(zip(first, first[1:] + first[:1], strict=True))
+    graph.add_edges_from(zip(second, second[1:] + second[:1], strict=True))
+    return graph
+
+
+def _write_source_cache(path: Path, graph: nx.DiGraph) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(pickle.dumps({"per_stem": {"bin": {"f": graph}}}))
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _audit_for_record(key: str, record: dict, old_value: float) -> dict:
+    return {
+        "summary": {
+            "total": {"confirmed_isomorphic": 0},
+            "by_decompiler": {"angr": {"confirmed_isomorphic": 0}},
+        },
+        "records": {
+            key: {
+                **record,
+                "old_value": old_value,
+                "old_perfect": old_value == 0.0,
+                "new_value": record["new_value"],
+                "new_perfect": record["new_perfect"],
+                "changed": old_value != record["new_value"],
+            }
+        },
+    }
+
+
+def _networkx_proof(
+    *,
+    isomorphic: bool = False,
+    counts_match: bool = True,
+    ambiguous: bool = False,
+) -> dict:
+    return {
+        "historical_isomorphic": isomorphic,
+        "historical_iso_proof": (
+            "directed_role_aware_networkx_replay_both_legacy_modes"
+            if ambiguous
+            else "directed_role_aware_networkx_replay"
+        ),
+        "historical_replay_verified": True,
+        "historical_networkx_calls": 2 if ambiguous else 1,
+        "historical_graph_counts_match": counts_match,
+    }
+
+
+def _proof_counts(
+    *,
+    pairs: int = 1,
+    calls: int = 1,
+    mismatches: int = 0,
+    slices: int = 1,
+) -> dict[str, int]:
+    return {
+        "historical_large_pairs": pairs,
+        "networkx_replayed_pairs": pairs,
+        "networkx_isomorphism_calls": calls,
+        "networkx_replay_slices": slices,
+        "count_mismatch_networkx_replays": mismatches,
+    }
+
+
+def test_every_historical_large_pair_is_a_replay_target() -> None:
+    node_key = "O2::proj::bin::angr::nodes"
+    edge_key = "O2::proj::bin::angr::edges"
+    equal_key = "O2::proj::bin::angr::equal"
+    records = {
+        node_key: _record(
+            historical_source=(61, 70),
+            historical_decompiled=(62, 70),
+        ),
+        edge_key: _record(
+            historical_source=(61, 70),
+            historical_decompiled=(61, 71),
+        ),
+        equal_key: _record(
+            historical_source=(61, 70),
+            historical_decompiled=(61, 70),
+        ),
+    }
+
+    replay = historical_iso.historical_iso_targets(records)
+
+    assert set(replay) == {"O2::proj::bin::angr"}
+    assert set(replay["O2::proj::bin::angr"]) == {"nodes", "edges", "equal"}
+
+
+@pytest.mark.parametrize(
+    ("candidate", "candidate_size"),
+    [
+        (_path_graph(62), (62, 61)),
+        (nx.cycle_graph(61, create_using=nx.DiGraph), (61, 61)),
+    ],
+)
+def test_unequal_count_replay_calls_exact_isomorphism(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    candidate: nx.DiGraph,
+    candidate_size: tuple[int, int],
+) -> None:
+    source = _path_graph(61)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "angr_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    monkeypatch.setattr(
+        historical_iso,
+        "extract_cfgs_from_source",
+        lambda *_args, **_kwargs: {"f": candidate},
+    )
+    calls: list[tuple[tuple[int, int], tuple[int, int]]] = []
+
+    def replay(source_cfg: nx.DiGraph, decompiled_cfg: nx.DiGraph) -> bool:
+        calls.append(
+            (
+                (source_cfg.number_of_nodes(), source_cfg.number_of_edges()),
+                (
+                    decompiled_cfg.number_of_nodes(),
+                    decompiled_cfg.number_of_edges(),
+                ),
+            )
+        )
+        return False
+
+    monkeypatch.setattr(historical_iso, "_is_isomorphic", replay)
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=candidate_size,
+    )
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::angr",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    _slice, proofs, _metadata = historical_iso.eval_historical_iso_one(task)
+
+    assert calls == [((61, 60), candidate_size)]
+    assert proofs["f"] == _networkx_proof(counts_match=False)
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        (nx.relabel_nodes(nx.cycle_graph(61, create_using=nx.DiGraph), lambda n: n + 100), True),
+        (_cycle_partition(61, 30), False),
+    ],
+)
+def test_equal_count_replay_runs_exact_isomorphism(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    candidate: nx.DiGraph,
+    expected: bool,
+) -> None:
+    source = nx.cycle_graph(61, create_using=nx.DiGraph)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "angr_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    monkeypatch.setattr(
+        historical_iso,
+        "extract_cfgs_from_source",
+        lambda *_args, **_kwargs: {"f": candidate},
+    )
+    record = _record(
+        historical_source=(61, 61),
+        historical_decompiled=(61, 61),
+    )
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::angr",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {"signature": "test"},
+    )
+
+    _slice, proofs, metadata = historical_iso.eval_historical_iso_one(task)
+
+    assert proofs["f"]["historical_isomorphic"] is expected
+    assert proofs["f"]["historical_replay_verified"] is True
+    assert metadata == {"signature": "test"}
+
+
+def test_replay_rejects_changed_graph_sizes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _path_graph(61)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "angr_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    monkeypatch.setattr(
+        historical_iso,
+        "extract_cfgs_from_source",
+        lambda *_args, **_kwargs: {"f": _path_graph(60)},
+    )
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::angr",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    with pytest.raises(RuntimeError, match="decompiled sizes changed"):
+        historical_iso.eval_historical_iso_one(task)
+
+
+def test_replay_uses_same_optimization_source_basis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _path_graph(61)
+    current = tmp_path / "current.pkl"
+    _write_source_cache(current, source)
+    artifact = tmp_path / "angr_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    monkeypatch.setattr(
+        historical_iso,
+        "extract_cfgs_from_source",
+        lambda *_args, **_kwargs: {"f": nx.relabel_nodes(source, lambda node: node + 100)},
+    )
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    record["historical_source_basis"] = "same_opt_inline"
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::angr",
+        str(artifact),
+        str(current),
+        "",
+        {"f": record},
+        {},
+    )
+
+    _slice, proofs, _metadata = historical_iso.eval_historical_iso_one(task)
+
+    assert proofs["f"]["historical_isomorphic"] is True
+
+
+def test_replay_uses_raw_candidate_for_legacy_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _path_graph(61)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "ida_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\n__int128 f(void) { return 0; }\n")
+    calls: list[bool] = []
+
+    def extract(*_args: object, **kwargs: object) -> dict:
+        calls.append(bool(kwargs["sanitize_decompiled"]))
+        return {"f": source}
+
+    monkeypatch.setattr(historical_iso, "extract_cfgs_from_source", extract)
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::ida",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    historical_iso.eval_historical_iso_one(task)
+
+    assert calls == [False]
+
+
+def test_replay_uses_sanitized_candidate_for_reconciled_legacy_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _path_graph(61)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "binja_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    calls: list[tuple[bool, bool]] = []
+
+    def extract(*_args: object, **kwargs: object) -> dict:
+        calls.append(
+            (
+                bool(kwargs["sanitize_decompiled"]),
+                bool(kwargs["preprocess_decompiled"]),
+            )
+        )
+        return {"f": source}
+
+    monkeypatch.setattr(historical_iso, "extract_cfgs_from_source", extract)
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    record["historical_decompiled_parse_mode"] = "legacy_sanitized"
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::binja",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    historical_iso.eval_historical_iso_one(task)
+
+    assert calls == [(True, False)]
+
+
+def test_ambiguous_legacy_replay_requires_both_modes_to_agree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _path_graph(61)
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, source)
+    artifact = tmp_path / "binja_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    calls: list[bool] = []
+
+    def extract(*_args: object, **kwargs: object) -> dict:
+        calls.append(bool(kwargs["sanitize_decompiled"]))
+        return {"f": nx.relabel_nodes(source, lambda node: node + len(calls) * 100)}
+
+    monkeypatch.setattr(historical_iso, "extract_cfgs_from_source", extract)
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    record["historical_decompiled_parse_mode"] = "legacy_raw_or_sanitized_same_fallback"
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::binja",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    _slice, proofs, _metadata = historical_iso.eval_historical_iso_one(task)
+
+    assert calls == [False, True]
+    assert proofs["f"]["historical_isomorphic"] is True
+    assert (
+        proofs["f"]["historical_iso_proof"]
+        == "directed_role_aware_networkx_replay_both_legacy_modes"
+    )
+    assert proofs["f"]["historical_networkx_calls"] == 2
+
+
+def test_replay_propagates_strict_parser_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy = tmp_path / "legacy.pkl"
+    _write_source_cache(legacy, _path_graph(61))
+    artifact = tmp_path / "angr_bin.c"
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+
+    def fail_parse(*_args: object, **_kwargs: object) -> dict:
+        raise RuntimeError("strict Joern failure")
+
+    monkeypatch.setattr(historical_iso, "extract_cfgs_from_source", fail_parse)
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(61, 60),
+    )
+    task: historical_iso.ReplayTask = (
+        "O2::proj::bin::angr",
+        str(artifact),
+        "",
+        str(legacy),
+        {"f": record},
+        {},
+    )
+
+    with pytest.raises(RuntimeError, match="strict Joern failure"):
+        historical_iso.eval_historical_iso_one(task)
+
+
+def test_replay_dependency_metadata_invalidates_changed_inputs(tmp_path: Path) -> None:
+    root = tmp_path / "results"
+    artifact = root / "O2/proj/decompiled/angr_bin.c"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("first")
+    score_checkpoint = root / "reeval_ged/O2__proj__bin__angr.json"
+    score_checkpoint.parent.mkdir()
+    score_checkpoint.write_text("{}")
+    legacy = root / "ged_src/proj.pkl"
+    legacy.parent.mkdir()
+    legacy.write_bytes(b"source")
+    targets = {
+        "f": _record(
+            historical_source=(61, 61),
+            historical_decompiled=(61, 61),
+        )
+    }
+
+    before = historical_iso.replay_dependency_meta(
+        root,
+        "O2::proj::bin::angr",
+        artifact,
+        score_checkpoint,
+        targets,
+    )
+    artifact.write_text("second")
+    after = historical_iso.replay_dependency_meta(
+        root,
+        "O2::proj::bin::angr",
+        artifact,
+        score_checkpoint,
+        targets,
+    )
+
+    assert before["artifact_sha256"] != after["artifact_sha256"]
+    assert before["ged_checkpoint_sha256"] == after["ged_checkpoint_sha256"]
+    assert before["source_cache_sha256"] == after["source_cache_sha256"]
+
+
+def test_replay_checkpoint_must_cover_exact_targets(tmp_path: Path) -> None:
+    path = tmp_path / "proof.json"
+    metadata = {"schema_version": 1}
+    proof = _networkx_proof()
+    path.write_text(json.dumps({"_meta": metadata, "proofs": {"f": proof}}))
+
+    assert historical_iso.valid_replay_checkpoint(path, metadata, {"f"}) == {"f": proof}
+    assert historical_iso.valid_replay_checkpoint(path, metadata, {"f", "g"}) is None
+    assert (
+        historical_iso.valid_replay_checkpoint(
+            path,
+            {"schema_version": 2},
+            {"f"},
+        )
+        is None
+    )
+
+
+def test_corrected_status_uses_historical_over_60_population() -> None:
+    key = "O2::proj::bin::angr::f"
+    record = _record(
+        historical_source=(61, 70),
+        historical_decompiled=(60, 69),
+        corrected_isomorphic=True,
+    )
+    record.update(
+        {
+            "corrected_source_nodes": 50,
+            "corrected_source_edges": 55,
+            "corrected_decompiled_nodes": 50,
+            "corrected_decompiled_edges": 55,
+            "corrected_over_60": False,
+        }
+    )
+    proof = _networkx_proof(counts_match=False)
+
+    enriched = historical_iso.enrich_audit(
+        _audit_for_record(key, record, old_value=2.0),
+        {key: record},
+        {key: proof},
+        _proof_counts(mismatches=1),
+    )
+
+    total = enriched["summary"]["total"]
+    assert total["corrected_isomorphic_for_historical_over_60"] == 1
+    assert total["corrected_nonisomorphic_for_historical_over_60"] == 0
+    assert total["corrected_isomorphism_unavailable_for_historical_over_60"] == 0
+
+
+def test_equal_count_nonisomorphic_old_zero_is_false_perfect() -> None:
+    key = "O2::proj::bin::angr::f"
+    record = _record(
+        historical_source=(61, 61),
+        historical_decompiled=(61, 61),
+    )
+    proof = _networkx_proof()
+
+    enriched = historical_iso.enrich_audit(
+        _audit_for_record(key, record, old_value=0.0),
+        {key: record},
+        {key: proof},
+        _proof_counts(),
+    )
+
+    total = enriched["summary"]["total"]
+    assert total["historical_confirmed_nonisomorphic"] == 1
+    assert total["historical_false_perfect"] == 1
+    assert enriched["summary"]["by_decompiler"]["angr"]["historical_false_perfect"] == 1
+
+
+def test_published_fallback_mismatch_does_not_claim_reconstructed_identity() -> None:
+    key = "O2::coreutils::factor::ida::factor_using_pollard_rho2"
+    record = _record(
+        historical_source=(112, 178),
+        historical_decompiled=(64, 95),
+    )
+    reconstructed_proof = _networkx_proof(counts_match=False)
+
+    enriched = historical_iso.enrich_audit(
+        _audit_for_record(key, record, old_value=138.0),
+        {key: record},
+        {key: reconstructed_proof},
+        _proof_counts(mismatches=1),
+    )
+
+    enriched_record = enriched["records"][key]
+    assert enriched_record["historical_size_fallback_expected_from_reconstruction"] == 131
+    assert enriched_record["historical_size_fallback_matches_published"] is False
+    assert (
+        enriched_record["historical_size_reconstruction_provenance"]
+        == "published_fallback_differs_from_reconstructed_sizes"
+    )
+    assert enriched_record["historical_isomorphic"] is False
+    assert enriched_record["historical_iso_proof"] == "directed_role_aware_networkx_replay"
+    total = enriched["summary"]["total"]
+    assert total["historical_count_mismatch_networkx_replays"] == 1
+    assert total["historical_reconstructed_fallback_mismatches_published"] == 1
+
+
+def test_fallback_mismatch_is_not_counted_as_historical_false_perfect() -> None:
+    key = "O2::proj::bin::angr::f"
+    record = _record(
+        historical_source=(61, 70),
+        historical_decompiled=(60, 69),
+    )
+    proof = _networkx_proof(counts_match=False)
+
+    enriched = historical_iso.enrich_audit(
+        _audit_for_record(key, record, old_value=0.0),
+        {key: record},
+        {key: proof},
+        _proof_counts(mismatches=1),
+    )
+
+    assert enriched["summary"]["total"]["historical_false_perfect"] == 0
+    assert (
+        enriched["summary"]["total"]["historical_reconstructed_fallback_mismatches_published"] == 1
+    )
+
+
+def test_new_only_historical_reconstruction_has_no_published_identity() -> None:
+    key = "O2::proj::bin::manifold::f"
+    record = _record(
+        historical_source=(61, 70),
+        historical_decompiled=(60, 69),
+    )
+    proof = _networkx_proof(counts_match=False)
+    audit = _audit_for_record(key, record, old_value=2.0)
+    audit["records"][key]["old_value"] = None
+    audit["records"][key]["old_perfect"] = False
+    audit["summary"]["by_decompiler"] = {"manifold": audit["summary"]["by_decompiler"].pop("angr")}
+
+    enriched = historical_iso.enrich_audit(
+        audit,
+        {key: record},
+        {key: proof},
+        _proof_counts(mismatches=1),
+    )
+
+    enriched_record = enriched["records"][key]
+    assert enriched_record["historical_size_fallback_matches_published"] is None
+    assert enriched_record["historical_size_reconstruction_provenance"] == "no_published_baseline"
+    assert enriched_record["historical_isomorphic"] is False
+    assert (
+        enriched["summary"]["total"]["historical_reconstructed_fallback_without_published_score"]
+        == 1
+    )
+
+
+def test_standalone_pass_enriches_only_audit(tmp_path: Path) -> None:
+    root = tmp_path / "results"
+    artifact = root / "O0/proj/decompiled/angr_bin.c"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("// Function: f @ 0x1000\nint f(void) { return 0; }\n")
+    source_cache = root / "ged_src/v1/projects/O0/proj.pkl"
+    _write_source_cache(source_cache, _path_graph(61))
+    legacy_source_cache = root / "ged_src/proj.pkl"
+    _write_source_cache(legacy_source_cache, _path_graph(61))
+
+    slice_key = "O0::proj::bin::angr"
+    function_key = f"{slice_key}::f"
+    record = _record(
+        historical_source=(61, 60),
+        historical_decompiled=(60, 59),
+    )
+    score = {"value": 1.0, "perfect": False}
+    score_checkpoint = historical_iso.checkpoint_path(root, slice_key)
+    score_checkpoint.parent.mkdir()
+    score_checkpoint.write_text(
+        json.dumps(
+            {
+                "_meta": historical_iso.checkpoint_metadata(
+                    historical_iso.checkpoint_signature(),
+                    True,
+                    {"f": 2.0},
+                ),
+                "scores": {"f": score},
+                "over_previous_limit": {"f": record},
+            }
+        )
+    )
+    replay_metadata = historical_iso.replay_dependency_meta(
+        root,
+        slice_key,
+        artifact,
+        score_checkpoint,
+        {"f": record},
+    )
+    replay_checkpoint = historical_iso.replay_checkpoint_path(root, slice_key)
+    replay_checkpoint.parent.mkdir()
+    replay_checkpoint.write_text(
+        json.dumps(
+            {
+                "_meta": replay_metadata,
+                "proofs": {"f": _networkx_proof(counts_match=False)},
+            }
+        )
+    )
+    overlay = root / "ged_new.json"
+    sidecar = root / "ged_new.slices.json"
+    overlay.write_text(json.dumps({function_key: score}))
+    sidecar.write_text(json.dumps([slice_key]))
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "groups": [
+                    {
+                        "opt_level": "O0",
+                        "project": "proj",
+                        "binary": "bin",
+                        "functions": [
+                            {
+                                "function": "f",
+                                "values": {"angr": {"ged": 2.0}},
+                                "perfects": {"angr": {"ged": False}},
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    historical_manifest = tmp_path / "historical-slices.json"
+    historical_manifest.write_text(json.dumps([slice_key]))
+    audit_path = root / "ged_large_graph_audit.json"
+    audit_path.write_text(
+        json.dumps(
+            {
+                "new_evaluator": historical_iso.checkpoint_signature(),
+                "comparison_baseline": {
+                    "path": str(baseline_path),
+                    "sha256": _sha(baseline_path),
+                },
+                "historical_overlay_manifest": {
+                    "path": str(historical_manifest),
+                    "sha256": _sha(historical_manifest),
+                    "slice_count": 1,
+                },
+                "coverage": {
+                    "published_scores_before": 1,
+                    "scores_after_reevaluation": 1,
+                },
+                "summary": {
+                    "total": {"confirmed_isomorphic": 0},
+                    "by_decompiler": {"angr": {"confirmed_isomorphic": 0}},
+                },
+                "records": {
+                    function_key: {
+                        **record,
+                        "old_value": 2.0,
+                        "old_perfect": False,
+                        "new_value": 1.0,
+                        "new_perfect": False,
+                        "changed": True,
+                    }
+                },
+            }
+        )
+    )
+    protected = {
+        score_checkpoint: _sha(score_checkpoint),
+        overlay: _sha(overlay),
+        sidecar: _sha(sidecar),
+    }
+
+    enriched = historical_iso.run_audit(root, workers=1)
+
+    assert all(_sha(path) == digest for path, digest in protected.items())
+    enriched_record = enriched["records"][function_key]
+    assert enriched_record["historical_isomorphic"] is False
+    assert enriched_record["historical_iso_proof"] == "directed_role_aware_networkx_replay"
+    assert enriched_record["historical_replay_verified"] is True
+    assert enriched_record["historical_networkx_calls"] == 1
+    assert enriched_record["historical_size_fallback_matches_published"] is True
+    assert enriched_record["corrected_isomorphic"] is False
+    assert "isomorphic" not in enriched_record
+    total = enriched["summary"]["total"]
+    assert total["historical_confirmed_nonisomorphic"] == 1
+    assert total["historical_networkx_replayed_pairs"] == 1
+    assert total["historical_count_mismatch_networkx_replays"] == 1
+    assert total["historical_false_perfect"] == 0
+    assert total["corrected_nonisomorphic_for_historical_over_60"] == 1
+    assert "confirmed_isomorphic" not in total
+    assert enriched["historical_isomorphism_audit"] == {
+        "schema_version": 4,
+        "isomorphism_semantics": "directed-role-aware-networkx-all-large-pairs-v3",
+        "historical_large_pairs": 1,
+        "networkx_replayed_pairs": 1,
+        "networkx_isomorphism_calls": 1,
+        "networkx_replay_slices": 1,
+        "count_mismatch_networkx_replays": 1,
+    }

--- a/tests/test_caching_dataset_subset.py
+++ b/tests/test_caching_dataset_subset.py
@@ -24,7 +24,6 @@ from decbench.dataset import (
     save_dataset,
 )
 from decbench.metrics.byte_match import ByteMatchMetric
-from decbench.utils.binfmt import function_bytes as _extract_function_bytes
 from decbench.metrics.ged import GEDMetric
 from decbench.metrics.type_match import TypeMatchMetric
 from decbench.models.decompilation import FunctionDecompilation, VariableInfo
@@ -36,6 +35,7 @@ from decbench.scoring.subset import (
     filter_function_data,
     size_distribution,
 )
+from decbench.utils.binfmt import function_bytes as _extract_function_bytes
 
 
 @pytest.fixture
@@ -102,6 +102,30 @@ def test_ged_cache_hit_across_fresh_instance(cache_dir):
     )
     metric2.compute_for_function(fd, source_cfg=g1, decompiled_cfg=g2)
     assert calls["n"] == 0, "value should come from the on-disk cache"
+
+
+def test_ged_cache_distinguishes_same_string_node_topologies(cache_dir):
+    class CFGNode:
+        is_entrypoint = False
+        is_exitpoint = False
+
+        def __str__(self) -> str:
+            return "same"
+
+    def graph(edges: list[tuple[int, int]]) -> nx.DiGraph:
+        nodes = [CFGNode() for _ in range(4)]
+        cfg = nx.DiGraph()
+        cfg.add_edges_from((nodes[src], nodes[dst]) for src, dst in edges)
+        return cfg
+
+    source = graph([(0, 1), (1, 2), (2, 3)])
+    same_path = graph([(0, 1), (1, 2), (2, 3)])
+    out_star = graph([(0, 1), (0, 2), (0, 3)])
+    fd = FunctionDecompilation(name="f", address=0x10, decompiled_code="", line_count=0)
+    metric = GEDMetric()
+
+    assert metric.compute_for_function(fd, source_cfg=source, decompiled_cfg=same_path).value == 0
+    assert metric.compute_for_function(fd, source_cfg=source, decompiled_cfg=out_star).value > 0
 
 
 def test_no_cache_disables_caching(cache_dir, monkeypatch):

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -1,0 +1,180 @@
+"""Tests for CFG input preparation."""
+
+import shutil
+from pathlib import Path
+
+import pyjoern
+import pytest
+
+from decbench.models.decompilation import (
+    DecompilationResult,
+    DecompilerMetadata,
+    FunctionDecompilation,
+)
+from decbench.utils.cfg import (
+    extract_cfgs_from_decompilation,
+    extract_cfgs_from_source,
+    preprocess_decompiled_c,
+)
+
+
+def test_preprocess_decompiled_c_expands_local_macros() -> None:
+    if shutil.which("gcc") is None and shutil.which("cc") is None:
+        pytest.skip("host C preprocessor is unavailable")
+
+    text = """
+#include <stdio.h>
+#define CHECK(value) do { if (!(value)) fail(7); } while (0)
+void target(int value) {
+    CHECK(value);
+}
+"""
+
+    preprocessed = preprocess_decompiled_c(text)
+
+    assert "#define" not in preprocessed
+    assert "#include" not in preprocessed
+    assert "CHECK" not in preprocessed
+    assert "if (!(value)) fail(7)" in preprocessed
+
+
+def test_preprocess_decompiled_c_skips_plain_text() -> None:
+    text = "void target(void) { return; }\n"
+    assert preprocess_decompiled_c(text) == text
+
+
+def test_preprocess_decompiled_c_protects_function_name_from_macro() -> None:
+    if shutil.which("gcc") is None and shutil.which("cc") is None:
+        pytest.skip("host C preprocessor is unavailable")
+
+    text = """
+// Function: usage @ 0x1000
+#define usage(message) translate(message)
+/* usage (via diagnostics) must not be mistaken for the definition. */
+void usage(int status) {
+    print(usage("help"));
+}
+"""
+
+    preprocessed = preprocess_decompiled_c(text)
+
+    assert "void usage(int status)" in preprocessed
+    assert 'print(translate("help"))' in preprocessed
+    assert "__decbench_function_" not in preprocessed
+
+
+def test_preprocess_decompiled_c_protects_object_macro_collision() -> None:
+    if shutil.which("gcc") is None and shutil.which("cc") is None:
+        pytest.skip("host C preprocessor is unavailable")
+
+    text = """
+// Function: target @ 0x1000
+#define target 2
+static int
+target(void) {
+    return target;
+}
+"""
+
+    preprocessed = preprocess_decompiled_c(text)
+
+    assert "target(void)" in preprocessed
+    assert "return 2" in preprocessed
+
+
+def test_extract_cfgs_from_decompilation_marks_source_before_preprocessing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if shutil.which("gcc") is None and shutil.which("cc") is None:
+        pytest.skip("host C preprocessor is unavailable")
+
+    parsed_text: list[str] = []
+
+    def capture_parse(path: Path) -> dict[str, object]:
+        parsed_text.append(path.read_text())
+        return {}
+
+    monkeypatch.setattr(pyjoern, "parse_source", capture_parse)
+    result = DecompilationResult(
+        binary_path=tmp_path / "binary",
+        binary_name="binary",
+        decompiler=DecompilerMetadata(decompiler_name="test"),
+        functions={
+            "target": FunctionDecompilation(
+                name="target",
+                address=0x1000,
+                decompiled_code="""
+#define target 2
+static int target(void) {
+    return target;
+}
+""",
+            )
+        },
+    )
+
+    assert extract_cfgs_from_decompilation(result) == {}
+    assert len(parsed_text) == 1
+    assert "static int target(void)" in parsed_text[0]
+    assert "return 2" in parsed_text[0]
+
+
+def test_extract_cfgs_from_decompilation_preprocesses_combined_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if shutil.which("gcc") is None and shutil.which("cc") is None:
+        pytest.skip("host C preprocessor is unavailable")
+
+    parsed_text: list[str] = []
+
+    def capture_parse(path: Path) -> dict[str, object]:
+        parsed_text.append(path.read_text())
+        return {}
+
+    monkeypatch.setattr(pyjoern, "parse_source", capture_parse)
+    result = DecompilationResult(
+        binary_path=tmp_path / "binary",
+        binary_name="binary",
+        decompiler=DecompilerMetadata(decompiler_name="test"),
+        functions={
+            "define_value": FunctionDecompilation(
+                name="define_value",
+                address=0x1000,
+                decompiled_code="""
+#define LOCAL_VALUE 7
+int define_value(void) {
+    return LOCAL_VALUE;
+}
+""",
+            ),
+            "use_value": FunctionDecompilation(
+                name="use_value",
+                address=0x2000,
+                decompiled_code="""
+int use_value(void) {
+    return LOCAL_VALUE;
+}
+""",
+            ),
+        },
+    )
+
+    assert extract_cfgs_from_decompilation(result) == {}
+    assert len(parsed_text) == 1
+    assert parsed_text[0].count("return 7") == 2
+
+
+def test_extract_cfgs_strict_mode_propagates_parser_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_path = tmp_path / "target.c"
+    source_path.write_text("void target(void) {}\n")
+
+    def fail_parse(_path: Path) -> None:
+        raise RuntimeError("parser failed")
+
+    monkeypatch.setattr(pyjoern, "parse_source", fail_parse)
+
+    assert extract_cfgs_from_source(source_path) == {}
+    with pytest.raises(RuntimeError, match="parser failed"):
+        extract_cfgs_from_source(source_path, raise_on_error=True)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -160,6 +160,274 @@ class TestGEDMetric:
         result = metric.compute_for_function(func, source_cfg=g, decompiled_cfg=g)
         assert result.value == 0.0
 
+    def test_ged_large_isomorphic_cfgs_bypass_limit(self, monkeypatch) -> None:
+        """Graph isomorphism is checked before the VJ-GED size cutoff."""
+        import networkx as nx
+
+        import decbench.metrics.ged as ged_module
+        from decbench.metrics.ged import GEDMetric
+
+        class CFGNode:
+            def __init__(self, index: int, *, entry: bool = False, exit: bool = False):
+                self.index = index
+                self.is_entrypoint = entry
+                self.is_exitpoint = exit
+
+        def path_graph() -> nx.DiGraph:
+            nodes = [CFGNode(i, entry=i == 0, exit=i == 7) for i in range(8)]
+            graph = nx.DiGraph()
+            graph.add_edges_from(zip(nodes, nodes[1:], strict=False))
+            return graph
+
+        monkeypatch.setattr(ged_module, "GED_MAX_NODES", 3)
+        monkeypatch.setenv("DECBENCH_NO_CACHE", "1")
+        metric = GEDMetric()
+        metric._get_vj_ged = lambda: pytest.fail("VJ-GED must not run for isomorphic CFGs")
+        func = FunctionDecompilation(name="test", address=0x1000, decompiled_code="")
+
+        result = metric.compute_for_function(
+            func,
+            source_cfg=path_graph(),
+            decompiled_cfg=path_graph(),
+        )
+
+        assert result.value == 0.0
+        assert result.metadata["method"] == "isomorphism"
+        assert result.metadata["isomorphic"] is True
+
+    def test_refined_isomorphism_matches_role_aware_networkx(self) -> None:
+        """Joint refinement only prunes; it does not change isomorphism."""
+        import random
+
+        import networkx as nx
+
+        from decbench.metrics.ged import _is_isomorphic, _role_graph
+
+        class CFGNode:
+            def __init__(self, index: int, *, entry: bool = False, exit: bool = False):
+                self.index = index
+                self.is_entrypoint = entry
+                self.is_exitpoint = exit
+
+        rng = random.Random(20260728)
+        role_match = nx.algorithms.isomorphism.categorical_node_match(
+            "role",
+            (False, False),
+        )
+        for node_count in range(2, 18):
+            source_nodes = [
+                CFGNode(
+                    index,
+                    entry=index == 0,
+                    exit=index == node_count - 1,
+                )
+                for index in range(node_count)
+            ]
+            decompiled_nodes = [
+                CFGNode(
+                    index,
+                    entry=index == 0,
+                    exit=index == node_count - 1,
+                )
+                for index in range(node_count)
+            ]
+            source = nx.DiGraph()
+            source.add_nodes_from(source_nodes)
+            for left in source_nodes:
+                for right in source_nodes:
+                    if left is not right and rng.random() < 0.14:
+                        source.add_edge(left, right)
+
+            permutation = list(range(node_count))
+            rng.shuffle(permutation)
+            decompiled = nx.DiGraph()
+            decompiled.add_nodes_from(decompiled_nodes[index] for index in permutation)
+            decompiled.add_edges_from(
+                (
+                    decompiled_nodes[left.index],
+                    decompiled_nodes[right.index],
+                )
+                for left, right in source.edges()
+            )
+
+            assert _is_isomorphic(source, decompiled)
+            assert nx.is_isomorphic(
+                _role_graph(source),
+                _role_graph(decompiled),
+                node_match=role_match,
+            )
+
+            if source.number_of_edges() > 0:
+                left, right = next(iter(decompiled.edges()))
+                decompiled.remove_edge(left, right)
+                expected = nx.is_isomorphic(
+                    _role_graph(source),
+                    _role_graph(decompiled),
+                    node_match=role_match,
+                )
+                assert _is_isomorphic(source, decompiled) is expected
+
+    def test_ged_large_role_mismatch_cannot_approximate_to_zero(self, monkeypatch) -> None:
+        """Equal-sized non-isomorphic CFGs remain non-perfect above the cutoff."""
+        import networkx as nx
+
+        import decbench.metrics.ged as ged_module
+        from decbench.metrics.ged import GEDMetric
+
+        class CFGNode:
+            def __init__(self, index: int, *, entry: bool = False, exit: bool = False):
+                self.index = index
+                self.is_entrypoint = entry
+                self.is_exitpoint = exit
+
+        def path_graph(*, reverse_roles: bool) -> nx.DiGraph:
+            nodes = [
+                CFGNode(
+                    i,
+                    entry=i == (7 if reverse_roles else 0),
+                    exit=i == (0 if reverse_roles else 7),
+                )
+                for i in range(8)
+            ]
+            graph = nx.DiGraph()
+            graph.add_edges_from(zip(nodes, nodes[1:], strict=False))
+            return graph
+
+        monkeypatch.setattr(ged_module, "GED_MAX_NODES", 3)
+        monkeypatch.setenv("DECBENCH_NO_CACHE", "1")
+        metric = GEDMetric()
+        metric._get_vj_ged = lambda: pytest.fail("VJ-GED must not run above the cutoff")
+        func = FunctionDecompilation(name="test", address=0x1000, decompiled_code="")
+
+        result = metric.compute_for_function(
+            func,
+            source_cfg=path_graph(reverse_roles=False),
+            decompiled_cfg=path_graph(reverse_roles=True),
+        )
+
+        assert result.value == 1.0
+        assert result.metadata["method"] == "size_lower_bound"
+        assert result.metadata["isomorphic"] is False
+        assert result.metadata["approximated"] is True
+
+    def test_ged_nonisomorphic_vj_zero_cannot_be_perfect(self, monkeypatch) -> None:
+        """VJ-GED's degree-only zero is not a perfect structural match."""
+        pytest.importorskip("cfgutils")
+        import networkx as nx
+
+        from decbench.metrics.ged import GEDMetric
+
+        class CFGNode:
+            is_entrypoint = False
+            is_exitpoint = False
+
+        source_nodes = [CFGNode() for _ in range(6)]
+        source = nx.DiGraph()
+        source.add_edges_from(
+            (source_nodes[index], source_nodes[(index + 1) % 6]) for index in range(6)
+        )
+
+        decompiled_nodes = [CFGNode() for _ in range(6)]
+        decompiled = nx.DiGraph()
+        decompiled.add_edges_from(
+            [
+                (decompiled_nodes[0], decompiled_nodes[1]),
+                (decompiled_nodes[1], decompiled_nodes[2]),
+                (decompiled_nodes[2], decompiled_nodes[0]),
+                (decompiled_nodes[3], decompiled_nodes[4]),
+                (decompiled_nodes[4], decompiled_nodes[5]),
+                (decompiled_nodes[5], decompiled_nodes[3]),
+            ]
+        )
+
+        monkeypatch.setenv("DECBENCH_NO_CACHE", "1")
+        func = FunctionDecompilation(name="test", address=0x1000, decompiled_code="")
+        result = GEDMetric().compute_for_function(
+            func,
+            source_cfg=source,
+            decompiled_cfg=decompiled,
+        )
+
+        assert result.value == 1.0
+        assert result.raw_value == 0.0
+        assert result.metadata["vj_ged_raw"] == 0.0
+        assert result.metadata["isomorphic"] is False
+
+    def test_ged_vj_defaults_missing_node_roles_to_false(self, monkeypatch) -> None:
+        """Plain NetworkX nodes use the same default roles in exact and VJ paths."""
+        import math
+
+        import networkx as nx
+
+        from decbench.metrics.ged import GEDMetric
+
+        source = nx.DiGraph([(0, 1), (1, 2), (2, 3)])
+        decompiled = nx.DiGraph([(0, 1), (0, 2), (0, 3)])
+        monkeypatch.setenv("DECBENCH_NO_CACHE", "1")
+        func = FunctionDecompilation(name="test", address=0x1000, decompiled_code="")
+
+        result = GEDMetric().compute_for_function(
+            func,
+            source_cfg=source,
+            decompiled_cfg=decompiled,
+        )
+
+        assert math.isfinite(result.value)
+        assert result.value > 0.0
+        assert result.metadata["method"] == "vj_ged"
+
+    def test_accelerated_vj_ged_matches_cfgutils(self) -> None:
+        """The compiled assignment solver preserves cfgutils' VJ-GED values."""
+        import random
+
+        import networkx as nx
+        from cfgutils.similarity import vj_ged as cfgutils_vj_ged
+
+        from decbench.metrics.vj_ged import vj_ged
+
+        class CFGNode:
+            def __init__(self, index: int, *, entry: bool, exit: bool):
+                self.index = index
+                self.is_entrypoint = entry
+                self.is_exitpoint = exit
+
+        rng = random.Random(20260727)
+        for source_count in range(1, 9):
+            for decompiled_count in range(1, 9):
+                source_nodes = [
+                    CFGNode(
+                        index,
+                        entry=index == 0 and rng.random() < 0.8,
+                        exit=index == source_count - 1 and rng.random() < 0.8,
+                    )
+                    for index in range(source_count)
+                ]
+                decompiled_nodes = [
+                    CFGNode(
+                        index,
+                        entry=index == 0 and rng.random() < 0.8,
+                        exit=index == decompiled_count - 1 and rng.random() < 0.8,
+                    )
+                    for index in range(decompiled_count)
+                ]
+                source = nx.DiGraph()
+                source.add_nodes_from(source_nodes)
+                decompiled = nx.DiGraph()
+                decompiled.add_nodes_from(decompiled_nodes)
+                for left in source_nodes:
+                    for right in source_nodes:
+                        if left is not right and rng.random() < 0.2:
+                            source.add_edge(left, right)
+                for left in decompiled_nodes:
+                    for right in decompiled_nodes:
+                        if left is not right and rng.random() < 0.2:
+                            decompiled.add_edge(left, right)
+
+                assert vj_ged(source, decompiled) == cfgutils_vj_ged(
+                    source,
+                    decompiled,
+                )
+
 
 class TestTypeMatchMetric:
     """Tests for the type match metric."""

--- a/tests/test_reeval_ged.py
+++ b/tests/test_reeval_ged.py
@@ -66,6 +66,14 @@ def _graph(nodes: int, edges: int) -> nx.DiGraph:
     return graph
 
 
+def test_promoted_decompilers_keep_builtins_and_selected_external_ids() -> None:
+    promoted = reeval_ged.promoted_decompilers(("angr", "mydec", "ghidra@12.1"))
+
+    assert promoted[: len(reeval_ged.CANONICAL_DECOMPILERS)] == (reeval_ged.CANONICAL_DECOMPILERS)
+    assert promoted.count("angr") == 1
+    assert promoted[-2:] == ("mydec", "ghidra@12.1")
+
+
 @pytest.mark.parametrize(
     ("baseline", "historical_slices"),
     [

--- a/tests/test_reeval_ged.py
+++ b/tests/test_reeval_ged.py
@@ -1,0 +1,810 @@
+"""Tests for the full-tree GED reevaluation audit."""
+
+import json
+import pickle
+from pathlib import Path
+from types import SimpleNamespace
+
+import networkx as nx
+import pytest
+
+from scripts import reeval_ged
+from scripts.reeval_ged import (
+    LEGACY_AMBIGUOUS,
+    LEGACY_RAW,
+    LEGACY_SANITIZED,
+    build_large_graph_audit,
+    build_tasks,
+    checkpoint_metadata,
+    eval_one,
+    historical_overlay_slices,
+    load_published_ged_scores,
+    migrate_compatible_checkpoints,
+    select_ambiguous_legacy_cfg,
+    select_legacy_parse_mode,
+    source_cache_path,
+)
+
+
+def _large_record(
+    *,
+    source_nodes: int,
+    decompiled_nodes: int,
+    method: str,
+    isomorphic: bool,
+    value: float,
+) -> dict:
+    return {
+        "historical_source_nodes": source_nodes,
+        "historical_source_edges": source_nodes + 1,
+        "historical_decompiled_nodes": decompiled_nodes,
+        "historical_decompiled_edges": decompiled_nodes + 1,
+        "historical_over_60": source_nodes > 60 or decompiled_nodes > 60,
+        "corrected_source_nodes": source_nodes,
+        "corrected_source_edges": source_nodes + 1,
+        "corrected_decompiled_nodes": decompiled_nodes,
+        "corrected_decompiled_edges": decompiled_nodes + 1,
+        "corrected_over_60": source_nodes > 60 or decompiled_nodes > 60,
+        "new_value": value,
+        "new_perfect": value == 0.0,
+        "method": method,
+        "isomorphic": isomorphic,
+        "approximated": method == "size_lower_bound",
+    }
+
+
+def _graph(nodes: int, edges: int) -> nx.DiGraph:
+    graph = nx.DiGraph()
+    graph.add_nodes_from(range(nodes))
+    candidates = (
+        (source, target) for source in range(nodes) for target in range(nodes) if source != target
+    )
+    for edge in candidates:
+        if graph.number_of_edges() == edges:
+            break
+        graph.add_edge(*edge)
+    return graph
+
+
+@pytest.mark.parametrize(
+    ("baseline", "historical_slices"),
+    [
+        (None, None),
+        ("baseline.json", None),
+        (None, "historical-slices.json"),
+    ],
+)
+def test_main_requires_both_frozen_provenance_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    baseline: str | None,
+    historical_slices: str | None,
+) -> None:
+    monkeypatch.setattr(
+        reeval_ged.sys,
+        "argv",
+        ["scripts/reeval_ged.py", str(tmp_path)],
+    )
+    monkeypatch.delenv("DECBENCH_GED_BASELINE", raising=False)
+    monkeypatch.delenv("DECBENCH_GED_HISTORICAL_SLICES", raising=False)
+    if baseline is not None:
+        monkeypatch.setenv("DECBENCH_GED_BASELINE", baseline)
+    if historical_slices is not None:
+        monkeypatch.setenv(
+            "DECBENCH_GED_HISTORICAL_SLICES",
+            historical_slices,
+        )
+
+    with pytest.raises(RuntimeError, match="are both required"):
+        reeval_ged.main()
+
+
+def test_legacy_parse_mode_uses_published_candidate_coverage() -> None:
+    source = {"f": _graph(136, 196)}
+    sanitized = {"f": _graph(98, 148)}
+
+    mode, reason = select_legacy_parse_mode(
+        "O2::bash::bash::binja",
+        source,
+        {},
+        sanitized,
+        {"f": 86.0},
+        sanitizer_changed=True,
+    )
+
+    assert mode == LEGACY_SANITIZED
+    assert reason == "f:published_candidate_coverage"
+
+
+def test_checkpoint_metadata_binds_legacy_score_evidence() -> None:
+    signature = {
+        "schema_version": 6,
+        "source_cache_schema": 1,
+        "metric_cache_version": "3",
+        "ged_max_nodes": 200,
+        "audit_threshold": 60,
+        "historical_candidate_parse": "legacy-overlay-evidence-reconciled-v3",
+    }
+
+    first = checkpoint_metadata(signature, True, {"f": 1.0})
+    second = checkpoint_metadata(signature, True, {"f": 2.0})
+
+    assert first["historical_score_evidence_sha256"] != second["historical_score_evidence_sha256"]
+    assert (
+        checkpoint_metadata(signature, False, {"f": 1.0})["historical_score_evidence_sha256"]
+        == "not_applicable"
+    )
+
+
+def test_legacy_parse_mode_reconciles_fallback_sort_style_mismatch() -> None:
+    source = {"f": _graph(136, 196)}
+    raw = {"f": _graph(95, 144)}
+    sanitized = {"f": _graph(98, 148)}
+
+    mode, reason = select_legacy_parse_mode(
+        "O2::bash::bash::binja",
+        source,
+        raw,
+        sanitized,
+        {"f": 86.0},
+        sanitizer_changed=True,
+    )
+
+    assert mode == LEGACY_SANITIZED
+    assert reason == "f:published_fallback_identity"
+
+
+def test_legacy_parse_mode_uses_pre_cutoff_vj_score_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = {"copy_attr": _graph(13, 17)}
+    raw = {"copy_attr": _graph(27, 37)}
+    sanitized = {"copy_attr": _graph(28, 37)}
+
+    def fake_vj_ged(_source: nx.DiGraph, candidate: nx.DiGraph) -> float:
+        return 60.0 if candidate.number_of_nodes() == 27 else 61.0
+
+    monkeypatch.setattr("decbench.metrics.vj_ged.vj_ged", fake_vj_ged)
+
+    mode, reason = select_legacy_parse_mode(
+        "O0::coreutils::cp::binja",
+        source,
+        raw,
+        sanitized,
+        {"copy_attr": 60.0},
+        sanitizer_changed=True,
+    )
+
+    assert mode == LEGACY_RAW
+    assert reason == "copy_attr:published_vj_ged_identity"
+
+
+def test_legacy_parse_mode_rejects_conflicting_slice_evidence() -> None:
+    source = {"raw": _graph(70, 80), "sanitized": _graph(70, 80)}
+    raw = {"raw": _graph(65, 75)}
+    sanitized = {"sanitized": _graph(65, 75)}
+
+    with pytest.raises(RuntimeError, match="conflicting legacy parse evidence"):
+        select_legacy_parse_mode(
+            "O2::proj::bin::binja",
+            source,
+            raw,
+            sanitized,
+            {"raw": 10.0, "sanitized": 10.0},
+            sanitizer_changed=True,
+        )
+
+
+def test_ambiguous_legacy_parse_requires_count_equivalence() -> None:
+    source = _graph(136, 196)
+    raw = _graph(95, 144)
+    sanitized = _graph(94, 145)
+
+    mode, _reason = select_legacy_parse_mode(
+        "O2::proj::bin::binja",
+        {"f": source},
+        {"f": raw},
+        {"f": sanitized},
+        {"f": 93.0},
+        sanitizer_changed=True,
+    )
+
+    assert mode == LEGACY_AMBIGUOUS
+    with pytest.raises(RuntimeError, match="ambiguous legacy graph sizes"):
+        select_ambiguous_legacy_cfg(
+            "O2::proj::bin::binja::f",
+            source,
+            raw,
+            sanitized,
+            93.0,
+        )
+
+
+def test_ambiguous_small_legacy_graphs_do_not_affect_large_census() -> None:
+    source = _graph(13, 17)
+    raw = _graph(27, 37)
+    sanitized = _graph(28, 37)
+
+    selected = select_ambiguous_legacy_cfg(
+        "O0::coreutils::cp::binja::copy_attr",
+        source,
+        raw,
+        sanitized,
+        60.0,
+    )
+
+    assert selected is raw
+
+
+def test_large_graph_audit_counts_changes_by_decompiler() -> None:
+    angr_key = "O2::bzip2::bzip2::angr::fallbackSort"
+    ida_key = "O2::bzip2::bzip2::ida::fallbackSort"
+    old = {
+        angr_key: {"value": 69.0, "perfect": False},
+        ida_key: {"value": 0.0, "perfect": True},
+    }
+    new = {
+        angr_key: {"value": 5.0, "perfect": False},
+        ida_key: {"value": 1.0, "perfect": False},
+    }
+    large = {
+        angr_key: _large_record(
+            source_nodes=78,
+            decompiled_nodes=50,
+            method="vj_ged",
+            isomorphic=False,
+            value=5.0,
+        ),
+        ida_key: _large_record(
+            source_nodes=78,
+            decompiled_nodes=78,
+            method="size_lower_bound",
+            isomorphic=False,
+            value=1.0,
+        ),
+    }
+
+    audit = build_large_graph_audit(
+        old,
+        new,
+        large,
+        {
+            "schema_version": 4,
+            "source_cache_schema": 1,
+            "metric_cache_version": "3",
+            "ged_max_nodes": 200,
+            "audit_threshold": 60,
+        },
+    )
+
+    total = audit["summary"]["total"]
+    assert total["pairs_over_60"] == 2
+    assert total["graphs_over_60"] == 3
+    assert total["corrected_pairs_over_60"] == 2
+    assert total["historical_and_corrected_over_60"] == 2
+    assert total["changed_scores"] == 2
+    assert total["improved_scores"] == 1
+    assert total["worsened_scores"] == 1
+    assert total["lost_perfect"] == 1
+    assert audit["summary"]["by_decompiler"]["angr"]["new_vj_ged"] == 1
+    assert audit["summary"]["by_decompiler"]["ida"]["new_size_lower_bound"] == 1
+
+
+def test_build_tasks_requires_matching_optimization_source_cache(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "results"
+    src_dir = root / "ged_src" / "v1"
+    o0_cache = source_cache_path(src_dir, "O0", "proj")
+    o0_cache.parent.mkdir(parents=True)
+    o0_cache.write_bytes(b"cache")
+    historical_cache = root / "ged_src" / "proj.pkl"
+    historical_cache.write_bytes(b"historical")
+    artifacts = [
+        ("O0", "proj", "bin", "angr", "/tmp/o0.c"),
+        ("O2", "proj", "bin", "angr", "/tmp/o2.c"),
+    ]
+
+    tasks, missing = build_tasks(
+        root,
+        src_dir,
+        artifacts,
+        old_scores={"O0::proj::bin::angr::f": {"value": 7.0}},
+    )
+
+    assert len(tasks) == 1
+    assert tasks[0][0] == "O0"
+    assert tasks[0][5] == str(o0_cache)
+    assert tasks[0][6] == str(historical_cache)
+    assert tasks[0][7] is False
+    assert tasks[0][8] == {"f": 7.0}
+    assert missing == [("O2", "proj")]
+
+
+def test_large_graph_audit_separates_historical_and_corrected_thresholds() -> None:
+    historical_key = "O2::proj::bin::angr::historical"
+    corrected_key = "O2::proj::bin::angr::corrected"
+    historical = _large_record(
+        source_nodes=70,
+        decompiled_nodes=50,
+        method="vj_ged",
+        isomorphic=False,
+        value=2.0,
+    )
+    historical["corrected_source_nodes"] = 50
+    historical["corrected_over_60"] = False
+    corrected = _large_record(
+        source_nodes=50,
+        decompiled_nodes=50,
+        method="vj_ged",
+        isomorphic=False,
+        value=2.0,
+    )
+    corrected["corrected_source_nodes"] = 70
+    corrected["corrected_over_60"] = True
+    audit = build_large_graph_audit(
+        {
+            historical_key: {"value": 10.0, "perfect": False},
+            corrected_key: {"value": 10.0, "perfect": False},
+        },
+        {
+            historical_key: {"value": 2.0, "perfect": False},
+            corrected_key: {"value": 2.0, "perfect": False},
+        },
+        {historical_key: historical, corrected_key: corrected},
+        {
+            "schema_version": 4,
+            "source_cache_schema": 1,
+            "metric_cache_version": "3",
+            "ged_max_nodes": 200,
+            "audit_threshold": 60,
+        },
+    )
+
+    total = audit["summary"]["total"]
+    assert total["pairs_over_60"] == 1
+    assert total["corrected_pairs_over_60"] == 1
+    assert total["historical_only_over_60"] == 1
+    assert total["corrected_only_over_60"] == 1
+
+
+def test_large_graph_audit_accepts_missing_corrected_score() -> None:
+    key = "O2::proj::bin::angr::large"
+    record = _large_record(
+        source_nodes=61,
+        decompiled_nodes=62,
+        method="vj_ged",
+        isomorphic=False,
+        value=1.0,
+    )
+    record.update(
+        {
+            "corrected_decompiled_nodes": None,
+            "corrected_decompiled_edges": None,
+            "corrected_over_60": False,
+            "new_value": None,
+            "new_perfect": None,
+            "method": None,
+            "isomorphic": None,
+            "approximated": None,
+        }
+    )
+
+    audit = build_large_graph_audit(
+        {key: {"value": 2.0, "perfect": False}},
+        {},
+        {key: record},
+        {
+            "schema_version": 4,
+            "source_cache_schema": 1,
+            "metric_cache_version": "3",
+            "ged_max_nodes": 200,
+            "audit_threshold": 60,
+        },
+    )
+
+    total = audit["summary"]["total"]
+    assert total["new_score_missing"] == 1
+    assert total["confirmed_isomorphic"] == 0
+
+
+def test_historical_overlay_sidecar_is_authoritative(tmp_path: Path) -> None:
+    (tmp_path / "ged_new.json").write_text('{"O0::proj::bin::angr::f": {"value": 0.0}}')
+    (tmp_path / "ged_new.slices.json").write_text('["O2::proj::bin::claude-code"]')
+
+    assert historical_overlay_slices(tmp_path) == {"O2::proj::bin::claude-code"}
+
+
+def test_published_scores_can_use_a_frozen_baseline(tmp_path: Path) -> None:
+    root = tmp_path / "results"
+    root.mkdir()
+    current = {
+        "groups": [
+            {
+                "opt_level": "O0",
+                "project": "proj",
+                "binary": "bin",
+                "functions": [
+                    {
+                        "function": "func",
+                        "values": {"angr": {"ged": 7.0}},
+                        "perfects": {"angr": {"ged": False}},
+                    }
+                ],
+            }
+        ]
+    }
+    frozen = {
+        "groups": [
+            {
+                "opt_level": "O0",
+                "project": "proj",
+                "binary": "bin",
+                "functions": [
+                    {
+                        "function": "func",
+                        "values": {"angr": {"ged": 3.0}},
+                        "perfects": {"angr": {"ged": False}},
+                    }
+                ],
+            }
+        ]
+    }
+    (root / "function_results.json").write_text(json.dumps(current))
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(frozen))
+
+    assert load_published_ged_scores(root)["O0::proj::bin::angr::func"]["value"] == 7.0
+    assert (
+        load_published_ged_scores(root, baseline_path)["O0::proj::bin::angr::func"]["value"] == 3.0
+    )
+
+
+def test_schema5_migration_replays_only_legacy_sanitizer_changes(
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "reeval_ged"
+    checkpoint_dir.mkdir()
+    source = tmp_path / "current.pkl"
+    historical = tmp_path / "historical.pkl"
+    source.write_bytes(b"current")
+    historical.write_bytes(b"historical")
+    plain = tmp_path / "plain.c"
+    sensitive = tmp_path / "sensitive.c"
+    plain.write_text("int f(void) { return 0; }\n")
+    sensitive.write_text("__int128 f(void) { return 0; }\n")
+    signature = {
+        "schema_version": 6,
+        "source_cache_schema": 1,
+        "metric_cache_version": "3",
+        "ged_max_nodes": 200,
+        "audit_threshold": 60,
+        "historical_candidate_parse": "legacy-overlay-evidence-reconciled-v3",
+    }
+    prior = dict(signature)
+    prior["schema_version"] = 5
+    prior["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    tasks = [
+        (
+            "O2",
+            "proj",
+            "plain",
+            "ida",
+            str(plain),
+            str(source),
+            str(historical),
+            True,
+            {},
+        ),
+        (
+            "O2",
+            "proj",
+            "sensitive",
+            "ida",
+            str(sensitive),
+            str(source),
+            str(historical),
+            True,
+            {},
+        ),
+    ]
+    for task in tasks:
+        key = f"{task[0]}__{task[1]}__{task[2]}__{task[3]}"
+        (checkpoint_dir / f"{key}.json").write_text(
+            json.dumps({"_meta": prior, "scores": {}, "over_previous_limit": {}})
+        )
+
+    migrated, require_replay = migrate_compatible_checkpoints(
+        checkpoint_dir,
+        tasks,
+        signature,
+    )
+
+    assert (migrated, require_replay) == (1, 1)
+    plain_payload = json.loads((checkpoint_dir / "O2__proj__plain__ida.json").read_text())
+    sensitive_payload = json.loads((checkpoint_dir / "O2__proj__sensitive__ida.json").read_text())
+    assert plain_payload["_meta"] == checkpoint_metadata(signature, True)
+    assert sensitive_payload["_meta"] == prior
+
+
+def test_checkpoint_migration_rejects_stored_source_basis_disagreement(
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "reeval_ged"
+    checkpoint_dir.mkdir()
+    artifact = tmp_path / "candidate.c"
+    source = tmp_path / "current.pkl"
+    historical = tmp_path / "historical.pkl"
+    artifact.write_text("int f(void) { return 0; }\n")
+    source.write_bytes(b"current")
+    historical.write_bytes(b"historical")
+    signature = {
+        "schema_version": 6,
+        "source_cache_schema": 1,
+        "metric_cache_version": "3",
+        "ged_max_nodes": 200,
+        "audit_threshold": 60,
+        "historical_candidate_parse": "legacy-overlay-evidence-reconciled-v3",
+    }
+    prior = dict(signature)
+    prior["schema_version"] = 5
+    prior["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    checkpoint = checkpoint_dir / "O2__proj__bin__angr.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "_meta": prior,
+                "scores": {},
+                "over_previous_limit": {"f": {"historical_source_basis": "legacy_overlay"}},
+            }
+        )
+    )
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(source),
+        str(historical),
+        False,
+        {},
+    )
+
+    migrated, require_replay = migrate_compatible_checkpoints(
+        checkpoint_dir,
+        [task],
+        signature,
+    )
+
+    assert (migrated, require_replay) == (0, 1)
+    assert json.loads(checkpoint.read_text())["_meta"] == prior
+
+
+def test_schema5_inline_checkpoint_migrates_despite_sanitizer_change(
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "reeval_ged"
+    checkpoint_dir.mkdir()
+    artifact = tmp_path / "candidate.c"
+    source = tmp_path / "current.pkl"
+    historical = tmp_path / "historical.pkl"
+    artifact.write_text("__int128 f(void) { return 0; }\n")
+    source.write_bytes(b"current")
+    historical.write_bytes(b"historical")
+    signature = {
+        "schema_version": 6,
+        "source_cache_schema": 1,
+        "metric_cache_version": "3",
+        "ged_max_nodes": 200,
+        "audit_threshold": 60,
+        "historical_candidate_parse": "legacy-overlay-evidence-reconciled-v3",
+    }
+    prior_signature = dict(signature)
+    prior_signature["schema_version"] = 5
+    prior_signature["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    checkpoint = checkpoint_dir / "O2__proj__bin__angr.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "_meta": {
+                    **prior_signature,
+                    "historical_source_basis": "same_opt_inline",
+                },
+                "scores": {},
+                "over_previous_limit": {
+                    "f": {
+                        "historical_source_basis": "same_opt_inline",
+                        "historical_decompiled_nodes": 61,
+                    }
+                },
+            }
+        )
+    )
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(source),
+        str(historical),
+        False,
+        {},
+    )
+
+    migrated, require_replay = migrate_compatible_checkpoints(
+        checkpoint_dir,
+        [task],
+        signature,
+    )
+
+    assert (migrated, require_replay) == (1, 0)
+    payload = json.loads(checkpoint.read_text())
+    assert payload["_meta"] == checkpoint_metadata(signature, False)
+    record = payload["over_previous_limit"]["f"]
+    assert record["historical_decompiled_parse_mode"] == "sanitized_without_macro_expansion"
+    assert record["historical_raw_candidate_present"] is False
+    assert record["historical_sanitized_candidate_present"] is True
+
+
+def test_eval_one_requires_every_frozen_row_to_be_reconstructable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "candidate.c"
+    artifact.write_text(
+        "// Function: present @ 0x1\n"
+        "int present(void) { return 0; }\n"
+        "// Function: missing @ 0x2\n"
+        "int missing(void) { return 0; }\n"
+    )
+    source_cfgs = {
+        "present": _graph(2, 1),
+        "missing": _graph(2, 1),
+    }
+    current_source = tmp_path / "current.pkl"
+    historical_source = tmp_path / "historical.pkl"
+    current_source.write_bytes(pickle.dumps({"bin": source_cfgs}))
+    historical_source.write_bytes(pickle.dumps({"bin": source_cfgs}))
+    candidate_cfgs = {"present": _graph(2, 1)}
+
+    monkeypatch.setattr(
+        "decbench.utils.cfg.extract_cfgs_from_source",
+        lambda *_args, **_kwargs: candidate_cfgs,
+    )
+
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(current_source),
+        str(historical_source),
+        True,
+        {"present": 0.0, "missing": 0.0},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"cannot reconstruct all published legacy scores: .*candidates=\['missing'\]",
+    ):
+        eval_one(task)
+
+
+def test_eval_one_rejects_reconstructed_fallback_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = tmp_path / "candidate.c"
+    artifact.write_text("// Function: f @ 0x1\n" "int f(void) { return 0; }\n")
+    source_cfgs = {"f": _graph(61, 62)}
+    candidate_cfgs = {"f": _graph(60, 60)}
+    current_source = tmp_path / "current.pkl"
+    historical_source = tmp_path / "historical.pkl"
+    current_source.write_bytes(pickle.dumps({"bin": source_cfgs}))
+    historical_source.write_bytes(pickle.dumps({"bin": source_cfgs}))
+
+    monkeypatch.setattr(
+        "decbench.utils.cfg.extract_cfgs_from_source",
+        lambda *_args, **_kwargs: candidate_cfgs,
+    )
+    monkeypatch.setattr(
+        "decbench.metrics.ged.GEDMetric.compute_for_function",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            value=3.0,
+            metadata={
+                "method": "vj_ged",
+                "isomorphic": False,
+                "approximated": False,
+            },
+        ),
+    )
+
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(current_source),
+        str(historical_source),
+        True,
+        {"f": 4.0},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"cannot reproduce published fallback 4\.0: reconstructed=3",
+    ):
+        eval_one(task)
+
+
+def test_checkpoint_migration_rejects_stored_fallback_mismatch(
+    tmp_path: Path,
+) -> None:
+    checkpoint_dir = tmp_path / "reeval_ged"
+    checkpoint_dir.mkdir()
+    artifact = tmp_path / "candidate.c"
+    current_source = tmp_path / "current.pkl"
+    historical_source = tmp_path / "historical.pkl"
+    artifact.write_text("int f(void) { return 0; }\n")
+    current_source.write_bytes(b"current")
+    historical_source.write_bytes(b"historical")
+    signature = {
+        "schema_version": 6,
+        "source_cache_schema": 1,
+        "metric_cache_version": "3",
+        "ged_max_nodes": 200,
+        "audit_threshold": 60,
+        "historical_candidate_parse": "legacy-overlay-evidence-reconciled-v3",
+    }
+    prior = dict(signature)
+    prior["schema_version"] = 5
+    prior["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    checkpoint = checkpoint_dir / "O2__proj__bin__angr.json"
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "_meta": {
+                    **prior,
+                    "historical_source_basis": "same_opt_inline",
+                },
+                "scores": {},
+                "over_previous_limit": {
+                    "f": {
+                        "historical_source_basis": "same_opt_inline",
+                        "historical_over_60": True,
+                        "historical_source_nodes": 70,
+                        "historical_source_edges": 80,
+                        "historical_decompiled_nodes": 65,
+                        "historical_decompiled_edges": 75,
+                    }
+                },
+            }
+        )
+    )
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(current_source),
+        str(historical_source),
+        False,
+        {"f": 9.0},
+    )
+
+    migrated, require_replay = migrate_compatible_checkpoints(
+        checkpoint_dir,
+        [task],
+        signature,
+    )
+
+    assert (migrated, require_replay) == (0, 1)
+    assert json.loads(checkpoint.read_text())["_meta"] == {
+        **prior,
+        "historical_source_basis": "same_opt_inline",
+    }

--- a/tests/test_results_store.py
+++ b/tests/test_results_store.py
@@ -114,10 +114,7 @@ def test_update_byte_match_slice_scoped() -> None:
 
 
 def test_read_ged_overlay_covers_evaluated_empty_slices(tmp_path: Path) -> None:
-    """The evaluated-slice set unions the payload keys, the sidecar, AND the
-    reeval_ged/ checkpoint filenames — so an evaluated-but-empty slice (present in
-    the cache with no entries) still clears stale inline GED, even without a
-    sidecar (older trees). Regression guard for the 219-slice re-inflation."""
+    """Legacy checkpoint names cover evaluated-empty slices without a sidecar."""
     root = tmp_path
     (root / "ged_new.json").write_text(
         json.dumps({"O0::projA::binA::angr::f1": {"value": 0.0, "perfect": True}})
@@ -136,6 +133,21 @@ def test_read_ged_overlay_covers_evaluated_empty_slices(tmp_path: Path) -> None:
     update_ged(fd, payload, covered=covered)
     noinline = fd.groups[1]
     assert "ged" not in noinline.functions[0].values["kuna"]
+
+
+def test_read_ged_overlay_sidecar_excludes_stale_checkpoints(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "ged_new.json").write_text(
+        json.dumps({"O0::projA::binA::angr::f1": {"value": 0.0, "perfect": True}})
+    )
+    (root / "ged_new.slices.json").write_text(json.dumps(["O0::projA::binA::angr"]))
+    (root / "reeval_ged").mkdir()
+    (root / "reeval_ged" / "O2-noinline__retired__binA__phoenix.json").write_text("{}")
+
+    payload, covered = read_ged_overlay(root)
+
+    assert payload is not None
+    assert covered == {("O0", "projA", "binA", "angr")}
 
 
 def test_merge_typematch_overlay() -> None:


### PR DESCRIPTION
## Summary

Fix GED evaluation so graph size can never prevent a perfect structural match:

- run directed, entry/exit-role-aware `nx.is_isomorphic` for every CFG pair, with no size limit
- return GED 0 immediately for isomorphic graphs
- raise the VJ-GED limit from 60 to 200 nodes
- use a SciPy assignment solver equivalent to cfgutils' VJ cost model
- use a nonzero size lower bound only for non-isomorphic graphs above 200 nodes
- bump the GED cache version and strengthen graph cache inputs
- expand locally defined macros in generated decompiler C before Joern parsing
- make reevaluation provenance-bound, resumable, slice-complete, and safe for external decompiler IDs
- add a standalone audit that literally replays every historical >60-node pair through NetworkX isomorphism

## Claude Code `fallbackSort`

Joern still gets source CFGs exclusively from compiled `.i` files. DecBench strips system headers and writes that same `.i` text to a temporary file with a `.c` suffix because Joern's C frontend expects that suffix; it does not read or fall back to the project's original `.c`.

For `bzip2/O2/bzip2::fallbackSort`, Claude recovered the source code, including its local macros. The historical candidate parse did not expand those macros:

- source CFG: 78 nodes / 115 edges
- historical candidate CFG: 103 nodes / 159 edges
- old >60 fallback: `|78-103| + |115-159| = 69`

After local macro expansion, the candidate CFG is also 78 nodes / 115 edges and is role-aware graph-isomorphic to the source, so its corrected GED is 0.

## Full-dataset impact

The completed reevaluation covered all 6,219 current artifact slices:

- frozen published scores: 453,391
- corrected scores: 455,711
- frozen scores missing afterward: 0
- new scores: 2,320
- changed comparable scores: 19,658
  - lower/improved: 2,048
  - higher: 17,610
  - became perfect: 1,148
  - lost perfect: 567
- corrected perfect scores: 155,822 / 455,711 (34.2%)

The historical 60-node census found 18,002 affected CFG pairs containing 29,977 individual graphs over the old limit. A pair contributes two graphs when both source and candidate exceeded 60 nodes.

| Decompiler | >60 pairs | >60 graphs | Frozen scores | Changed scores |
| --- | ---: | ---: | ---: | ---: |
| angr | 3,050 | 5,076 | 3,046 | 2,701 |
| binja | 2,652 | 4,471 | 2,652 | 2,344 |
| claude-code | 26 | 48 | 25 | 22 |
| codex | 28 | 48 | 28 | 24 |
| dewolf | 202 | 202 | 202 | 195 |
| ghidra | 3,122 | 5,258 | 3,122 | 2,793 |
| ida | 3,090 | 5,186 | 3,090 | 2,761 |
| kuna | 3,223 | 5,527 | 3,223 | 2,848 |
| manifold | 26 | 38 | 0 | 0 |
| r2dec | 2,583 | 4,123 | 2,577 | 2,326 |
| **Total** | **18,002** | **29,977** | **17,965** | **16,014** |

Among historical-large scores, 52 became lower and 15,962 became higher. The predominantly higher distances are expected: the old node/edge-count fallback was only a weak lower bound, whereas graphs up to 200 nodes now receive VJ-GED after exact isomorphism fails.

The literal historical replay passed all 18,002 pairs, including unequal-count
pairs and both raw/sanitized variants for ambiguous legacy slices:

- 26,325 literal NetworkX calls over 3,100 artifact slices
- 57 historically isomorphic / 17,945 non-isomorphic / 0 unavailable
- 17,965 published fallback scores reconstructed exactly, 37 scoreless records,
  and 0 reconstruction mismatches
- 70 historical false-perfect scores: non-isomorphic graphs whose equal node/edge
  counts made the old fallback return 0
- under the corrected evaluator: 59 isomorphic / 17,933 non-isomorphic / 10
  unavailable historical-large pairs

## Site-update preparation

An isolated candidate was built at
`/tmp/decbench-ged-site-candidate-eccsksw3`; no live result, site, or dataset tree
was changed.

- all 455,711 promoted overlay records exactly match schema-6 checkpoints
- 6,219 promoted slices and all 18,259 large-graph audit records are
  provenance-bound
- the original nine gain 2,179 GED scores and lose 0
- default unoptimized GED ranks are unchanged
- major-dataset Union rank swaps are among near-ties with at most 0.70 percentage
  points of movement
- Claude Code moves from #2 to #1 on sample-set GED (+11.38 percentage points;
  +11.59 with normalized failures), explained by 18 newly-perfect corrected
  functions including `fallbackSort`
- larger rank movements in the `large` preset occur among rates at or below
  1.34%, where a handful of functions changes several tied positions

The candidate also records one non-score metadata delta: current `main` adds its
existing LLM-recall warning to the sample-set description, while the frozen live
aggregate predates that prose commit. The guard permits exactly that suffix and
requires all other preset metadata to match.

## Validation

- 188 focused GED, CFG, cache, result-store, reevaluation, audit, site, and publishing tests pass
- full suite: 472 passed, 7 skipped; the five `tests/test_content.py` failures reproduce unchanged on `main`
- accelerated VJ matched cfgutils across 16,708 exhaustive small-graph comparisons
- refined role-aware isomorphism matched plain role-aware NetworkX across randomized checks
- Ruff, Black, and `git diff --check` pass
- all 7,052 current decompiled C artifacts were checked; none contains a raw control byte affected by the parser sanitizer added in current `main`

## Publication scope

This PR contains the metric, parser, reevaluation/audit tooling, tests, and explanatory source documentation. It does not commit regenerated `site/` output, live score overlays, or Hugging Face dataset data. Those remain a separate synchronized publication step after review of this PR and the isolated candidate report.
