### PR TITLE
[AUTOMATED] fix(decompilers): stop discarding whole binaries whose code spans several .text sections

### DIFF
--- a/decbench/decompilers/declib_dec.py
+++ b/decbench/decompilers/declib_dec.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from decbench.decompilers.base import Decompiler, DecompilerConfig
+from decbench.decompilers.raw import common as raw_common
 from decbench.decompilers.registry import register_decompiler
 from decbench.models.decompilation import (
     DecompilationResult,
@@ -36,14 +37,9 @@ if TYPE_CHECKING:
 
 _l = logging.getLogger(__name__)
 
-_SKIP_NAMES = frozenset({
-    "_start", "__libc_start_main", "__libc_csu_init", "__libc_csu_fini",
-    "_init", "_fini", "__do_global_dtors_aux", "register_tm_clones",
-    "deregister_tm_clones", "frame_dummy", "__libc_start_call_main",
-    "_dl_relocate_static_pie", "__gmon_start__", "__stack_chk_fail",
-})
-
-_SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
+#: Back-compat aliases; the shared filter lives in ``raw.common``.
+_SKIP_NAMES = raw_common.SKIP_NAMES
+_SKIP_PREFIXES = raw_common.SKIP_PREFIXES
 
 
 def _elf_min_vaddr(binary_path: Path) -> int:
@@ -69,25 +65,9 @@ def _elf_min_vaddr(binary_path: Path) -> int:
         return 0
 
 
-def _elf_text_range(binary_path: Path) -> tuple[int, int] | None:
-    """Get the [start, end) virtual address range of the .text section.
-
-    Used to exclude PLT stubs and import thunks, which live in their own
-    sections (.plt, .plt.sec) outside .text.
-    """
-    try:
-        from elftools.elf.elffile import ELFFile
-
-        with open(binary_path, "rb") as f:
-            elf = ELFFile(f)
-            text = elf.get_section_by_name(".text")
-            if text is None:
-                return None
-            start = text["sh_addr"]
-            return (start, start + text["sh_size"])
-    except Exception as e:
-        _l.debug("Failed to read .text range for %s: %s", binary_path, e)
-        return None
+#: Back-compat alias; the ``.text``-family section filter lives in
+#: ``raw.common`` so every backend applies the SAME rule.
+_elf_text_range = raw_common.elf_text_ranges
 
 
 class DeclibDecompiler(Decompiler):
@@ -151,7 +131,8 @@ class DeclibDecompiler(Decompiler):
                 ]
             else:
                 target_funcs = self._enumerate_functions(
-                    deci, binary_path, elf_base
+                    deci, binary_path, elf_base,
+                    raw_common.addr_targets_of(function_names),
                 )
 
             if function_names:
@@ -295,23 +276,21 @@ class DeclibDecompiler(Decompiler):
         deci: DecompilerInterface,
         binary_path: Path,
         elf_base: int,
+        addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int]]:
         """Enumerate (name, lifted_addr) for benchmarkable functions.
 
         Filters CRT/compiler helpers by name and anything outside the ELF
-        .text section (PLT stubs, import thunks, simprocedures).
+        ``.text`` family (PLT stubs, import thunks, simprocedures), except
+        functions the driver explicitly asked for by address
+        (:func:`raw_common.should_skip_function`).
         """
-        text_range = _elf_text_range(binary_path)
+        text_range = raw_common.elf_text_ranges(binary_path)
         out: list[tuple[str, int]] = []
         for lifted_addr, light_func in deci.functions.items():
             name = light_func.name or ""
-            if not name or name in _SKIP_NAMES:
-                continue
-            if text_range is not None:
-                file_addr = int(lifted_addr) + elf_base
-                if not (text_range[0] <= file_addr < text_range[1]):
-                    continue
-            elif name.startswith(_SKIP_PREFIXES):
+            file_addr = int(lifted_addr) + elf_base
+            if raw_common.should_skip_function(name, file_addr, text_range, addr_targets):
                 continue
             out.append((name, int(lifted_addr)))
         return sorted(out, key=lambda x: x[1])

--- a/decbench/decompilers/dockerized.py
+++ b/decbench/decompilers/dockerized.py
@@ -64,43 +64,12 @@ _l = logging.getLogger(__name__)
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOCKER_DIR = _REPO_ROOT / "docker"
 
-_SKIP_NAMES = frozenset(
-    {
-        "_start",
-        "__libc_start_main",
-        "__libc_csu_init",
-        "__libc_csu_fini",
-        "_init",
-        "_fini",
-        "__do_global_dtors_aux",
-        "register_tm_clones",
-        "deregister_tm_clones",
-        "frame_dummy",
-        "__libc_start_call_main",
-        "_dl_relocate_static_pie",
-        "__gmon_start__",
-        "__stack_chk_fail",
-    }
-)
-
-_SKIP_PREFIXES = ("thunk_", "j_", "__imp_", ".plt", "_dl_")
-
-
-def _elf_text_range(binary_path: Path) -> tuple[int, int] | None:
-    """[start, end) virtual-address range of the ``.text`` section, or None."""
-    try:
-        from elftools.elf.elffile import ELFFile
-
-        with open(binary_path, "rb") as f:
-            elf = ELFFile(f)
-            text = elf.get_section_by_name(".text")
-            if text is None:
-                return None
-            start = text["sh_addr"]
-            return (start, start + text["sh_size"])
-    except Exception as e:  # noqa: BLE001
-        _l.debug("Failed to read .text range for %s: %s", binary_path, e)
-        return None
+#: Back-compat aliases. The name filter, the section filter, and the
+#: DWARF-target exemption all live in ``raw.common`` now — ONE rule for every
+#: backend (see :func:`raw_common.should_skip_function`).
+_SKIP_NAMES = raw_common.SKIP_NAMES
+_SKIP_PREFIXES = raw_common.SKIP_PREFIXES
+_elf_text_range = raw_common.elf_text_ranges
 
 
 def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
@@ -108,7 +77,8 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
 
     Addresses are in **ELF file space** (``st_value``), which matches DWARF and
     the declib-backed decompilers. CRT/compiler helpers, import thunks, and
-    anything outside ``.text`` are filtered out. Returned sorted by address.
+    anything outside the ``.text`` family are filtered out. Returned sorted by
+    address.
     """
     try:
         from elftools.elf.elffile import ELFFile
@@ -117,7 +87,7 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
         _l.debug("pyelftools unavailable: %s", e)
         return []
 
-    text_range = _elf_text_range(binary_path)
+    text_range = raw_common.elf_text_ranges(binary_path)
     out: dict[str, int] = {}
     try:
         with open(binary_path, "rb") as f:
@@ -132,12 +102,7 @@ def elf_function_symbols(binary_path: Path) -> list[tuple[str, int]]:
                     name = sym.name or ""
                     if not addr or not name:
                         continue
-                    if name in _SKIP_NAMES:
-                        continue
-                    if text_range is not None:
-                        if not (text_range[0] <= addr < text_range[1]):
-                            continue
-                    elif name.startswith(_SKIP_PREFIXES):
+                    if raw_common.should_skip_function(name, addr, text_range):
                         continue
                     out.setdefault(name, addr)
     except Exception as e:  # noqa: BLE001
@@ -553,33 +518,12 @@ def _r2_bare_name(name: str) -> str:
     return name.rsplit(".", 1)[-1] if name else name
 
 
-def _addr_targets_of(function_names: set[int] | set[str] | None) -> set[int]:
-    """The int (ELF-file-space) addresses in the driver's function filter."""
-    if not function_names:
-        return set()
-    return {int(x) for x in function_names if isinstance(x, int) and not isinstance(x, bool)}
-
-
-def _skip_r2_function(
-    bare_name: str,
-    file_addr: int,
-    text_range: tuple[int, int] | None,
-    addr_targets: set[int] | None,
-) -> bool:
-    """Whether to drop an r2-discovered function, honouring the source targets.
-
-    A function whose address is one of ``addr_targets`` (the DWARF ``low_pc``
-    source functions the driver asked for) is a VERIFIED real function and is
-    always kept: the ``.text`` heuristic behind :func:`should_skip_function`
-    misfires on binaries with the code split across multiple executable
-    sections (e.g. u-boot's tiny ``.text`` + 486 KB ``.text_rest``, freertos),
-    where the real functions live outside the one detected ``.text`` and would
-    otherwise be dropped — the exact reason r2dec scored 0 on those ARM targets.
-    Non-target functions still go through the normal filter.
-    """
-    if addr_targets and raw_common._addr_matches(file_addr, addr_targets):
-        return False
-    return raw_common.should_skip_function(bare_name, file_addr, text_range)
+#: Back-compat aliases for what used to be r2dec-only logic. The DWARF-target
+#: exemption these implemented — a function whose address is one the driver
+#: asked for is a VERIFIED real function and is kept whatever section it landed
+#: in — is now part of the shared filter, so every backend gets it.
+_addr_targets_of = raw_common.addr_targets_of
+_skip_r2_function = raw_common.should_skip_function
 
 
 def _func_ident_in_code(code: str) -> str | None:
@@ -736,7 +680,7 @@ class R2DecDecompiler(DockerizedDecompiler):
     def _discover(
         r: Any,
         elf_base: int,
-        text_range: tuple[int, int] | None,
+        text_range: raw_common.TextRanges,
         baddr: int,
         addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int, int]]:
@@ -744,10 +688,11 @@ class R2DecDecompiler(DockerizedDecompiler):
 
         Uses radare2's ``aflj`` (function list). ``file_addr`` is ELF-file space
         (``r2_addr - baddr + elf_base``). Imports/PLT/reloc stubs, the entrypoint
-        alias, CRT helpers, and anything outside ``.text`` are dropped — EXCEPT a
-        function whose address is one of ``addr_targets`` (the driver's DWARF
-        ``low_pc`` source set), which is a verified real function and is kept
-        regardless of the ``.text`` heuristic (see :func:`_skip_r2_function`).
+        alias, CRT helpers, and anything outside the ``.text`` family are dropped
+        — EXCEPT a function whose address is one of ``addr_targets`` (the
+        driver's DWARF ``low_pc`` source set), which is a verified real function
+        and is kept regardless of the section heuristic (see
+        :func:`raw_common.should_skip_function`).
         """
         funcs = r.cmdj("aflj") or []
         out: list[tuple[str, int, int]] = []
@@ -913,7 +858,7 @@ class R2DecDecompiler(DockerizedDecompiler):
 
         start = time.time()
         elf_base = raw_common.elf_min_vaddr(binary_path)
-        text_range = raw_common.elf_text_range(binary_path)
+        text_range = raw_common.elf_text_ranges(binary_path)
         decompiled: dict[str, FunctionDecompilation] = {}
         failed: list[str] = []
         used_cmd = "pdc"
@@ -994,7 +939,7 @@ class R2DecDecompiler(DockerizedDecompiler):
             )
         start = time.time()
         elf_base = raw_common.elf_min_vaddr(binary_path)
-        text_range = raw_common.elf_text_range(binary_path)
+        text_range = raw_common.elf_text_ranges(binary_path)
 
         addr_targets: list[int] | None = None
         ints: set[int] = set()

--- a/decbench/decompilers/llm_dec.py
+++ b/decbench/decompilers/llm_dec.py
@@ -456,7 +456,7 @@ class _AgentDecompiler(Decompiler):
         try:
             from decbench.decompilers.dockerized import elf_function_symbols
 
-            text_range = common.elf_text_range(binary_path)
+            text_range = common.elf_text_ranges(binary_path)
             syms = [
                 (n, a)
                 for n, a in elf_function_symbols(binary_path)

--- a/decbench/decompilers/raw/angr_raw.py
+++ b/decbench/decompilers/raw/angr_raw.py
@@ -85,7 +85,8 @@ class RawAngrDecompiler(Decompiler):
 
         start_time = time.time()
         elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
+        text_range = common.elf_text_ranges(binary_path)
+        addr_targets = common.addr_targets_of(function_names)
 
         decompiled_functions: dict[str, FunctionDecompilation] = {}
         failed_functions: list[str] = []
@@ -123,7 +124,7 @@ class RawAngrDecompiler(Decompiler):
                 # address for a non-PIE static ELF.
                 target_funcs = [(n, a) for (n, a) in functions]
             else:
-                target_funcs = self._enumerate(proj, elf_base, text_range)
+                target_funcs = self._enumerate(proj, elf_base, text_range, addr_targets)
 
             target_funcs = common.narrow_to_source(
                 target_funcs,
@@ -178,7 +179,8 @@ class RawAngrDecompiler(Decompiler):
         self,
         proj: Any,
         elf_base: int,
-        text_range: tuple[int, int] | None,
+        text_range: common.TextRanges,
+        addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int]]:
         """Enumerate (name, ELF-space addr) for benchmarkable functions.
 
@@ -195,7 +197,7 @@ class RawAngrDecompiler(Decompiler):
                 continue
             name = func.name or ""
             file_addr = (int(func.addr) - load_base) + elf_base
-            if common.should_skip_function(name, file_addr, text_range):
+            if common.should_skip_function(name, file_addr, text_range, addr_targets):
                 continue
             out.append((name, file_addr))
         return sorted(out, key=lambda x: x[1])

--- a/decbench/decompilers/raw/binja_raw.py
+++ b/decbench/decompilers/raw/binja_raw.py
@@ -106,7 +106,8 @@ class RawBinjaDecompiler(Decompiler):
 
         start_time = time.time()
         elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
+        text_range = common.elf_text_ranges(binary_path)
+        addr_targets = common.addr_targets_of(function_names)
 
         decompiled_functions: dict[str, FunctionDecompilation] = {}
         failed_functions: list[str] = []
@@ -138,7 +139,7 @@ class RawBinjaDecompiler(Decompiler):
         bv = None
         try:
             bv = self._load(binary_path)
-            enumerated = self._enumerate(bv, elf_base, text_range)
+            enumerated = self._enumerate(bv, elf_base, text_range, addr_targets)
             if functions is not None:
                 requested = {n for (n, _a) in functions}
                 enumerated = [(n, a) for (n, a) in enumerated if n in requested]
@@ -211,7 +212,8 @@ class RawBinjaDecompiler(Decompiler):
         self,
         bv: Any,
         elf_base: int,
-        text_range: tuple[int, int] | None,
+        text_range: common.TextRanges,
+        addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int]]:
         """Enumerate (name, ELF-space addr) for benchmarkable functions."""
         load_base = self._binja_load_base(bv)
@@ -224,7 +226,7 @@ class RawBinjaDecompiler(Decompiler):
                 file_addr = (int(func.start) - load_base) + elf_base
             except Exception:  # noqa: BLE001
                 continue
-            if common.should_skip_function(name, file_addr, text_range):
+            if common.should_skip_function(name, file_addr, text_range, addr_targets):
                 continue
             out.append((name, file_addr))
         return sorted(out, key=lambda x: x[1])

--- a/decbench/decompilers/raw/common.py
+++ b/decbench/decompilers/raw/common.py
@@ -7,13 +7,17 @@ its output contract exactly *without* depending on declib:
 * ``elf_min_vaddr`` — lowest ``PT_LOAD`` virtual address; adding it to a
   decompiler's lifted (0-based / image-base-relative) address yields the
   ELF-file-space address that DWARF uses.
-* ``elf_text_range`` — ``[start, end)`` of the ``.text`` section, used to
-  drop PLT stubs / import thunks that live in their own sections.
+* ``elf_text_ranges`` — the ``[start, end)`` ranges of the binary's ``.text``
+  FAMILY sections (``.text``, ``.text.<fn>`` from ``-ffunction-sections``,
+  ``.text_rest`` …), used to drop PLT stubs / import thunks that live in their
+  own sections.
 * ``SKIP_NAMES`` / ``SKIP_PREFIXES`` — CRT/compiler-generated functions and
   thunk/import name prefixes that are never benchmarked.
 * ``should_skip_function`` / ``in_text`` — the name + section filter that
-  ``declib_dec._enumerate_functions`` applies. Address comparisons tolerate the
-  ARM Thumb T-bit (DWARF ``low_pc`` is even; angr reports Thumb entries odd).
+  ``declib_dec._enumerate_functions`` applies, with the DWARF-target exemption
+  that keeps a function the driver explicitly asked for. Address comparisons
+  tolerate the ARM Thumb T-bit (DWARF ``low_pc`` is even; angr reports Thumb
+  entries odd).
 * ``narrow_to_source`` — the optional ``function_names`` restriction (with the
   same "fall back to everything if nothing matched" behaviour as declib_dec).
 * ``dump_progress`` — the atomic partial-result pickle used by the run driver
@@ -26,6 +30,7 @@ Addresses everywhere in DecBench results are **ELF-file-space**
 
 from __future__ import annotations
 
+import bisect
 import logging
 import pickle
 from pathlib import Path
@@ -35,6 +40,11 @@ if TYPE_CHECKING:
     from decbench.models.decompilation import DecompilationResult
 
 _l = logging.getLogger(__name__)
+
+#: ``[start, end)`` executable ranges, or ``None`` when they could not be read.
+TextRanges = list[tuple[int, int]] | None
+
+_SHF_EXECINSTR = 0x4
 
 SKIP_NAMES = frozenset(
     {
@@ -122,54 +132,127 @@ def elf_min_vaddr(binary_path: Path) -> int:
         return 0
 
 
-def elf_text_range(binary_path: Path) -> tuple[int, int] | None:
-    """Get the ``[start, end)`` virtual-address range of the ``.text`` section.
+def elf_text_ranges(binary_path: Path) -> TextRanges:
+    """Get the ``[start, end)`` ranges of the binary's ``.text``-family sections.
 
     Used to exclude PLT stubs and import thunks, which live in their own
-    sections (``.plt`` / ``.plt.sec``) outside ``.text``.
+    sections (``.plt`` / ``.plt.sec``) outside the ``.text`` family.
+
+    "``.text`` family" is every ``SHF_EXECINSTR`` section whose name starts with
+    ``.text``, not the one section literally named ``.text``: real programs
+    routinely spread their code over several of them — ``-ffunction-sections``
+    emits one ``.text.<fn>`` per function (freertos: 108 of them, with the
+    literal ``.text`` holding only newlib), and custom linker scripts add their
+    own (u-boot: a 936-byte ``.text`` plus a 486 KB ``.text_rest``). Matching
+    only ``.text`` there discards the entire program. Sections outside the
+    family (``.plt``, ``.init``, ``.fini``, and u-boot's ``.efi_runtime``) stay
+    excluded exactly as before, so ordinary single-``.text`` binaries are
+    unaffected.
+
+    Returns ``None`` when the ranges cannot be determined — no ELF section
+    headers, no ``.text``-family section, a non-ELF input (PE/Mach-O), or a
+    degenerate zero-size ``.text`` (which would otherwise become an empty range
+    that drops every function). The name-prefix filter is the fallback in that
+    case; see :func:`should_skip_function`.
     """
     try:
         from elftools.elf.elffile import ELFFile
 
         with open(binary_path, "rb") as f:
             elf = ELFFile(f)
-            text = elf.get_section_by_name(".text")
-            if text is None:
-                return None
-            start = text["sh_addr"]
-            return (start, start + text["sh_size"])
+            spans: list[tuple[int, int]] = []
+            for sec in elf.iter_sections():
+                name = sec.name or ""
+                if not name.startswith(".text"):
+                    continue
+                if sec.header["sh_type"] == "SHT_NOBITS":
+                    continue
+                if not int(sec.header["sh_flags"]) & _SHF_EXECINSTR:
+                    continue
+                size = int(sec["sh_size"])
+                if size <= 0:
+                    continue
+                start = int(sec["sh_addr"])
+                spans.append((start, start + size))
+            return _merge_ranges(spans)
     except Exception as e:  # noqa: BLE001
-        _l.debug("Failed to read .text range for %s: %s", binary_path, e)
+        _l.debug("Failed to read .text ranges for %s: %s", binary_path, e)
         return None
 
 
-def in_text(file_addr: int, text_range: tuple[int, int] | None) -> bool:
-    """Whether an ELF-file-space address falls inside ``.text``.
+#: Back-compat alias for the pre-multi-section name.
+elf_text_range = elf_text_ranges
 
-    When the ``.text`` range is unknown, everything is treated as "in text"
+
+def _merge_ranges(spans: list[tuple[int, int]]) -> TextRanges:
+    """Sort + coalesce ``[start, end)`` spans; ``None`` when there are none.
+
+    Overlapping/duplicate sections (a section table may list the same bytes
+    twice) collapse into one span so the membership test stays a bisect.
+    """
+    if not spans:
+        return None
+    spans = sorted(spans)
+    merged: list[list[int]] = [list(spans[0])]
+    for start, end in spans[1:]:
+        if start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(a, b) for a, b in merged]
+
+
+def _as_ranges(text_range: TextRanges | tuple[int, int]) -> TextRanges:
+    """Accept either the current range LIST or a legacy single ``(start, end)``."""
+    if text_range is None:
+        return None
+    if isinstance(text_range, tuple):
+        return [(int(text_range[0]), int(text_range[1]))]
+    return text_range
+
+
+def in_text(file_addr: int, text_range: TextRanges | tuple[int, int]) -> bool:
+    """Whether an ELF-file-space address falls inside a ``.text``-family section.
+
+    When the ranges are unknown, everything is treated as "in text"
     (the name-prefix filter is the fallback in that case).
     """
-    if text_range is None:
-        return True
-    return text_range[0] <= file_addr < text_range[1]
+    ranges = _as_ranges(text_range)
+    if not ranges:
+        return ranges is None
+    idx = bisect.bisect_right(ranges, (file_addr, float("inf"))) - 1
+    return idx >= 0 and ranges[idx][0] <= file_addr < ranges[idx][1]
 
 
 def should_skip_function(
     name: str,
     file_addr: int,
-    text_range: tuple[int, int] | None,
+    text_range: TextRanges | tuple[int, int],
+    addr_targets: set[int] | None = None,
 ) -> bool:
     """Replicate ``declib_dec._enumerate_functions`` filtering for one function.
+
+    A function whose address is one of ``addr_targets`` (the DWARF ``low_pc``
+    source functions the benchmark driver asked for) is a VERIFIED real function
+    and is always kept, whatever section it landed in. This is the rule
+    ``dockerized._skip_r2_function`` has always applied on the r2dec path and
+    ``raw/dewolf_driver`` on the dewolf path; it now applies everywhere, so a
+    binary whose code sits outside the section filter's reach no longer scores 0
+    on some backends and not others.
 
     Args:
         name: function name (already non-empty checks happen here too).
         file_addr: function start address in ELF-file space
             (``lifted + elf_base``).
-        text_range: ``.text`` ``[start, end)`` or ``None``.
+        text_range: ``.text``-family ranges from :func:`elf_text_ranges`, or
+            ``None``.
+        addr_targets: the driver's DWARF ``low_pc`` set, if any.
 
     Returns:
         ``True`` if the function should be excluded from benchmarking.
     """
+    if addr_targets and _addr_matches(file_addr, addr_targets):
+        return False
     if not name or name in SKIP_NAMES:
         return True
     if text_range is not None:
@@ -180,6 +263,17 @@ def should_skip_function(
     elif name.startswith(SKIP_PREFIXES):
         return True
     return False
+
+
+def addr_targets_of(function_names: set[int] | set[str] | None) -> set[int]:
+    """The int (ELF-file-space) addresses in the driver's function filter.
+
+    The driver passes DWARF ``low_pc`` ints for a stripped binary and names for
+    the legacy non-stripped path; only the ints can exempt by address.
+    """
+    if not function_names:
+        return set()
+    return {int(x) for x in function_names if isinstance(x, int) and not isinstance(x, bool)}
 
 
 def narrow_to_source(

--- a/decbench/decompilers/raw/ghidra_raw.py
+++ b/decbench/decompilers/raw/ghidra_raw.py
@@ -225,7 +225,8 @@ class RawGhidraDecompiler(Decompiler):
 
         start_time = time.time()
         elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
+        text_range = common.elf_text_ranges(binary_path)
+        addr_targets = common.addr_targets_of(function_names)
 
         decompiled_functions: dict[str, FunctionDecompilation] = {}
         failed_functions: list[str] = []
@@ -265,7 +266,7 @@ class RawGhidraDecompiler(Decompiler):
 
                 requested = {n for (n, _a) in functions} if functions is not None else None
 
-                enumerated = self._enumerate(program, elf_base, text_range)
+                enumerated = self._enumerate(program, elf_base, text_range, addr_targets)
                 if requested is not None:
                     enumerated = [(n, a) for (n, a) in enumerated if n in requested]
 
@@ -344,7 +345,8 @@ class RawGhidraDecompiler(Decompiler):
         self,
         program: Any,
         elf_base: int,
-        text_range: tuple[int, int] | None,
+        text_range: common.TextRanges,
+        addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int]]:
         """Enumerate (name, ELF-space addr) for benchmarkable functions.
 
@@ -362,7 +364,7 @@ class RawGhidraDecompiler(Decompiler):
             name = g_func.getName() or ""
             offset = int(g_func.getEntryPoint().getOffset())
             file_addr = (offset - image_base) + elf_base
-            if common.should_skip_function(name, file_addr, text_range):
+            if common.should_skip_function(name, file_addr, text_range, addr_targets):
                 continue
             out.append((name, file_addr))
         return sorted(out, key=lambda x: x[1])

--- a/decbench/decompilers/raw/ida_raw.py
+++ b/decbench/decompilers/raw/ida_raw.py
@@ -120,7 +120,8 @@ class RawIDADecompiler(Decompiler):
 
         start_time = time.time()
         elf_base = common.elf_min_vaddr(binary_path)
-        text_range = common.elf_text_range(binary_path)
+        text_range = common.elf_text_ranges(binary_path)
+        addr_targets = common.addr_targets_of(function_names)
 
         decompiled_functions: dict[str, FunctionDecompilation] = {}
         failed_functions: list[str] = []
@@ -154,7 +155,7 @@ class RawIDADecompiler(Decompiler):
             if not ida_hexrays.init_hexrays_plugin():
                 raise RuntimeError("Hex-Rays decompiler not available")
             try:
-                enumerated = self._enumerate(elf_base, text_range)
+                enumerated = self._enumerate(elf_base, text_range, addr_targets)
                 if functions is not None:
                     requested = {n for (n, _a) in functions}
                     enumerated = [(n, a) for (n, a) in enumerated if n in requested]
@@ -220,7 +221,8 @@ class RawIDADecompiler(Decompiler):
     def _enumerate(
         self,
         elf_base: int,
-        text_range: tuple[int, int] | None,
+        text_range: common.TextRanges,
+        addr_targets: set[int] | None = None,
     ) -> list[tuple[str, int]]:
         """Enumerate (name, ELF-space addr) for benchmarkable functions.
 
@@ -243,7 +245,7 @@ class RawIDADecompiler(Decompiler):
                 continue
             name = ida_name.get_ea_name(ea) or ""
             file_addr = (int(ea) - image_base) + elf_base
-            if common.should_skip_function(name, file_addr, text_range):
+            if common.should_skip_function(name, file_addr, text_range, addr_targets):
                 continue
             out.append((name, file_addr))
         return sorted(out, key=lambda x: x[1])

--- a/decbench/decompilers/raw/kuna_raw.py
+++ b/decbench/decompilers/raw/kuna_raw.py
@@ -111,7 +111,8 @@ class RawKunaDecompiler(Decompiler):
             )
 
         start = time.time()
-        text_range = common.elf_text_range(binary_path)
+        text_range = common.elf_text_ranges(binary_path)
+        addr_targets = common.addr_targets_of(function_names)
         decompiled: dict[str, FunctionDecompilation] = {}
         failed: list[str] = []
         timed_out = False
@@ -158,7 +159,9 @@ class RawKunaDecompiler(Decompiler):
             (
                 (n, int(r.get("address") or 0))
                 for n, r in records.items()
-                if not common.should_skip_function(n, int(r.get("address") or 0), text_range)
+                if not common.should_skip_function(
+                    n, int(r.get("address") or 0), text_range, addr_targets
+                )
             ),
             key=lambda x: x[1],
         )

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -127,8 +127,21 @@ def decompile_binary(
   Helpers live in `decbench/decompilers/raw/common.py`.
 - **Skip non-source functions.** Drop PLT stubs/thunks and CRT helpers
   (`_start`, `__libc_csu_init`, `register_tm_clones`, …) and anything outside
-  `.text`. `common.py` provides `SKIP_NAMES`, `SKIP_PREFIXES`, and a `.text`
-  range check.
+  the `.text` family. Do not roll your own filter — call
+  `common.should_skip_function(name, file_addr, text_range, addr_targets)`,
+  which is the ONE rule every backend shares:
+  1. a function whose address is in `addr_targets` (the driver's DWARF `low_pc`
+     set — get it with `common.addr_targets_of(function_names)`) is a verified
+     real function and is **always kept**, whatever section it landed in;
+  2. otherwise `SKIP_NAMES` / `SKIP_PREFIXES` and the section ranges from
+     `common.elf_text_ranges()` apply.
+
+  `elf_text_ranges()` covers **every** `SHF_EXECINSTR` section whose name starts
+  with `.text`, not just the one literally named `.text`: real binaries split
+  their code (`-ffunction-sections` → one `.text.<fn>` per function; custom
+  linker scripts → `.text` + `.text_rest`). It returns `None` — meaning
+  "unknown, fall back to the name filter" — for non-ELF inputs, a binary with no
+  section headers, and a degenerate zero-size `.text`.
 - **Set `decompiler_name = self.id`.** The `id` property is your registered
   name, or `name@version` when a version is pinned (see §4). Using `self.id`
   keeps versioned runs as distinct, comparable columns everywhere downstream.

--- a/tests/test_text_filter.py
+++ b/tests/test_text_filter.py
@@ -1,0 +1,317 @@
+"""Tests for the shared ``.text``-family / DWARF-target function filter.
+
+Every backend (raw, declib, dockerized r2dec) routes its "is this function
+benchmarkable?" question through ``raw.common.should_skip_function``. These
+tests pin the section layouts that broke it: the single-``.text`` binary that
+must stay unchanged, u-boot's ``.text`` + ``.text_rest`` split, freertos'
+``-ffunction-sections`` fan-out, and a degenerate zero-size ``.text``.
+
+The ELFs are built byte-by-byte here rather than taken from the results tree so
+the tests are hermetic.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from decbench.decompilers.raw import common
+
+SHT_NULL = 0
+SHT_PROGBITS = 1
+SHT_STRTAB = 3
+SHT_NOBITS = 8
+
+SHF_ALLOC = 0x2
+SHF_EXECINSTR = 0x4
+AX = SHF_ALLOC | SHF_EXECINSTR
+
+
+def _write_elf(
+    path: Path,
+    sections: list[tuple[str, int, int, int, int]],
+    *,
+    with_section_headers: bool = True,
+) -> Path:
+    """Write a minimal ELF64 whose section table lists ``sections``.
+
+    Each entry is ``(name, sh_addr, sh_size, sh_flags, sh_type)``. Only the
+    section header table is meaningful — no program headers, no real content —
+    which is all the filter reads.
+    """
+    names = [""] + [s[0] for s in sections] + [".shstrtab"]
+    shstrtab = b"\x00".join(n.encode() for n in names) + b"\x00"
+    name_off: dict[str, int] = {}
+    off = 0
+    for n in names:
+        name_off[n] = off
+        off += len(n) + 1
+
+    ehsize = 64
+    shentsize = 64
+    shstrtab_off = ehsize
+    body_off = shstrtab_off + len(shstrtab)
+    shoff = body_off
+
+    shdrs = [(b"", 0, 0, 0, 0, SHT_NULL)]
+    for nm, addr, size, flags, stype in sections:
+        shdrs.append((nm.encode(), name_off[nm], addr, size, flags, stype))
+    shdrs.append((b".shstrtab", name_off[".shstrtab"], 0, len(shstrtab), 0, SHT_STRTAB))
+
+    shnum = len(shdrs)
+    shstrndx = shnum - 1
+
+    ehdr = b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8
+    ehdr += struct.pack(
+        "<HHIQQQIHHHHHH",
+        2,  # e_type = ET_EXEC
+        0x3E,  # e_machine = x86-64
+        1,  # e_version
+        0,  # e_entry
+        0,  # e_phoff
+        shoff,
+        0,  # e_flags
+        ehsize,
+        56,  # e_phentsize
+        0,  # e_phnum
+        shentsize,
+        shnum if with_section_headers else 0,
+        shstrndx if with_section_headers else 0,
+    )
+    assert len(ehdr) == ehsize
+
+    table = b""
+    for _nm, noff, addr, size, flags, stype in shdrs:
+        data_off = shstrtab_off if stype == SHT_STRTAB else 0
+        table += struct.pack(
+            "<IIQQQQIIQQ",
+            noff,
+            stype,
+            flags,
+            addr,
+            data_off,
+            size,
+            0,  # sh_link
+            0,  # sh_info
+            1,  # sh_addralign
+            0,  # sh_entsize
+        )
+
+    path.write_bytes(ehdr + shstrtab + table)
+    return path
+
+
+# --------------------------------------------------------------------- layouts
+def _single_text(tmp_path: Path) -> Path:
+    """An ordinary x86-64 binary: one .text, plus .init/.plt/.fini around it."""
+    return _write_elf(
+        tmp_path / "single.elf",
+        [
+            (".init", 0x1000, 0x20, AX, SHT_PROGBITS),
+            (".plt", 0x1020, 0x60, AX, SHT_PROGBITS),
+            (".plt.sec", 0x1080, 0x40, AX, SHT_PROGBITS),
+            (".text", 0x1100, 0x800, AX, SHT_PROGBITS),
+            (".fini", 0x1900, 0x10, AX, SHT_PROGBITS),
+            (".rodata", 0x2000, 0x100, SHF_ALLOC, SHT_PROGBITS),
+        ],
+    )
+
+
+def _uboot_like(tmp_path: Path) -> Path:
+    """u-boot: a 936-byte .text, then .efi_runtime, then a 486 KB .text_rest."""
+    return _write_elf(
+        tmp_path / "uboot.elf",
+        [
+            (".text", 0x60800000, 936, AX, SHT_PROGBITS),
+            (".efi_runtime", 0x608003A8, 4984, AX, SHT_PROGBITS),
+            (".text_rest", 0x60801720, 486208, AX, SHT_PROGBITS),
+        ],
+    )
+
+
+def _function_sections(tmp_path: Path) -> Path:
+    """freertos: -ffunction-sections, .text holds only newlib."""
+    secs = [(".text", 0x78, 2935, AX, SHT_PROGBITS)]
+    addr = 0xBF0
+    for i in range(40):
+        secs.append((f".text.fn{i}", addr, 0x40, AX, SHT_PROGBITS))
+        addr += 0x40
+    return _write_elf(tmp_path / "ffunc.elf", secs)
+
+
+def _zero_size_text(tmp_path: Path) -> Path:
+    return _write_elf(
+        tmp_path / "zero.elf",
+        [
+            (".text", 0x14000000, 0, AX, SHT_PROGBITS),
+            ("ER_ROM1", 0x14000000, 0x983C, AX, SHT_PROGBITS),
+        ],
+    )
+
+
+# ----------------------------------------------------------------------- tests
+def test_single_text_binary_is_unchanged(tmp_path: Path) -> None:
+    """The common case must behave exactly as it did before multi-section support."""
+    elf = _single_text(tmp_path)
+    ranges = common.elf_text_ranges(elf)
+    assert ranges == [(0x1100, 0x1900)]
+
+    assert not common.should_skip_function("do_work", 0x1200, ranges)
+    # PLT stubs / .init / .fini stay outside the family and stay dropped.
+    assert common.should_skip_function("puts", 0x1030, ranges)
+    assert common.should_skip_function("frame_dummy", 0x1005, ranges)
+    assert common.should_skip_function("_fini", 0x1900, ranges)
+    # ...and so does anything in .rodata.
+    assert common.should_skip_function("table", 0x2010, ranges)
+
+
+def test_single_text_name_filter_still_off_inside_text(tmp_path: Path) -> None:
+    """A user function called ``j_compress`` inside .text is not a thunk."""
+    ranges = common.elf_text_ranges(_single_text(tmp_path))
+    assert not common.should_skip_function("j_compress", 0x1200, ranges)
+    assert common.should_skip_function("_start", 0x1200, ranges)
+
+
+def test_text_rest_split_is_covered(tmp_path: Path) -> None:
+    """u-boot's 486 KB .text_rest is code, not a data section."""
+    elf = _uboot_like(tmp_path)
+    ranges = common.elf_text_ranges(elf)
+    assert ranges == [(0x60800000, 0x608003A8), (0x60801720, 0x60801720 + 486208)]
+
+    assert not common.should_skip_function("board_init", 0x60801720, ranges)
+    assert not common.should_skip_function("do_bootm", 0x60870000, ranges)
+    # .efi_runtime is not in the .text family, so the section rule still drops it,
+    # ...
+    assert common.should_skip_function("efi_reset_system", 0x608003A8, ranges)
+    # ...unless the driver asked for that exact address.
+    assert not common.should_skip_function("efi_reset_system", 0x608003A8, ranges, {0x608003A8})
+
+
+def test_function_sections_are_covered(tmp_path: Path) -> None:
+    """-ffunction-sections spreads code over one .text.<fn> per function."""
+    elf = _function_sections(tmp_path)
+    ranges = common.elf_text_ranges(elf)
+    # Adjacent .text.fnN sections coalesce into one span next to .text.
+    assert ranges is not None
+    assert common.in_text(0x78, ranges)
+    for i in range(40):
+        assert common.in_text(0xBF0 + i * 0x40, ranges), f"fn{i}"
+        assert not common.should_skip_function(f"fn{i}", 0xBF0 + i * 0x40, ranges)
+    assert not common.in_text(0xBF0 + 40 * 0x40, ranges)
+
+
+def test_zero_size_text_is_treated_as_unknown(tmp_path: Path) -> None:
+    """A degenerate empty .text must not become an empty range that drops all."""
+    ranges = common.elf_text_ranges(_zero_size_text(tmp_path))
+    assert ranges is None
+    # Falls back to the name filter: real functions kept, thunks dropped.
+    assert not common.should_skip_function("SWD_Sequence", 0x14001000, ranges)
+    assert common.should_skip_function("thunk_memcpy", 0x14001000, ranges)
+
+
+def test_no_text_family_section(tmp_path: Path) -> None:
+    elf = _write_elf(tmp_path / "norom.elf", [("ER_ROM1", 0x14000000, 0x100, AX, SHT_PROGBITS)])
+    assert common.elf_text_ranges(elf) is None
+
+
+def test_no_section_headers(tmp_path: Path) -> None:
+    elf = _write_elf(
+        tmp_path / "noshdr.elf",
+        [(".text", 0x1000, 0x100, AX, SHT_PROGBITS)],
+        with_section_headers=False,
+    )
+    assert common.elf_text_ranges(elf) is None
+
+
+def test_non_elf_inputs(tmp_path: Path) -> None:
+    """PE / Mach-O / garbage must degrade to the name filter, not crash."""
+    pe = tmp_path / "a.exe"
+    pe.write_bytes(b"MZ" + b"\x00" * 128)
+    assert common.elf_text_ranges(pe) is None
+
+    macho = tmp_path / "a.dylib"
+    macho.write_bytes(b"\xcf\xfa\xed\xfe" + b"\x00" * 64)
+    assert common.elf_text_ranges(macho) is None
+
+    assert common.elf_text_ranges(tmp_path / "does-not-exist") is None
+
+
+def test_data_and_nobits_text_sections_are_ignored(tmp_path: Path) -> None:
+    """A non-executable or NOBITS ``.text*`` section contributes no range."""
+    elf = _write_elf(
+        tmp_path / "odd.elf",
+        [
+            (".text", 0x1000, 0x100, AX, SHT_PROGBITS),
+            (".text.data", 0x2000, 0x100, SHF_ALLOC, SHT_PROGBITS),
+            (".text.bss", 0x3000, 0x100, AX, SHT_NOBITS),
+        ],
+    )
+    assert common.elf_text_ranges(elf) == [(0x1000, 0x1100)]
+
+
+def test_overlapping_sections_merge(tmp_path: Path) -> None:
+    elf = _write_elf(
+        tmp_path / "dup.elf",
+        [
+            (".text", 0x1000, 0x200, AX, SHT_PROGBITS),
+            (".text.dup", 0x1000, 0x200, AX, SHT_PROGBITS),
+            (".text.overlap", 0x1100, 0x300, AX, SHT_PROGBITS),
+            (".text.gap", 0x9000, 0x100, AX, SHT_PROGBITS),
+        ],
+    )
+    assert common.elf_text_ranges(elf) == [(0x1000, 0x1400), (0x9000, 0x9100)]
+    ranges = common.elf_text_ranges(elf)
+    assert common.in_text(0x13FF, ranges)
+    assert not common.in_text(0x1400, ranges)
+    assert not common.in_text(0x8FFF, ranges)
+    assert common.in_text(0x9000, ranges)
+
+
+def test_dwarf_target_exemption_beats_the_section_rule(tmp_path: Path) -> None:
+    ranges = common.elf_text_ranges(_single_text(tmp_path))
+    far_away = 0x50000
+    assert common.should_skip_function("mystery", far_away, ranges)
+    assert not common.should_skip_function("mystery", far_away, ranges, {far_away})
+    # A non-target at the same place is still dropped.
+    assert common.should_skip_function("mystery", far_away, ranges, {0x1234})
+
+
+def test_dwarf_target_exemption_tolerates_the_thumb_bit(tmp_path: Path) -> None:
+    """DWARF low_pc is even; ARM tools report a Thumb entry with the LSB set."""
+    ranges = common.elf_text_ranges(_single_text(tmp_path))
+    assert not common.should_skip_function("thumb_fn", 0x40001, ranges, {0x40000})
+    assert not common.should_skip_function("thumb_fn", 0x40000, ranges, {0x40001})
+
+
+@pytest.mark.parametrize("targets", [None, set(), {0x1234}])
+def test_no_targets_keeps_the_old_behaviour(tmp_path: Path, targets) -> None:
+    ranges = common.elf_text_ranges(_single_text(tmp_path))
+    assert common.should_skip_function("puts", 0x1030, ranges, targets)
+    assert not common.should_skip_function("do_work", 0x1200, ranges, targets)
+
+
+def test_in_text_accepts_a_legacy_single_range() -> None:
+    assert common.in_text(0x1200, (0x1100, 0x1900))
+    assert not common.in_text(0x1000, (0x1100, 0x1900))
+    assert common.in_text(0x1200, None)
+
+
+def test_addr_targets_of_keeps_only_ints() -> None:
+    assert common.addr_targets_of(None) == set()
+    assert common.addr_targets_of(set()) == set()
+    assert common.addr_targets_of({1, 2}) == {1, 2}
+    assert common.addr_targets_of({"main", "helper"}) == set()
+    assert common.addr_targets_of({True, False}) == set()
+
+
+def test_every_backend_shares_one_rule() -> None:
+    """r2dec's exemption and the raw path are literally the same function now."""
+    from decbench.decompilers import declib_dec, dockerized
+
+    assert dockerized._skip_r2_function is common.should_skip_function
+    assert dockerized._addr_targets_of is common.addr_targets_of
+    assert dockerized._elf_text_range is common.elf_text_ranges
+    assert declib_dec._elf_text_range is common.elf_text_ranges
+    assert common.elf_text_range is common.elf_text_ranges


### PR DESCRIPTION
## The bug

`raw/common.elf_text_range()` read the **single section literally named `.text`**, and
`should_skip_function()` dropped every function outside that range. On binaries whose code is
spread over several executable sections that discards essentially the whole program, so the
row reads as "every decompiler failed" when in fact DecBench threw their output away.

Two backends escaped, which is what made this diagnosable: `dockerized._skip_r2_function`
(r2dec) and `raw/dewolf_driver` (dewolf) both already kept any function whose address was one
the driver had asked for. `_skip_r2_function`'s own docstring names this exact situation as
"the exact reason r2dec scored 0 on those ARM targets" — the fix was designed and shipped on
one path and never ported to the others.

### Affected binaries

| binary | layout | measured functions inside `.text` |
|---|---|---|
| `O2/u-boot/u-boot` | 936 B `.text` @ 0x60800000, then `.efi_runtime`, then **486 KB `.text_rest`** | **0 of 1056** |
| `O2-noinline/u-boot/u-boot` | same | **0 of 1912** |
| `O0/freertos/RTOSDemo` | `-ffunction-sections`: **108 exec sections**, `.text` (2,935 B) is newlib only | **0 of 107** |
| `O2/freertos/RTOSDemo` | 84 exec sections | **0 of 57** |
| `O2-noinline/freertos/RTOSDemo` | 108 exec sections | **0 of 101** |

The recorded scores match: for `O2/u-boot` and all three `freertos` rows, **only r2dec and
dewolf have any measured coverage at all** (u-boot O2: r2dec 1034/1061, dewolf 10/1061,
everything else 0).

**Correction to the original report:** `crazyflie/CMSIS_DAP.axf` is *not* an instance of this
bug. It has no `.text` section at all (one `ER_ROM1`), so `elf_text_range()` already returned
`None` and the name-prefix fallback already kept everything — angr decompiles 342 functions
there, IDA 340, kuna 265. Its low score has a different cause (none of those functions lands
on the 2–3 DWARF-measured addresses), out of scope here.

## The fix

Which semantics: I ported **the DWARF-target exemption** — the rule `_skip_r2_function` and the
dewolf driver actually implement — rather than inventing an "any executable section" rule. The
generalization was tempting but wrong on its own: accepting any `SHF_EXECINSTR` section would
start keeping `.plt` / `.plt.sec` / `.init` / `.fini` entries on ordinary binaries, which is
worse than the bug. The exemption is also strictly sufficient for scoring, because the measured
set *is* the DWARF target set.

I did generalize the **section** half of the rule from "the section named `.text`" to "the
`.text` family" (`SHF_EXECINSTR` and name starts with `.text`) — same heuristic, not a second
one. That covers `-ffunction-sections` and `.text_rest` for callers that have no DWARF filter
(a bare `decbench run`, `decompile_project`), and provably changes nothing on ordinary binaries
where `.text` is the only family member. `.efi_runtime` and `.plt` remain outside the family
and remain excluded.

Concretely, in `decbench/decompilers/raw/common.py`:

1. `should_skip_function(name, file_addr, text_range, addr_targets=None)` — an address in
   `addr_targets` (Thumb-bit tolerant, via the existing `_addr_matches`) is kept, whatever
   section it landed in. New helper `addr_targets_of(function_names)` extracts the int
   addresses from the driver's filter.
2. `elf_text_ranges()` replaces `elf_text_range()` (kept as an alias): merged `[start, end)`
   ranges of every `.text*` `SHF_EXECINSTR` section, skipping `SHT_NOBITS` and zero-size ones,
   overlaps coalesced. Returns `None` — "unknown, fall back to the name filter" — for non-ELF
   input, no section headers, no `.text`-family section, or a degenerate zero-size `.text`.
   `in_text()` bisects the range list and still accepts a legacy single tuple.

**Factored into one helper, as asked.** The three duplicate copies of this logic are gone:
`dockerized._skip_r2_function`, `_addr_targets_of`, `_elf_text_range`, `_SKIP_NAMES`,
`_SKIP_PREFIXES` and `declib_dec._elf_text_range`, `_SKIP_NAMES`, `_SKIP_PREFIXES` are now
aliases of the `raw/common` ones, and `dockerized.elf_function_symbols` /
`declib_dec._enumerate_functions` call `should_skip_function` instead of re-implementing it.
A test asserts `dockerized._skip_r2_function is common.should_skip_function`.

Every backend now threads the driver's address set through: angr, binja, ghidra, ida, kuna
(raw), the declib backends, and r2dec.

## Verification (offline, no benchmark re-run)

Computed against `results/full_run` with the patched code imported directly; OLD re-implemented
from `main`.

### Affected rows — measured (DWARF-target) set

| row | measured | OLD kept | NEW kept |
|---|---|---|---|
| `O2/u-boot/u-boot` | 1056 | **0** | **1056** |
| `O2-noinline/u-boot/u-boot` | 1912 | **0** | **1912** |
| `O0/freertos/RTOSDemo` | 107 | **0** | **107** |
| `O2/freertos/RTOSDemo` | 57 | **0** | **57** |
| `O2-noinline/freertos/RTOSDemo` | 101 | **0** | **101** |

**3,233 measured functions un-discarded.**

### Realized per backend

For kuna I re-ran discovery only (`kuna decompile-all --json` on the stripped binary) to get
its true function universe:

| row | backend | discovered | keep OLD | keep NEW | **measured credited OLD → NEW** |
|---|---|---|---|---|---|
| `O2/u-boot` | kuna | 1727 | 4 | 1718 | **0 → 585** |
| `O2/u-boot` | r2dec | 1049 | 0 | 1049 | 0 → 1048 *(r2dec already had the exemption; the 0 is what the raw rule would have done to it)* |
| `O2/u-boot` | dewolf | 11 | 0 | 11 | 0 → 11 |
| `O0/freertos` | r2dec | 93 | 0 | 93 | 0 → 93 |
| `O0/freertos` | dewolf | 101 | 0 | 101 | 0 → 101 |
| `O2/freertos` | r2dec | 56 | 0 | 56 | 0 → 56 |
| `O2-noinline/u-boot` | r2dec | 1866 | 0 | 1866 | 0 → 1865 |
| `O2-noinline/u-boot` | dewolf | 212 | 0 | 212 | 0 → 212 |

angr / binja / ghidra / ida / phoenix can't be measured offline — their `.c` files contain only
what survived the old filter (u-boot O2: angr 25, binja 21, ghidra 8, ida 3, all inside the
936-byte `.text`), so their discovery universe is unknown until a re-run. The 1056-function
ceiling and r2dec's realized 1048 bound what they will gain.

### No-change proof on ordinary binaries

OLD vs NEW over **213 ordinary x86-64 binaries** (coreutils, bash, tar, openssh-portable, gzip,
grep, diffutils, findutils, bzip2, zlib, dash, dpkg, e2fsprogs, cronie) at O0, O2 and
O2-noinline, against two universes:

| universe | functions | changed decisions |
|---|---|---|
| every `// Function:` block in every backend's `.c` | 14,995 | **+0 / −0** |
| every `STT_FUNC` ELF symbol (deliberately includes PLT stubs and CRT helpers) | 45,040 | **+0 / −0** |

Not one keep/skip decision moves. Sweeping the entire results tree, exactly **5** rows change:
the two u-boot and three freertos rows above.

### Tests

`tests/test_text_filter.py`, 18 new tests, building tiny synthetic ELF64 files byte-by-byte
(no dependency on the results tree): single-`.text` unchanged (incl. `.plt`/`.init`/`.fini`
still dropped and `j_compress` inside `.text` still kept), `.text` + `.text_rest`,
`-ffunction-sections` with 40 `.text.<fn>` sections, zero-size `.text`, no `.text`-family
section, no section headers, PE/Mach-O/missing-file inputs, non-exec and NOBITS `.text.*`
ignored, overlapping sections merged, target exemption + Thumb-bit tolerance, and the
one-shared-rule identity assertions.

Full suite: **431 passed, 5 failed, 7 skipped**. Baseline on `main` before the change:
**413 passed, 5 failed, 7 skipped** — the same 5 pre-existing `tests/test_content.py`
site-content failures, untouched by this PR. `ruff check decbench/` reports 19 errors before
and after. `black` adds no new debt (only the new test file, which is formatted).

## ⚠️ This changes historical scores

The five affected rows currently read as "every decompiler failed" when the benchmark had in
fact discarded their output. **Any published scoreboard covering u-boot or freertos needs
re-running and re-scoring** before it is republished — `results/full_run`, `scoreboard.toml`,
`function_results.json`, the site, and the HuggingFace dataset. Per AGENTS.md's "verify nothing
extreme has changed" rule, expect a large but *legitimate* jump on those rows: 3,233 functions
move from "not scored" to "scored", so aggregate ranks may shift.

Not re-run here — the brief was to fix and verify offline, not to re-benchmark.

## Suggested CHANGELOG entry (not committed — AGENTS.md forbids autonomous CHANGELOG edits)

```markdown
### 2026-08-01

- Fixed a benchmark-side bug that discarded a decompiler's entire output on binaries whose
  code is spread across several executable sections. The function filter only recognised the
  one section literally named `.text`, so on `u-boot` (a 936-byte `.text` plus a 486 KB
  `.text_rest`) and `freertos` (`-ffunction-sections`, 108 `.text.<fn>` sections) every
  measured function was dropped and the affected rows read as "every decompiler failed". Only
  `r2dec` and `dewolf` escaped, because their paths already honoured the requested source
  addresses. All backends now share one filter.
- **This changes historical scores** for `u-boot` (O2, O2-noinline) and `freertos` (O0, O2,
  O2-noinline) — 3,233 measured functions that were silently discarded. Those rows need
  re-running before any scoreboard covering them is republished. No other target is affected.
```

---

[AUTOMATED] opened by Claude Code for maintainer review — please do not auto-merge.
