### PR TITLE
[AUTOMATED] feat(cpp): C++ project support + leveldb target

### DIFF
--- a/decbench/compilers/gcc.py
+++ b/decbench/compilers/gcc.py
@@ -10,6 +10,20 @@ from pathlib import Path
 
 from decbench.compilers.base import Compiler, CompileResult
 from decbench.models.project import opt_gcc_flags
+from decbench.utils.langs import PREPROC_EXTS, SOURCE_EXTS, preprocessed_ext
+
+# Build by-products that are never a linked binary, so they are skipped before
+# the (more expensive) ELF/PE sniff.
+_NON_BINARY_EXTS = (".o", ".a", ".s", ".h", ".hh", ".hpp", *PREPROC_EXTS, *SOURCE_EXTS)
+
+
+def find_preprocessed(base_path: Path) -> Path | None:
+    """First existing ``base_path`` re-suffixed with a preprocessed extension."""
+    for ext in PREPROC_EXTS:
+        candidate = base_path.with_suffix(ext)
+        if candidate.exists():
+            return candidate
+    return None
 
 
 class GCCCompiler(Compiler):
@@ -94,7 +108,8 @@ class GCCCompiler(Compiler):
 
         stem = source_path.stem
         object_path = output_dir / f"{stem}.o"
-        preprocessed_path = output_dir / f"{stem}.i" if emit_preprocessed else None
+        pp_ext = preprocessed_ext(source_path)
+        preprocessed_path = output_dir / f"{stem}{pp_ext}" if emit_preprocessed else None
 
         flags = list(self.base_flags)
         flags.extend(opt_gcc_flags(optimization))
@@ -130,7 +145,7 @@ class GCCCompiler(Compiler):
                 )
 
             if emit_preprocessed and not preprocessed_path.exists():
-                alt_path = source_path.with_suffix(".i")
+                alt_path = source_path.with_suffix(pp_ext)
                 if alt_path.exists():
                     shutil.move(str(alt_path), str(preprocessed_path))
 
@@ -294,7 +309,7 @@ class GCCCompiler(Compiler):
                         continue
                     if entry.is_symlink():
                         continue
-                    if entry.suffix in (".o", ".a", ".i", ".s", ".c", ".h"):
+                    if entry.suffix in _NON_BINARY_EXTS:
                         continue
                     if not self._is_linked_binary(entry):
                         continue
@@ -306,14 +321,14 @@ class GCCCompiler(Compiler):
 
                     obj_file = entry.with_suffix(".o")
                     c_file = entry.with_suffix(".c")
-                    i_file = entry.with_suffix(".i")
+                    i_file = find_preprocessed(entry)
                     dest_i = None
-                    if i_file.exists():
+                    if i_file is not None:
                         dest_i = output_dir / i_file.name
                         shutil.copy2(i_file, dest_i)
                     elif obj_file.exists():
-                        alt_i = obj_file.with_suffix(".i")
-                        if alt_i.exists() and alt_i != i_file:
+                        alt_i = find_preprocessed(obj_file)
+                        if alt_i is not None:
                             dest_i = output_dir / alt_i.name
                             shutil.copy2(alt_i, dest_i)
 
@@ -325,8 +340,8 @@ class GCCCompiler(Compiler):
                     ))
 
                 for obj_file in project_dir.rglob("*.o"):
-                    i_file = obj_file.with_suffix(".i")
-                    if i_file.exists():
+                    i_file = find_preprocessed(obj_file)
+                    if i_file is not None:
                         dest_i = output_dir / i_file.name
                         if not dest_i.exists():
                             shutil.copy2(i_file, dest_i)

--- a/decbench/evalkit/resolve.py
+++ b/decbench/evalkit/resolve.py
@@ -6,7 +6,7 @@ address space as the rest of DecBench:
 * :func:`name_to_addr` follows ``project_source_functions``
   (``scripts/run_benchmark.py``): DWARF ``DW_TAG_subprogram`` entries with a
   ``low_pc``, optionally filtered to the project's own translation units via
-  ``DW_AT_decl_file`` stems (the compiled ``.i`` stems).
+  ``DW_AT_decl_file`` stems (the compiled ``.i``/``.ii`` stems).
 * :class:`AddrLookup` follows ``_relabel_to_dwarf``'s tolerance rules when
   mapping a reported address back to a DWARF name: exact, Thumb ``addr & ~1``,
   PE ``addr + min_vaddr`` (ImageBase), and both combined.
@@ -26,33 +26,33 @@ import os
 import struct
 from pathlib import Path
 
+from decbench.utils.langs import PREPROC_EXTS, strip_source_ext
+
 _l = logging.getLogger(__name__)
 
 
 def source_stems(tree: Path, opt: str, project: str) -> set[str]:
-    """Stems of the project's preprocessed ``.i`` translation units at ``opt``.
+    """Stems of the project's preprocessed (``.i``/``.ii``) units at ``opt``.
 
     These are the ``DW_AT_decl_file`` filter used to keep only functions defined
     in the project's own sources (excluding bundled gnulib etc.). An empty set
-    means the tree has no ``.i`` files for this slice (caller decides whether to
-    fall back to an unfiltered walk).
+    means the tree has no preprocessed files for this slice (caller decides
+    whether to fall back to an unfiltered walk).
     """
     compiled = Path(tree) / opt / project / "compiled"
-    return {f.stem for f in compiled.glob("*.i")}
-
-
-def _decode(value: bytes | str) -> str:
-    return value.decode() if isinstance(value, bytes) else str(value)
+    return {f.stem for ext in PREPROC_EXTS for f in compiled.glob(f"*{ext}")}
 
 
 def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
     """DWARF subprogram walk: ``low_pc -> DW_AT_name`` (decl-file-filtered).
 
     Mirrors ``project_source_functions`` (scripts/run_benchmark.py) including its
-    DWARF v4/v5 ``decl_file`` index handling and the object-prefixed stem match
-    (``mydoom-main.i`` <-> decl ``main.c``). When ``stems`` is None the
-    decl-file filter is skipped and every named subprogram with a ``low_pc`` is
-    kept. Returns an empty map when the binary has no usable DWARF.
+    DWARF v4/v5 ``decl_file`` index handling, the ``DW_AT_specification`` chase
+    that finds C++ out-of-line definitions, the source-extension-agnostic stem
+    comparison, and the object-prefixed stem match (``mydoom-main.i`` <-> decl
+    ``main.c``). When ``stems`` is None the decl-file filter is skipped and every
+    named subprogram with a ``low_pc`` is kept. Returns an empty map when the
+    binary has no usable DWARF.
     """
     from decbench.utils import binfmt
 
@@ -64,37 +64,29 @@ def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
     if dw is None:
         return {}
     addr2name: dict[int, str] = {}
+    file_tables: dict[int, list[str | None]] = {}
+    stem_index = {strip_source_ext(s): s for s in (stems or ())}
     try:
         for cu in dw.iter_CUs():
-            files: list[str | None] = []
-            if stems is not None:
-                lp = dw.line_program_for_CU(cu)
-                # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
-                # makes the index line up either way.
-                version = 4
-                if lp is not None:
-                    version = lp.header.get("version", cu.header.get("version", 4))
-                files = [] if version >= 5 else [None]
-                if lp is not None:
-                    for fe in lp["file_entry"]:
-                        files.append(_decode(fe.name))
             for die in cu.iter_DIEs():
-                if die.tag != "DW_TAG_subprogram":
+                if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
                     continue
-                attrs = die.attributes
-                if "DW_AT_low_pc" not in attrs or "DW_AT_name" not in attrs:
+                name = binfmt.die_str_attr(die, "DW_AT_name")
+                if name is None:
                     continue
                 if stems is not None:
-                    fi = attrs.get("DW_AT_decl_file")
-                    if fi is None or not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                    fi, owner = binfmt.die_attr_owner(die, "DW_AT_decl_file")
+                    if fi is None:
                         continue
-                    base = os.path.basename(files[fi.value])  # type: ignore[arg-type]
-                    stem = base[:-2] if base.endswith(".c") else base
-                    if stem not in stems and not any(
-                        s.endswith("-" + stem) or s.endswith("_" + stem) for s in stems
+                    files = binfmt.cu_file_table(dw, owner.cu, file_tables)
+                    if not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                        continue
+                    stem = strip_source_ext(os.path.basename(files[fi.value]))  # type: ignore[arg-type]
+                    if stem not in stem_index and not any(
+                        s.endswith("-" + stem) or s.endswith("_" + stem) for s in stem_index
                     ):
                         continue
-                addr2name[int(attrs["DW_AT_low_pc"].value)] = _decode(attrs["DW_AT_name"].value)
+                addr2name[int(die.attributes["DW_AT_low_pc"].value)] = name
     except Exception as e:  # noqa: BLE001
         _l.warning("DWARF walk failed for %s: %s", binary, e)
         return {}

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -244,11 +244,19 @@ def extract_ground_truth_types(binary_path: Path) -> dict[str, list[dict[str, An
 
 
 def _parse_function_die(die: Any, dwarfinfo: Any) -> tuple[str | None, list[dict[str, Any]]]:
-    """Parse a DW_TAG_subprogram DIE to extract function variable types."""
-    if "DW_AT_name" not in die.attributes:
-        return None, []
+    """Parse a DW_TAG_subprogram DIE to extract function variable types.
 
-    func_name = die.attributes["DW_AT_name"].value.decode("utf-8", "replace")
+    The name is read through ``DW_AT_specification``/``DW_AT_abstract_origin``:
+    a C++ out-of-line member definition carries the body but keeps its name on
+    the in-class declaration it references. C subprograms always name themselves
+    on the defining DIE, so the chase never fires and C ground truth is byte-for-
+    byte what it was.
+    """
+    from decbench.utils import binfmt
+
+    func_name = binfmt.die_str_attr(die, "DW_AT_name")
+    if func_name is None:
+        return None, []
     variables: list[dict[str, Any]] = []
 
     arg_index = 0

--- a/decbench/pipeline/compile.py
+++ b/decbench/pipeline/compile.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from decbench.compilers.gcc import GCCCompiler
 from decbench.models.project import OptimizationLevel, Project, RemoteType
+from decbench.utils.langs import SOURCE_EXTS
 
 if TYPE_CHECKING:
     from decbench.compilers.base import CompileResult
@@ -164,8 +165,9 @@ def compile_project(
         # Dedup by basename, SHALLOWEST path first: plain sorted() would put arch/foo.c
         # before foo.c and let an unrelated nested duplicate shadow the compiled file.
         src_dir = source_dir / config.source_dir if config.source_dir else source_dir
+        candidates = [p for ext in SOURCE_EXTS for p in src_dir.rglob(f"*{ext}")]
         seen: set[str] = set()
-        for c_file in sorted(src_dir.rglob("*.c"), key=lambda p: (len(p.parts), str(p))):
+        for c_file in sorted(candidates, key=lambda p: (len(p.parts), str(p))):
             if c_file.name in seen:
                 continue
             seen.add(c_file.name)

--- a/decbench/pipeline/executor.py
+++ b/decbench/pipeline/executor.py
@@ -13,6 +13,7 @@ from decbench.pipeline.compile import compile_projects
 from decbench.pipeline.decompile import decompile_projects
 from decbench.pipeline.evaluate import evaluate_projects
 from decbench.scoring.scoreboard import build_scoreboard_from_function_data
+from decbench.utils.langs import PREPROC_EXTS
 
 if TYPE_CHECKING:
     from decbench.models.scoreboard import Scoreboard
@@ -322,7 +323,9 @@ class PipelineExecutor:
                 else:
                     print(f"Warning: no ELF binaries found in {compiled_dir}")
 
-                i_files = {f.stem: f for f in sorted(compiled_dir.glob("*.i"))}
+                i_files = {
+                    f.stem: f for ext in PREPROC_EXTS for f in sorted(compiled_dir.glob(f"*{ext}"))
+                }
                 if i_files:
                     project.preprocessed_sources[opt] = i_files
                     print(

--- a/decbench/results_store.py
+++ b/decbench/results_store.py
@@ -56,6 +56,7 @@ PROJECT_DIRS = [
     _REPO_ROOT / "projects/sailr",
     _REPO_ROOT / "projects/cps",
     _REPO_ROOT / "projects/malware",
+    _REPO_ROOT / "projects/cpp",
 ]
 
 GUARD_PRINT_CAP = 100

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -18,6 +18,11 @@ What's here:
   * :func:`function_bytes` / :func:`object_text_bytes` — original function bytes
     from a final ELF/PE, and the `.text` of a single-function recompiled object
     (ELF or COFF), for byte_match.
+  * :func:`die_attr` / :func:`die_str_attr` / :func:`die_attr_owner` — read a DIE
+    attribute through ``DW_AT_specification`` (and, in a C++ unit only,
+    ``DW_AT_abstract_origin``), which is where C++ out-of-line definitions keep
+    their name and decl file; :func:`cu_file_table` resolves the
+    ``DW_AT_decl_file`` index and :func:`cu_is_cxx` reports the unit's language.
 """
 
 from __future__ import annotations
@@ -255,6 +260,103 @@ def dwarf_info(path: Path):
             return _build_dwarfinfo(secs, elf.little_endian, addr_size, march)
     except Exception:
         return None
+
+
+_DIE_REF_MAX_HOPS = 4
+
+# DW_LANG_C_plus_plus and its dated successors (03/11/14/17/20/23).
+_CXX_LANGS = frozenset({0x04, 0x19, 0x1A, 0x21, 0x2A, 0x2B, 0x33})
+
+_SPEC_ONLY = ("DW_AT_specification",)
+_SPEC_AND_ORIGIN = ("DW_AT_specification", "DW_AT_abstract_origin")
+
+
+def cu_is_cxx(cu) -> bool:
+    """True when the compilation unit's ``DW_AT_language`` is a C++ dialect."""
+    try:
+        attr = cu.get_top_DIE().attributes.get("DW_AT_language")
+    except Exception:
+        return False
+    return attr is not None and attr.value in _CXX_LANGS
+
+
+def die_attr_owner(die, name: str):
+    """``(attribute, owning DIE)`` for ``name``, following DIE reference chains.
+
+    gcc splits an out-of-line C++ member definition in two: the defining DIE
+    carries ``DW_AT_low_pc`` but NO ``DW_AT_name``/``DW_AT_decl_file``, which
+    live on the in-class declaration it points at via ``DW_AT_specification``
+    (and that declaration may itself forward once more, e.g. a template
+    instantiation). Following the chain is what makes a C++ binary's functions
+    visible at all.
+
+    ``DW_AT_specification`` is a C++-only construct, so following it can never
+    change a C result. ``DW_AT_abstract_origin`` is NOT — in C, gcc uses it for
+    the out-of-line copy it keeps of a function it also inlined, and following
+    it would newly surface ~10-20% more functions in the existing C corpus
+    (measured: grep at O2 goes 262 -> 314). That hop is therefore taken only in
+    a C++ compilation unit, which leaves every C binary bit-identical.
+
+    The owning DIE is returned because a CU-relative attribute value such as
+    ``DW_AT_decl_file`` must be read against ITS CU's line program, not the
+    starting DIE's.
+    """
+    cur = die
+    refs = _SPEC_AND_ORIGIN if cu_is_cxx(die.cu) else _SPEC_ONLY
+    for _ in range(_DIE_REF_MAX_HOPS + 1):
+        attr = cur.attributes.get(name)
+        if attr is not None:
+            return attr, cur
+        nxt = None
+        for ref in refs:
+            if ref in cur.attributes:
+                try:
+                    nxt = cur.get_DIE_from_attribute(ref)
+                except Exception:
+                    nxt = None
+                break
+        if nxt is None:
+            return None, None
+        cur = nxt
+    return None, None
+
+
+def die_attr(die, name: str):
+    """The attribute ``name``, following DIE reference chains (:func:`die_attr_owner`)."""
+    return die_attr_owner(die, name)[0]
+
+
+def die_str_attr(die, name: str) -> str | None:
+    """:func:`die_attr` decoded to ``str``, or None when absent."""
+    attr = die_attr(die, name)
+    if attr is None:
+        return None
+    val = attr.value
+    return val.decode("utf-8", "replace") if isinstance(val, bytes) else str(val)
+
+
+def cu_file_table(dwarfinfo, cu, cache: dict[int, list] | None = None) -> list:
+    """A CU's ``DW_AT_decl_file`` index table, optionally memoized by CU offset.
+
+    DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the leading
+    placeholder entry makes the index line up either way.
+    """
+    if cache is not None:
+        cached = cache.get(cu.cu_offset)
+        if cached is not None:
+            return cached
+    lp = dwarfinfo.line_program_for_CU(cu)
+    version = 4
+    if lp is not None:
+        version = lp.header.get("version", cu.header.get("version", 4))
+    files: list = [] if version >= 5 else [None]
+    if lp is not None:
+        for fe in lp["file_entry"]:
+            nm = fe.name
+            files.append(nm.decode("utf-8", "replace") if isinstance(nm, bytes) else nm)
+    if cache is not None:
+        cache[cu.cu_offset] = files
+    return files
 
 
 def _dwarf_function_range(path: Path, func_name: str) -> tuple[int, int] | None:

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -8,6 +8,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from decbench.utils.langs import CXX_PREPROC_EXTS, PREPROC_EXTS
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -101,9 +103,9 @@ def _is_system_header(path: str) -> bool:
 
 
 def strip_system_headers(preprocessed: str) -> str:
-    """Drop inlined system-header code from a preprocessed (.i) translation unit.
+    """Drop inlined system-header code from a preprocessed (``.i``/``.ii``) unit.
 
-    A ``.i`` file is the project source with EVERY ``#include`` expanded inline,
+    A preprocessed file is the project source with EVERY ``#include`` expanded inline,
     so it is dominated (80-98%) by glibc/toolchain headers. Joern then either
     times out parsing megabytes of headers or drowns the project's own functions
     in thousands of header inlines — which is why GED "source-parse failures"
@@ -195,21 +197,32 @@ def resolved_source_for_binary(
     return resolved
 
 
+def temp_parse_suffix(source_path: Path) -> str:
+    """The temp-file suffix Joern must see for ``source_path``'s language.
+
+    Joern picks its frontend from the file extension, and its C frontend returns
+    ZERO functions for C++ input — so a ``.ii`` (preprocessed C++) translation
+    unit handed over as ``.c`` silently scores nothing. Preprocessed C++ becomes
+    ``.cpp``; everything else stays ``.c``.
+    """
+    return ".cpp" if source_path.suffix in CXX_PREPROC_EXTS else ".c"
+
+
 def extract_cfgs_from_source(
     source_path: Path, sanitize_decompiled: bool = False
 ) -> dict[str, DiGraph]:
-    """Extract CFGs from a C source file using pyjoern.
+    """Extract CFGs from a C or C++ source file using pyjoern.
 
     Args:
-        source_path: Path to C source file (.c or .i). For ``.i`` files the
-            inlined system headers are stripped first (see
-            :func:`strip_system_headers`) so Joern parses only the project's own
-            (already-preprocessed, correctly-ifdef'd) code — fast and complete.
+        source_path: Path to a source file (``.c``, or preprocessed ``.i``/``.ii``).
+            For preprocessed files the inlined system headers are stripped first
+            (see :func:`strip_system_headers`) so Joern parses only the project's
+            own (already-preprocessed, correctly-ifdef'd) code — fast and complete.
         sanitize_decompiled: When True and ``source_path`` is a *decompiled* ``.c``
-            (i.e. NOT a ``.i`` ground-truth source), run its text through
+            (i.e. NOT a preprocessed ground-truth source), run its text through
             :func:`sanitize_decompiled_c` before parsing so decompiler-specific
-            quirks don't drop the function from GED. Never applied to ``.i`` files
-            — sanitizing ground truth would be wrong.
+            quirks don't drop the function from GED. Never applied to preprocessed
+            files — sanitizing ground truth would be wrong.
 
     Returns:
         Dictionary mapping function names to CFG DiGraphs
@@ -224,8 +237,8 @@ def extract_cfgs_from_source(
     cfgs = {}
     # Joern names its workspace after the input basename, so a unique temp name is
     # what keeps concurrent parses of the same filename from colliding.
-    temp_c_path = Path(tempfile.mktemp(suffix=".c"))
-    if source_path.suffix == ".i":
+    temp_c_path = Path(tempfile.mktemp(suffix=temp_parse_suffix(source_path)))
+    if source_path.suffix in PREPROC_EXTS:
         temp_c_path.write_text(strip_system_headers(source_path.read_text(errors="replace")))
     else:
         text = source_path.read_text(errors="replace")

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -235,16 +235,20 @@ def extract_cfgs_from_source(
         )
 
     cfgs = {}
-    # Joern names its workspace after the input basename, so a unique temp name is
-    # what keeps concurrent parses of the same filename from colliding.
-    temp_c_path = Path(tempfile.mktemp(suffix=temp_parse_suffix(source_path)))
+    text = source_path.read_text(errors="replace")
     if source_path.suffix in PREPROC_EXTS:
-        temp_c_path.write_text(strip_system_headers(source_path.read_text(errors="replace")))
-    else:
-        text = source_path.read_text(errors="replace")
-        if sanitize_decompiled:
-            text = sanitize_decompiled_c(text)
-        temp_c_path.write_text(text)
+        text = strip_system_headers(text)
+    elif sanitize_decompiled:
+        text = sanitize_decompiled_c(text)
+
+    # Joern names its workspace after the input basename, so a unique temp name is
+    # what keeps concurrent parses of the same filename from colliding. The suffix
+    # is what selects Joern's frontend (see :func:`temp_parse_suffix`).
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=temp_parse_suffix(source_path), delete=False
+    ) as f:
+        f.write(text)
+        temp_c_path = Path(f.name)
     parse_path = temp_c_path
 
     try:

--- a/decbench/utils/langs.py
+++ b/decbench/utils/langs.py
@@ -1,0 +1,48 @@
+"""Source-language vocabulary shared by the compiler, CFG, and source-extract paths.
+
+gcc names its ``-save-temps`` output after the LANGUAGE, not the flag: a C
+translation unit yields ``<name>.i`` and a C++ one ``<name>.ii``. Joern picks
+its frontend the same way — from the extension — and its C frontend returns
+zero functions for C++ input. So the ``.i``/``.ii`` distinction has to be
+carried end-to-end, and every site that used to hard-code ``.i`` speaks these
+tuples instead.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+C_SOURCE_EXTS = (".c",)
+CXX_SOURCE_EXTS = (".cc", ".cpp", ".cxx", ".c++", ".C")
+SOURCE_EXTS = (*C_SOURCE_EXTS, *CXX_SOURCE_EXTS)
+
+C_PREPROC_EXTS = (".i",)
+CXX_PREPROC_EXTS = (".ii",)
+PREPROC_EXTS = (*C_PREPROC_EXTS, *CXX_PREPROC_EXTS)
+
+SOURCE_AND_PREPROC_EXTS = (*SOURCE_EXTS, *PREPROC_EXTS)
+
+
+def preprocessed_ext(source_path: Path | str) -> str:
+    """The ``-save-temps`` preprocessed extension for a translation unit."""
+    return ".ii" if Path(source_path).suffix in CXX_SOURCE_EXTS else ".i"
+
+
+def is_cxx_preprocessed(path: Path | str) -> bool:
+    """True for a preprocessed C++ translation unit (``.ii``)."""
+    return Path(path).suffix in CXX_PREPROC_EXTS
+
+
+def strip_source_ext(name: str) -> str:
+    """Drop a trailing C/C++ *source* extension from ``name``.
+
+    Used to compare a DWARF ``DW_AT_decl_file`` basename against a preprocessed
+    translation-unit stem, which differ in shape between C and C++: gcc emits
+    ``foo.i`` for ``foo.c`` (stem ``foo``) but CMake's object naming makes it
+    ``foo.cc.ii`` for ``foo.cc`` (stem ``foo.cc``). Header extensions are
+    deliberately NOT stripped, so header-defined functions stay outside the
+    "project's own translation units" filter exactly as before.
+    """
+    stem, ext = os.path.splitext(name)
+    return stem if ext in SOURCE_EXTS else name

--- a/decbench/utils/source_extract.py
+++ b/decbench/utils/source_extract.py
@@ -7,17 +7,19 @@ parser, so this is heuristic but conservative:
 
 1. Read the function's ``decl_file`` / ``decl_line`` from the binary's DWARF
    (when present) to know *which* source file and roughly *where*.
-2. Find the matching original ``.c`` next to the binary (the compile stage keeps
-   per-binary sources in ``compiled/``), then locate the function *definition*
-   (not a call/prototype) and brace-match its body. K&R-style definitions are
-   accepted too (bare-identifier param list guarded against prototypes).
-3. Fall back to the preprocessed ``.i`` next to the binary when no ``.c`` carries
-   the definition (nested-tree projects keep only ``.i`` in ``compiled/``). The
-   ``.i`` text is macro-expanded, so it is only used when a real ``.c`` is absent.
+2. Find the matching original ``.c``/``.cc``/``.cpp`` next to the binary (the
+   compile stage keeps per-binary sources in ``compiled/``), then locate the
+   function *definition* (not a call/prototype) and brace-match its body.
+   K&R-style definitions are accepted too (bare-identifier param list guarded
+   against prototypes).
+3. Fall back to the preprocessed ``.i``/``.ii`` next to the binary when no
+   original source carries the definition (nested-tree projects keep only the
+   preprocessed unit in ``compiled/``). That text is macro-expanded, so it is
+   only used when a real source file is absent.
 
 :func:`function_source_ex` returns ``(code, status)`` where an empty ``status``
-means the code came from a ``.c``, ``"preprocessed"`` means it came from a ``.i``,
-and the miss codes (``binary_not_found`` / ``no_source_files`` /
+means the code came from an original source, ``"preprocessed"`` means it came
+from a ``.i``/``.ii``, and the miss codes (``binary_not_found`` / ``no_source_files`` /
 ``func_not_in_sources`` / ``extract_failed``) say why ``code`` is ``None``.
 Returns ``None`` whenever anything is uncertain rather than guessing wrong.
 """
@@ -28,9 +30,16 @@ import os
 import re
 from pathlib import Path
 
+from decbench.utils import binfmt
+from decbench.utils.langs import PREPROC_EXTS, SOURCE_EXTS, strip_source_ext
+
 
 def _dwarf_decl(binary_path: Path) -> dict[str, tuple[str, int]]:
     """Map function name -> (decl_file basename, decl_line) from DWARF.
+
+    Attributes are read through ``DW_AT_specification``/``DW_AT_abstract_origin``
+    so a C++ out-of-line member definition, which carries none of them itself,
+    still resolves to its declaring file and line.
 
     Empty dict when DWARF is missing/unreadable (callers then search all
     sibling sources without a line hint).
@@ -46,31 +55,21 @@ def _dwarf_decl(binary_path: Path) -> dict[str, tuple[str, int]]:
             if not elf.has_dwarf_info():
                 return out
             dw = elf.get_dwarf_info()
+            file_tables: dict[int, list] = {}
             for cu in dw.iter_CUs():
-                lp = dw.line_program_for_CU(cu)
-                # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
-                # makes the index line up either way.
-                version = 4
-                if lp is not None:
-                    version = lp.header.get("version", cu.header.get("version", 4))
-                files: list = [] if version >= 5 else [None]
-                if lp is not None:
-                    for fe in lp["file_entry"]:
-                        nm = fe.name
-                        files.append(nm.decode() if isinstance(nm, bytes) else nm)
                 for die in cu.iter_DIEs():
-                    if die.tag != "DW_TAG_subprogram":
+                    if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
                         continue
-                    attrs = die.attributes
-                    if "DW_AT_name" not in attrs or "DW_AT_low_pc" not in attrs:
+                    name = binfmt.die_str_attr(die, "DW_AT_name")
+                    if name is None:
                         continue
-                    nm = attrs["DW_AT_name"].value
-                    name = nm.decode() if isinstance(nm, bytes) else nm
-                    fi = attrs.get("DW_AT_decl_file")
-                    ln = attrs.get("DW_AT_decl_line")
+                    fi, fi_owner = binfmt.die_attr_owner(die, "DW_AT_decl_file")
+                    ln = binfmt.die_attr(die, "DW_AT_decl_line")
                     fname = None
-                    if fi is not None and 0 <= fi.value < len(files):
-                        fname = files[fi.value]
+                    if fi is not None:
+                        files = binfmt.cu_file_table(dw, fi_owner.cu, file_tables)
+                        if 0 <= fi.value < len(files):
+                            fname = files[fi.value]
                     line = int(ln.value) if ln is not None else 0
                     out[name] = (os.path.basename(fname) if fname else "", line)
     except Exception:  # noqa: BLE001
@@ -229,15 +228,15 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
     """Best-effort source text for ``func_name`` plus a provenance/miss status.
 
     Searches the sources kept next to the binary (the compile stage writes them
-    into ``compiled/``), guided by DWARF when available: ``.c`` first (readable
-    original), then the preprocessed ``.i`` (macro-expanded fallback for nested-
-    tree projects that keep only ``.i``). Within each extension the DWARF-named
-    file is tried first.
+    into ``compiled/``), guided by DWARF when available: the original ``.c``/
+    ``.cc``/``.cpp`` first (readable), then the preprocessed ``.i``/``.ii``
+    (macro-expanded fallback for nested-tree projects that keep only those).
+    Within each extension the DWARF-named file is tried first.
 
     Returns ``(code, status)`` where ``status`` is ``""`` when ``code`` came from
-    a ``.c``, ``"preprocessed"`` when from a ``.i``, and one of
-    ``"binary_not_found"`` / ``"no_source_files"`` / ``"func_not_in_sources"`` /
-    ``"extract_failed"`` when ``code`` is ``None``.
+    an original source, ``"preprocessed"`` when from a preprocessed unit, and one
+    of ``"binary_not_found"`` / ``"no_source_files"`` / ``"func_not_in_sources"``
+    / ``"extract_failed"`` when ``code`` is ``None``.
     """
     if binary_path is None:
         return None, "binary_not_found"
@@ -252,14 +251,15 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
 
     any_sources = False
     found_name = False
-    for ext in (".c", ".i"):
+    for ext in (*SOURCE_EXTS, *PREPROC_EXTS):
         sources = sorted(p for p in search_dir.glob(f"*{ext}") if p.is_file())
         if not sources:
             continue
         any_sources = True
+        original = ext in SOURCE_EXTS
         ordered: list[Path] = []
         if decl_stem:
-            ordered = [p for p in sources if p.stem == decl_stem]
+            ordered = [p for p in sources if strip_source_ext(p.stem) == decl_stem]
         ordered += [p for p in sources if p not in ordered]
 
         for p in ordered:
@@ -270,11 +270,11 @@ def function_source_ex(binary_path: Path | None, func_name: str) -> tuple[str | 
             if func_name not in text:
                 continue
             found_name = True
-            # decl_line indexes the original .c, not the preprocessed .i line numbers.
-            line_hint = decl_line if (ext == ".c" and p.stem == decl_stem) else 0
-            snippet = extract_from_text(text, func_name, line_hint)
+            # decl_line indexes the original source, not the preprocessed line numbers.
+            hit = original and strip_source_ext(p.stem) == decl_stem
+            snippet = extract_from_text(text, func_name, decl_line if hit else 0)
             if snippet:
-                return snippet, ("" if ext == ".c" else "preprocessed")
+                return snippet, ("" if original else "preprocessed")
 
     if not any_sources:
         return None, "no_source_files"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -83,9 +83,10 @@ nothing. Fix: drop the matching Joern **v4.0.150** `joern-cli` into
 
 ## The benchmark corpus
 
-All targets are C project TOMLs under `projects/`; a "full run" spans all of
-`projects/{sailr,cps,malware}/*.toml` (both drivers gather them via
-`gather_tomls()`; `cps/disabled/` excluded).
+Targets are project TOMLs under `projects/`; a "full run" spans all of
+`projects/{sailr,cps,malware,cpp}/*.toml` (both drivers gather them via
+`gather_tomls()`; `cps/disabled/` excluded). Everything except `projects/cpp/`
+is C.
 
 - **sailr** — 26 sailr-eval Debian packages in `projects/sailr/*.toml`, each
   built at O0 / O2 / O2-noinline, labeled by kind + domain. Compiles on the
@@ -100,9 +101,9 @@ All targets are C project TOMLs under `projects/`; a "full run" spans all of
   with `scripts/cps_compile_smoke.py` inside the image. angr/Ghidra decompile
   ARM; byte_match abstains for ARM on hosts without the arm-none-eabi
   toolchain — GED/type_match carry these targets. The two C++ autopilots
-  (ArduPilot, PX4) are DISABLED in `projects/cps/disabled/` (decbench has no
-  C++ support yet — pyjoern/GED is C-only); their recipes are verified-working
-  and re-enable by moving the TOML back up to `projects/cps/`.
+  (ArduPilot, PX4) are still DISABLED in `projects/cps/disabled/`; their
+  recipes are verified-working and re-enable by moving the TOML back up to
+  `projects/cps/`, but neither has been run through the C++ path below.
 - **malware** — REAL MALWARE targets in `projects/malware/*.toml` (C, from
   theZoo): mirai (ELF/gcc), mydoom, x0r-usb, minipig, dexter (PE/MinGW).
   (mirai-win was removed 2026-07-23: theZoo's "Win32.Mirai" is actually
@@ -117,6 +118,35 @@ All targets are C project TOMLs under `projects/`; a "full run" spans all of
   `utils/binfmt.py` (byte_match needs the MinGW toolchain, else it abstains).
   See `projects/malware/README.md` (DO NOT EXECUTE). Binaries never leave
   `results/`.
+- **cpp** — the C++ targets in `projects/cpp/*.toml`: currently **leveldb**
+  (Google's embedded key-value store, CMake, x86 host build). Read
+  [C++ targets](#c-targets) before using their numbers.
+
+### C++ targets
+
+C++ works end-to-end as of `projects/cpp/leveldb.toml`; the mechanics live in
+[metrics.md](metrics.md#preprocessed-iii-files-are-required--source-cfgs-come-exclusively-from-them).
+Three things are worth knowing before reading a C++ number:
+
+- **No demangler is involved anywhere.** DWARF `DW_AT_name` for
+  `leveldb::DBImpl::Get` is `"Get"`, and Joern's C++ frontend keys on the short
+  name too, so both sides of the match already speak unqualified names. Mangled
+  `_ZN...` never appears.
+- **Same-name collisions make a C++ target's absolute GED incomparable to a C
+  project's.** Because matching is by unqualified name, leveldb's 7-8
+  same-named methods per name (`Next`, `Seek`, `SeekToFirst`, `Name` — one per
+  iterator class) all collapse onto whichever body won the per-name reduction.
+  Rank C++ targets against each other; do not read leveldb's GED next to
+  grep's. Qualified-name keying is the fix and is not implemented.
+- **Not publishable to the dataset yet.** The publish/dataset paths still glob
+  only `*.i`, so a C++ project's source CFGs never make it into the exported
+  tree (see metrics.md for the file list).
+
+CMake-based C++ TOMLs have two traps worth copying from leveldb's: leave
+`CMAKE_BUILD_TYPE` **empty** (a named type appends its own `-O` flag AFTER
+`CMAKE_CXX_FLAGS` and silently overrides the level being measured), and set
+`BUILD_SHARED_LIBS=ON` (a static `.a` is not a linked binary, so the collector
+skips it and the library under test never gets decompiled).
 
 ### Optimization levels
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,31 +19,53 @@ lossless — see [dataset-publishing.md](dataset-publishing.md)).
   `DECBENCH_GED_MAX_NODES` nodes (default 60, read in `metrics/ged.py`) — a
   few huge optimized CFGs would otherwise dominate a run.
 
-### Preprocessed `.i` files are REQUIRED — source CFGs come EXCLUSIVELY from them
+### Preprocessed `.i`/`.ii` files are REQUIRED — source CFGs come EXCLUSIVELY from them
 
 `pipeline/evaluate.py` (via `project.preprocessed_sources`),
 `scripts/run_benchmark.py`, and `pipeline/executor.py` (which globs
-`compiled_dir/*.i`) all build the source-side CFGs by feeding `.i` files to
-`utils/cfg.py extract_cfgs_from_source` (system headers stripped, then pyjoern
-`parse_source`). `.i` over `.c` is deliberate: Joern needs macro-expanded,
-ifdef-resolved code to parse completely — raw `.c` with unexpanded includes
-parses incompletely. Without `.i` the pipeline takes the "No preprocessed
-sources" branch and **GED is silently None for every function of the run — no
-error**.
+`compiled_dir/*.i` and `*.ii`) all build the source-side CFGs by feeding the
+preprocessed units to `utils/cfg.py extract_cfgs_from_source` (system headers
+stripped, then pyjoern `parse_source`). Preprocessed over raw source is
+deliberate: Joern needs macro-expanded, ifdef-resolved code to parse
+completely — raw `.c` with unexpanded includes parses incompletely. Without
+them the pipeline takes the "No preprocessed sources" branch and **GED is
+silently None for every function of the run — no error**.
 
-byte_match/type_match don't use `.i` (`requires_source_cfg = False`;
-gcc-recompile and DWARF respectively), and sample source extraction only
-*falls back* to `.i`. So do NOT disable `Project.emit_preprocessed` (default
-True, `models/project.py`) or `-save-temps=obj` in the default `base_flags`
-(`compilers/gcc.py`). The only `.i`-free evaluation path is the
-published-dataset `--source-cfgs` flow (precomputed `source_cfgs/*.json`,
-built FROM `.i` at publish time by `publish/cfg_export.py`) — and that path
-cannot score type_match.
+gcc names the preprocessed output after the LANGUAGE, not the flag: a C unit
+yields `.i` and a C++ unit `.ii`. Joern picks its frontend the same way, and
+its **C frontend returns ZERO functions for C++ input** — so `utils/cfg.py`
+chooses the temp-file suffix from the input (`.ii` -> `.cpp`, `.i` -> `.c`)
+via `temp_parse_suffix`. Handing a `.ii` to Joern as `.c` scores nothing at
+all (measured on a leveldb TU: 0 functions as `.c`, 393 as `.cpp`).
+
+byte_match/type_match don't use the preprocessed units
+(`requires_source_cfg = False`; gcc-recompile and DWARF respectively), and
+sample source extraction only *falls back* to them. So do NOT disable
+`Project.emit_preprocessed` (default True, `models/project.py`) or
+`-save-temps=obj` in the default `base_flags` (`compilers/gcc.py`). The only
+preprocessed-free evaluation path is the published-dataset `--source-cfgs`
+flow (precomputed `source_cfgs/*.json`, built FROM the preprocessed units at
+publish time by `publish/cfg_export.py`) — and that path cannot score
+type_match. The publish/dataset paths still glob only `*.i`
+(`publish/layout.py`, `publish/cfg_export.py`, `dataset.py`,
+`evalkit/ingest.py`, `scripts/reeval_ged.py`,
+`scripts/compute_dataset_info.py`), so a C++ project cannot be published to the
+dataset yet.
 
 Source-side matching is per-TU: `pipeline/evaluate.py` matches a binary's OWN
 translation unit first, cross-TU best-by-name only as fallback (avoids
 same-name collisions across TUs). The old JOERN_FAILURES.md failure analysis
 lives in git history; Joern parse-health stats render on the site's data page.
+
+**C++ name collisions.** Matching is by UNQUALIFIED name on both sides (DWARF
+`DW_AT_name` is `Get`, not `leveldb::DBImpl::Get`, and Joern's C++ frontend
+keys on the short name too — so no demangler is involved anywhere). A C++
+binary therefore collapses every same-named method onto one entry: leveldb has
+7-8 `Next`/`Seek`/`SeekToFirst`/`Name` methods, one per iterator class, and
+they are all scored against whichever body won `best_source_by_name`. A C++
+target's absolute GED is consequently **not comparable to a C project's** —
+compare C++ targets to each other. Qualified-name keying (Joern `fullName` +
+DWARF parent-DIE walking) is the fix and is not implemented.
 
 ## Type Correctness — `metrics/type_match.py`
 
@@ -65,6 +87,30 @@ backends that carry no `VariableInfo`, e.g. LLM agents and external
 submissions: the C signature is parsed into ABI-positioned args + locals). At
 `-O2`, register locals that decompilers fold into expressions count as misses
 for everyone uniformly.
+
+A subprogram's name is read through `binfmt.die_attr` rather than straight off
+the DIE, because gcc keeps a C++ out-of-line member definition's `DW_AT_name`
+on the in-class declaration it references. Without that chase, leveldb's
+ground truth is 97 functions instead of 4,236. See
+[DWARF reference chains](#dwarf-reference-chains-c-vs-c) for why this does not
+change any C value.
+
+### DWARF reference chains (C vs C++)
+
+`utils/binfmt.py` `die_attr` / `die_str_attr` / `die_attr_owner` read a DIE
+attribute through the reference chain gcc uses to split a definition from its
+declaration. The two reference attributes are NOT equivalent:
+
+- **`DW_AT_specification`** is C++-only (out-of-line member definition ->
+  in-class declaration). Following it can never change a C result, so it is
+  always followed.
+- **`DW_AT_abstract_origin`** is used in C too — for the out-of-line copy gcc
+  keeps of a function it also inlined. Following it in C would newly surface
+  ~10-20% more functions in the pinned corpus (measured on grep at O2: 262 ->
+  314 DWARF subprograms). It is therefore followed **only in a C++
+  compilation unit** (`binfmt.cu_is_cxx`, on `DW_AT_language`), which keeps
+  every existing C binary bit-identical. Enabling it for C is a deliberate,
+  corpus-invalidating change that has not been made.
 
 ## Recompilation Bytematch — `metrics/byte_match.py`
 
@@ -127,6 +173,11 @@ over seen (decompiled, source) pairs skip recomputation.
 - **Caching is deterministic by content: if you change a metric's algorithm,
   bump its `cache_version` class attr** — else stale values are served — or
   run with `DECBENCH_NO_CACHE=1`.
+- The converse also matters: a change that is **provably a no-op for existing
+  input** must NOT bump `cache_version`, because the frozen rival checkpoints
+  are pinned and a needless bump forces a corpus-wide recompute. The C++
+  `DW_AT_specification` chase is the worked example — see
+  [DWARF reference chains](#dwarf-reference-chains-c-vs-c).
 - Cache root: `DECBENCH_CACHE_DIR`; disable entirely with
   `DECBENCH_NO_CACHE=1`.
 

--- a/projects/cpp/leveldb.toml
+++ b/projects/cpp/leveldb.toml
@@ -1,0 +1,66 @@
+# DecBench Project Configuration: leveldb
+# Google's LevelDB — an embedded ordered key-value store, and DecBench's first
+# C++ target. It is a good C++ probe: heavy on classes, virtual dispatch, STL
+# containers and templates, but with no external dependencies beyond a C++11
+# compiler, so a build is reproducible anywhere gcc is.
+#
+# CAVEAT — leveldb's absolute GED is NOT comparable to a C project's. DecBench
+# matches source functions to decompiled ones by UNQUALIFIED name (both DWARF
+# DW_AT_name and Joern's C++ frontend key on the short name), so the 7-8
+# same-named methods a C++ binary carries per name (`Next`, `Seek`, `Name`,
+# `SeekToFirst`, ... one per iterator class) all collapse onto whichever body
+# won the per-name reduction — usually the largest. Rank C++ targets against
+# each other, not against the C corpus. Qualified-name keying is tracked as
+# follow-up work.
+
+name = "leveldb"
+version = "1.23"
+
+source_remote = "https://github.com/google/leveldb"
+remote_type = "git"
+
+# leveldb builds out-of-tree into `build/`, but source_dir stays "." (the clone
+# root) so the collector's rglob sees BOTH the build outputs (binaries, objects,
+# and the .ii preprocessed units that -save-temps=obj drops next to them) and the
+# .cc sources under db/ table/ util/, which pipeline/compile.py copies into
+# compiled/ for the report's source pane. Pointing it at "build" loses the .cc.
+package_dir = "leveldb"
+source_dir = "."
+
+post_download_cmds = []
+
+# CMAKE_BUILD_TYPE is deliberately EMPTY: a named build type appends its own
+# CMAKE_CXX_FLAGS_<TYPE> (e.g. `-O3 -DNDEBUG` for Release) AFTER CMAKE_CXX_FLAGS,
+# which would silently override the optimization level DecBench is measuring.
+# CMAKE_CXX_FLAGS carries $CFLAGS, which the pipeline sets to the base flags plus
+# the level's -O flag.
+#
+# BUILD_SHARED_LIBS=ON because the collector only takes LINKED binaries: a static
+# libleveldb.a is skipped, which would leave only the 90 KB `leveldbutil` and
+# throw away the library that is the actual benchmark target.
+#
+# Tests and benchmarks are OFF because they vendor googletest/benchmark, whose
+# thousands of template instantiations would dominate every metric's denominator
+# and measure GoogleTest instead of leveldb.
+pre_make_cmds = [
+  'cmake -S . -B build -DCMAKE_BUILD_TYPE= -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS="$CFLAGS" -DLEVELDB_BUILD_TESTS=OFF -DLEVELDB_BUILD_BENCHMARKS=OFF -DBUILD_SHARED_LIBS=ON',
+]
+
+# The `rm` drops CMake's compiler-probe binaries (a.out,
+# CMakeDetermineCompilerABI_*.bin), which are real ELF executables under
+# build/CMakeFiles/<cmake-version>/ and would otherwise be collected as targets.
+# It lives in make_cmd because ProjectConfig.post_make_cmds is declared but never
+# executed by pipeline/compile.py.
+make_cmd = 'cmake --build build -j && rm -rf build/CMakeFiles/3.*'
+
+labels = ["cpp", "library", "database", "key-value-store"]
+
+[compilation]
+optimization_levels = ["O0", "O2", "O2-noinline"]
+base_flags = ["-g", "-fno-builtin", "-save-temps=obj"]
+c_compiler = "gcc"
+# cpp_compiler is recorded for documentation only — pipeline/compile.py builds a
+# GCCCompiler from c_compiler and never reads it, and wiring it into the build
+# env would newly define $CXX for all 40 existing C projects. The build picks its
+# C++ compiler explicitly via -DCMAKE_CXX_COMPILER above.
+cpp_compiler = "g++"

--- a/projects/cps/disabled/README.md
+++ b/projects/cps/disabled/README.md
@@ -6,11 +6,19 @@ drivers and `decbench run projects/cps/*.toml` will not pick them up).
 
 ## Why
 
-decbench does not support **C++** yet. The GED metric extracts source control-
-flow graphs with pyjoern, which is C-oriented, so C++ projects produce no `.i`
-preprocessed sources and cannot be scored on GED. (They also exhibit the usual
-C++-from-binary friction — name mangling, `this` pointers, vtables — which makes
-type recovery harder.)
+These were disabled when decbench had no **C++** support. That reason is now
+out of date: C++ works end-to-end (see `projects/cpp/leveldb.toml` and
+[docs/benchmarking.md](../../../docs/benchmarking.md#c-targets)). The original
+rationale — "pyjoern is C-oriented, so C++ projects produce no `.i` and cannot
+be scored" — was wrong on both halves: a C++ translation unit does get
+preprocessed, just to `.ii` rather than `.i`, and Joern parses it fine once the
+file is handed to its C++ frontend by extension.
+
+What still holds is that neither autopilot has ever been *run* through that
+path. They are large cross-compiled Cortex-M/-A firmware, so re-enabling one is
+a measurement exercise (build time, Joern parse health on hundreds of C++ TUs,
+and the same-name collision caveat that applies to every C++ target), not a
+flip of a switch. They stay here until someone does that work.
 
 | target | dominant language |
 | --- | --- |

--- a/scripts/compile_all.py
+++ b/scripts/compile_all.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-"""Compile every sailr project at every opt level into a persistent dir.
+"""Compile every corpus project at every opt level into a persistent dir.
 
 Build-verification driver: runs the real ``compile_project`` code path for
 each (project, opt) pair in parallel, persisting binaries under
 ``<out>/<opt>/<project>/compiled/`` so a later ``--skip-compile`` decompile
-+ evaluate run can reuse them. Prints a per-target binary/.i count table and
-writes ``compile_report.json`` for the orchestrator.
++ evaluate run can reuse them. Prints a per-target binary/preprocessed count
+table and writes ``compile_report.json`` for the orchestrator.
 """
 
 from __future__ import annotations
@@ -20,12 +20,18 @@ from pathlib import Path
 
 from decbench.models.project import OptimizationLevel, Project
 from decbench.pipeline.compile import compile_project
+from decbench.utils.langs import PREPROC_EXTS, SOURCE_EXTS
 
 # 'fork' deadlocks when a worker is forked while the parent's pool-management
 # thread holds an internal mutex.
 _MP = multiprocessing.get_context("spawn")
 
-PROJECT_DIRS = [Path("projects/sailr"), Path("projects/cps"), Path("projects/malware")]
+PROJECT_DIRS = [
+    Path("projects/sailr"),
+    Path("projects/cps"),
+    Path("projects/malware"),
+    Path("projects/cpp"),
+]
 
 
 def gather_tomls() -> list[Path]:
@@ -43,17 +49,18 @@ OPT_LEVELS = [
 
 
 def _count_outputs(out_dir: Path, opt: str, name: str) -> tuple[int, int]:
-    """Return (elf_binary_count, i_file_count) in the compiled dir."""
+    """Return (elf_binary_count, preprocessed_file_count) in the compiled dir."""
     import struct
 
     compiled = out_dir / opt / name / "compiled"
     if not compiled.is_dir():
         return (0, 0)
+    skip = (".o", ".a", ".s", ".h", *PREPROC_EXTS, *SOURCE_EXTS)
     elfs = 0
     for entry in compiled.iterdir():
         if not entry.is_file() or entry.is_symlink():
             continue
-        if entry.suffix in (".i", ".o", ".a", ".s", ".c", ".h"):
+        if entry.suffix in skip:
             continue
         try:
             with open(entry, "rb") as f:
@@ -64,7 +71,7 @@ def _count_outputs(out_dir: Path, opt: str, name: str) -> tuple[int, int]:
                     elfs += 1
         except (OSError, struct.error):
             continue
-    i_files = len(list(compiled.glob("*.i")))
+    i_files = sum(len(list(compiled.glob(f"*{ext}"))) for ext in PREPROC_EXTS)
     return (elfs, i_files)
 
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -43,7 +43,9 @@ from decbench.pipeline.evaluate import evaluate_project  # noqa: E402
 from decbench.pipeline.executor import PipelineConfig, PipelineExecutor  # noqa: E402
 from decbench.results_store import PROJECT_DIRS  # noqa: F401,E402
 from decbench.results_store import gather_project_tomls as gather_tomls
+from decbench.utils import binfmt  # noqa: E402
 from decbench.utils.cfg import extract_cfgs_from_source
+from decbench.utils.langs import strip_source_ext  # noqa: E402
 
 OPT_LEVELS = [
     OptimizationLevel.O0,
@@ -151,7 +153,12 @@ def project_source_functions(
     Reads the binary's DWARF and keeps DW_TAG_subprogram entries that have a
     low_pc (i.e. are defined in this binary) AND whose decl_file basename stem
     is one of ``source_stems`` (the project's compiled translation units, e.g.
-    grep's ``src/*.c``). This excludes bundled gnulib/system-header functions —
+    grep's ``src/*.c``). Name and decl_file are read through
+    ``DW_AT_specification``/``DW_AT_abstract_origin`` so C++ out-of-line member
+    definitions — which carry neither on the defining DIE — are found; stems are
+    compared with the source extension stripped from both sides, because a C
+    unit's preprocessed stem is ``foo`` (``foo.i``) while a C++ one is ``foo.cc``
+    (``foo.cc.ii``). This excludes bundled gnulib/system-header functions —
     matching SAILR's "evaluate the project's own code" intent — and shrinks the
     decompile/evaluate workload by ~1-2 orders of magnitude on gnulib-heavy
     binaries. The address (DWARF low_pc, in ELF-file space) is the key so the
@@ -162,50 +169,38 @@ def project_source_functions(
     if not source_stems:
         return {}
     try:
-        from decbench.utils import binfmt
-
         dw = binfmt.dwarf_info(binary_path)
     except Exception:  # noqa: BLE001
         return {}
     if dw is None:
         return {}
     addr2name: dict[int, str] = {}
+    file_tables: dict[int, list] = {}
+    stem_index = {strip_source_ext(s): s for s in source_stems}
     try:
         for cu in dw.iter_CUs():
-            lp = dw.line_program_for_CU(cu)
-            # DW_AT_decl_file is 1-based pre-DWARF5 and 0-based in DWARF5; the placeholder
-            # makes the index line up either way.
-            version = 4
-            if lp is not None:
-                version = lp.header.get("version", cu.header.get("version", 4))
-            files: list = [] if version >= 5 else [None]
-            if lp is not None:
-                for fe in lp["file_entry"]:
-                    nm = fe.name
-                    files.append(nm.decode() if isinstance(nm, bytes) else nm)
             for die in cu.iter_DIEs():
-                if die.tag != "DW_TAG_subprogram":
+                if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
                     continue
-                attrs = die.attributes
-                if "DW_AT_low_pc" not in attrs or "DW_AT_name" not in attrs:
+                name = binfmt.die_str_attr(die, "DW_AT_name")
+                if name is None:
                     continue
-                fi = attrs.get("DW_AT_decl_file")
-                if fi is None or not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                fi, owner = binfmt.die_attr_owner(die, "DW_AT_decl_file")
+                if fi is None:
                     continue
-                base = os.path.basename(files[fi.value])
-                stem = base[:-2] if base.endswith(".c") else base
-                matched: str | None = None
-                if stem in source_stems:
-                    matched = stem
-                else:
-                    for s in source_stems:
-                        if s.endswith("-" + stem) or s.endswith("_" + stem):
-                            matched = s
+                files = binfmt.cu_file_table(dw, owner.cu, file_tables)
+                if not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                    continue
+                stem = strip_source_ext(os.path.basename(files[fi.value]))
+                matched = stem_index.get(stem)
+                if matched is None:
+                    for norm, original in stem_index.items():
+                        if norm.endswith("-" + stem) or norm.endswith("_" + stem):
+                            matched = original
                             break
                 if matched is not None:
-                    nm = attrs["DW_AT_name"].value
-                    lp_addr = int(attrs["DW_AT_low_pc"].value)
-                    addr2name[lp_addr] = nm.decode() if isinstance(nm, bytes) else nm
+                    lp_addr = int(die.attributes["DW_AT_low_pc"].value)
+                    addr2name[lp_addr] = name
                     if stem_out is not None:
                         stem_out[lp_addr] = matched
     except Exception:  # noqa: BLE001

--- a/tests/test_cpp_support.py
+++ b/tests/test_cpp_support.py
@@ -1,0 +1,140 @@
+"""C++ project support: preprocessed-unit naming, Joern frontend selection, DWARF chases.
+
+The DWARF tests compile a tiny C and C++ pair so the C-vs-C++ asymmetry in
+``binfmt.die_attr`` (``DW_AT_specification`` always followed,
+``DW_AT_abstract_origin`` only in a C++ unit) is checked against real gcc
+output rather than a hand-built fixture.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from decbench.compilers.gcc import find_preprocessed
+from decbench.utils import binfmt
+from decbench.utils.cfg import temp_parse_suffix
+from decbench.utils.langs import preprocessed_ext, strip_source_ext
+from decbench.utils.source_extract import _dwarf_decl
+
+CXX_SRC = """
+namespace demo {
+class Widget {
+ public:
+  int Get(int x);
+  inline int Inlined(int x) { return x + 1; }
+};
+int Widget::Get(int x) { return Inlined(x) * 2; }
+}  // namespace demo
+
+int main() {
+  demo::Widget w;
+  return w.Get(1);
+}
+"""
+
+C_SRC = """
+static int helper(int x) { return x + 1; }
+int main(void) { return helper(1) + helper(2); }
+"""
+
+
+def test_preprocessed_ext_follows_the_language() -> None:
+    assert preprocessed_ext(Path("db_impl.cc")) == ".ii"
+    assert preprocessed_ext(Path("db_impl.cpp")) == ".ii"
+    assert preprocessed_ext(Path("grep.c")) == ".i"
+
+
+def test_temp_parse_suffix_picks_joerns_frontend() -> None:
+    # Joern's C frontend returns zero functions for C++, so a .ii must be
+    # handed over as .cpp.
+    assert temp_parse_suffix(Path("db_impl.cc.ii")) == ".cpp"
+    assert temp_parse_suffix(Path("grep.i")) == ".c"
+    assert temp_parse_suffix(Path("decompiled.c")) == ".c"
+
+
+def test_strip_source_ext_only_strips_source_extensions() -> None:
+    # A C unit's preprocessed stem is "grep" but a C++ one is "db_impl.cc";
+    # both sides of the DWARF decl-file match are normalized through this.
+    assert strip_source_ext("db_impl.cc") == "db_impl"
+    assert strip_source_ext("grep") == "grep"
+    assert strip_source_ext("main.c") == "main"
+    # Headers stay unstripped so header-defined functions remain outside the
+    # "project's own translation units" filter.
+    assert strip_source_ext("stl_vector.h") == "stl_vector.h"
+
+
+def test_find_preprocessed_tries_both_extensions(tmp_path: Path) -> None:
+    assert find_preprocessed(tmp_path / "grep.o") is None
+    (tmp_path / "grep.i").write_text("")
+    assert find_preprocessed(tmp_path / "grep.o") == tmp_path / "grep.i"
+    (tmp_path / "db_impl.cc.ii").write_text("")
+    assert find_preprocessed(tmp_path / "db_impl.cc.o") == tmp_path / "db_impl.cc.ii"
+
+
+needs_gcc = pytest.mark.skipif(
+    shutil.which("gcc") is None or shutil.which("g++") is None,
+    reason="needs gcc and g++",
+)
+
+
+def _build(tmp_path: Path, name: str, src: str, compiler: str, opt: str) -> Path:
+    source = tmp_path / name
+    source.write_text(src)
+    binary = tmp_path / (source.stem + ".bin")
+    subprocess.run(
+        [compiler, "-g", opt, str(source), "-o", str(binary)],
+        check=True,
+        capture_output=True,
+    )
+    return binary
+
+
+def _subprograms(binary: Path):
+    dw = binfmt.dwarf_info(binary)
+    assert dw is not None
+    for cu in dw.iter_CUs():
+        for die in cu.iter_DIEs():
+            if die.tag == "DW_TAG_subprogram" and "DW_AT_low_pc" in die.attributes:
+                yield die
+
+
+@needs_gcc
+def test_cxx_out_of_line_definition_resolves_its_name(tmp_path: Path) -> None:
+    binary = _build(tmp_path, "w.cc", CXX_SRC, "g++", "-O0")
+    named = [d for d in _subprograms(binary) if "DW_AT_name" in d.attributes]
+    resolved = [d for d in _subprograms(binary) if binfmt.die_str_attr(d, "DW_AT_name")]
+    # Get() is defined out of line, so its defining DIE has no DW_AT_name.
+    assert len(resolved) > len(named)
+    assert "Get" in {binfmt.die_str_attr(d, "DW_AT_name") for d in resolved}
+    assert "Get" not in {
+        d.attributes["DW_AT_name"].value.decode() for d in named  # type: ignore[union-attr]
+    }
+    assert "Get" in _dwarf_decl(binary)
+
+
+@needs_gcc
+def test_abstract_origin_is_not_followed_in_a_c_unit(tmp_path: Path) -> None:
+    """The C corpus must stay bit-identical: no C DIE may gain a name.
+
+    gcc at -O2 keeps an out-of-line copy of a function it also inlined; that DIE
+    carries DW_AT_abstract_origin and no DW_AT_name. Following it would enlarge
+    the pinned C corpus, so the hop is gated on the CU being C++.
+    """
+    binary = _build(tmp_path, "h.c", C_SRC, "gcc", "-O2")
+    for die in _subprograms(binary):
+        assert not binfmt.cu_is_cxx(die.cu)
+        direct = die.attributes.get("DW_AT_name")
+        chased = binfmt.die_str_attr(die, "DW_AT_name")
+        assert chased == (direct.value.decode() if direct is not None else None)
+
+
+@needs_gcc
+def test_cu_is_cxx_distinguishes_the_languages(tmp_path: Path) -> None:
+    cxx = _build(tmp_path, "w.cc", CXX_SRC, "g++", "-O0")
+    c = _build(tmp_path, "h.c", C_SRC, "gcc", "-O0")
+    assert all(binfmt.cu_is_cxx(d.cu) for d in _subprograms(cxx))
+    assert not any(binfmt.cu_is_cxx(d.cu) for d in _subprograms(c))


### PR DESCRIPTION
DecBench scored **exactly zero** on a C++ project — and did so silently, with no
error anywhere. This adds end-to-end C++ support and `projects/cpp/leveldb.toml`
as the first target.

## What was broken

Five independent `.i`-only assumptions, each of which alone reduces a C++ run to
nothing:

| # | Site | Bug |
|---|---|---|
| 1 | `compilers/gcc.py` | gcc names `-save-temps` output after the **language**, so a C++ TU emits `<name>.ii`. Both collection sites and the `.o` sweep used `with_suffix(".i")`, and `.cc`/`.cpp`/`.ii` were not in the skip-suffix tuple. |
| 2 | `pipeline/executor.py` | `compiled_dir.glob("*.i")` does not match `*.ii` → `preprocessed_sources` empty → the run driver's DWARF filter gets an empty stem set → **`SKIP: no binary has a usable DWARF source filter`**. |
| 3 | `utils/cfg.py` | The stripped preprocessed text was written to a `.c` temp file. Joern picks its frontend by extension and its **C frontend returns zero functions for C++**. |
| 4 | `scripts/run_benchmark.py` + `evalkit/resolve.py` | gcc keeps an out-of-line C++ member definition's `DW_AT_name`/`DW_AT_decl_file` on the in-class declaration it points at (`DW_AT_specification`), so the naive walk missed 90% of them. The stem match also hard-coded a `.c` strip, which cannot match the `.cc.ii` stem shape. |
| 5 | `results_store.py`, `scripts/compile_all.py` | `projects/cpp` in neither `PROJECT_DIRS` (missing either makes the project invisible to one driver; `finalize_tree` hard-fails on an empty gather). |

Plus, for the report to be readable at all: `pipeline/compile.py` copied only
`*.c` into `compiled/`, and `utils/source_extract.py` searched only `(".c", ".i")`
and required `DW_AT_name` on the defining DIE.

## Measured before → after

Everything below is on `projects/cpp/leveldb.toml` at O0, built by the real
`scripts/compile_all.py`, decompiled by the real `scripts/run_benchmark.py`.

| Quantity | before | after |
|---|---:|---:|
| preprocessed units collected into `compiled/` | **0** | **39** |
| original sources collected (`*.cc`) | 0 | 75 |
| DWARF source-function filter, `libleveldb.so.1.23.0` | 81 | **746** |
| DWARF source-function filter, `leveldbutil` | 2 | 9 |
| DWARF filter, whole project (driver's own number) | — | **755** |
| Joern functions, `db_impl.cc.ii` (`.c` vs `.cpp` temp suffix) | **0** | **393** |
| type_match DWARF ground truth, `libleveldb.so` | 67 | **1480** |
| `function_source_ex` on 10 leveldb methods | 0/10 | **10/10** |
| **whole-pipeline result** | `SKIP … 0 funcs decompiled`, 0 scores | **537 function rows scored** |

The "before" row for the whole pipeline is not inferred — origin/main was run on
the identical compiled tree and printed:

```
[leveldb/O0] SKIP: no binary has a usable DWARF source filter (2 binaries skipped) in 0s
[done] leveldb: 0 funcs decompiled in 0s (checkpointed)
```

### leveldb @ O0, kuna — the campaign's baseline number

```
2 binaries, 39 .ii, DWARF filter 755 funcs
decompiled in 26s (ok=2 partial=0 timeout=0 error=0), evaluated in 111s
total_functions = 537    Union perfect = 185 (34.45%)
  ged         n=410  perfect=179 (43.66%)  mean 7.22   median 4.5
  type_match  n=525  perfect=7   ( 1.33%)  mean 0.118  median 0.0
  byte_match  n=537  perfect=24  ( 4.47%)  mean 0.301  median 0.282
```

**Type recovery is where C++ falls off a cliff: 7 perfect of 525 (1.33%).**
Like-for-like against kuna on the existing C corpus **at the same opt level**
(computed from `results/full_run/function_results.json`, O0 slice only — the
all-opts figure would flatter leveldb, since O0 is the easiest level for type
recovery):

| kuna, perfect % | C corpus @ O0 | leveldb @ O0 | |
|---|---:|---:|---|
| `type_match` | **7.50%** (2336/31148) | **1.33%** (7/525) | **5.6× worse** |
| `ged` | 45.40% (14682/32339) | 43.66% (179/410) | ~on par |
| `byte_match` | 3.19% (1046/32758) | 4.47% (24/537) | slightly better |
| Union | 37.91% (all opts) | 34.45% | |

Type recovery is the real C++ gap and it is the only metric that moves sharply.
Read the GED row with the same-name-collision caveat below in mind — "on par" is
partly an artifact of collapsed methods, not evidence that structure recovery is
healthy. For reference, kuna's `type_match` over the whole C corpus (all three
opt levels) is 5.17% (4485/86671); the field ranges from angr at 7.29% down to
r2dec at 1.49%.

GED distribution on `libleveldb.so` (n=403): 177 at 0, 1 at 2, 24 at 3, 23 at 5,
22 at 6, 23 at 8, … 101 above 10, max 95.

### Joern robustness — all 39 TUs, measured not assumed

`utils/cfg.py` swallows a parse failure as a logger warning, so every TU was run
through `extract_cfgs_from_source` explicitly:

```
TUs=39   zero-function TUs=0   total funcs=5348
min/median/max funcs per TU: 5 / 118 / 393
```

Header stripping works unchanged on `.ii` (`db_impl.cc.ii`: 1.43 MB → 110 KB).

## No-regression evidence for C

This is the load-bearing check, because the DWARF changes touch code that every
existing C project's numbers flow through. A digest of **five** DWARF-facing
helpers was computed on the pristine `origin/main` tree and on this branch, over
**127 already-compiled binaries** from `results/full_run`:

* projects: grep (O0/O2/O2-noinline), zlib (O0/O2), coreutils (O0), mydoom (O2,
  PE/MinGW), betaflight (O0, ARM Cortex-M)
* helpers: `project_source_functions` (+ its `stem_out`),
  `evalkit.resolve._dwarf_addr_to_name`, `type_match.extract_ground_truth_types`,
  `source_extract._dwarf_decl`, and `source_extract.function_source_ex`
  (25 functions per binary)

Result: **byte-identical on all 127 binaries.** (`type_match` builds its type
lists from `set`s, so the digest sorts every list — otherwise `PYTHONHASHSEED`
alone shows as a difference.)

Getting there required one design decision. A naive
`DW_AT_specification` + `DW_AT_abstract_origin` chase is **not** a no-op for C:
gcc uses `DW_AT_abstract_origin` for the out-of-line copy it keeps of a function
it also inlined, and following it took grep at O2 from 262 to 314 subprograms
and zlib/example from 119 to 134. So:

* `DW_AT_specification` (a C++-only construct) is **always** followed;
* `DW_AT_abstract_origin` is followed **only in a C++ compilation unit**, gated
  on `DW_AT_language` via the new `binfmt.cu_is_cxx`.

Cost of the gate on leveldb: 563 filtered functions instead of 746, so it is not
free — but enlarging the pinned C corpus is a separate, deliberate change and
does not belong in this PR. Both halves are covered by tests that compile a real
C and C++ pair with gcc/g++.

## `cache_version` decision: **NOT bumped** — and that is deliberate

`metrics/type_match.py` stays at `cache_version = "4"`.

The only change to type_match is that `_parse_function_die` reads the name via
`binfmt.die_str_attr` instead of `die.attributes["DW_AT_name"]`. For a C
compilation unit that helper returns the identical value or `None` in the
identical cases: `DW_AT_specification` never appears in C, and the
`DW_AT_abstract_origin` hop is language-gated off. This is not an argument from
first principles — `extract_ground_truth_types` was diffed on all 127 C binaries
above and is byte-identical, so no cached value can be stale. Bumping would have
forced a corpus-wide recompute against the frozen rival checkpoints for zero
change in output.

## Documented caveats

* **Same-name collisions.** Matching is by *unqualified* name on both sides —
  DWARF `DW_AT_name` for `leveldb::DBImpl::Get` is `"Get"`, and Joern's C++
  frontend keys on the short name too, so **no demangler is involved anywhere**
  and mangled `_ZN...` never appears. The cost is that leveldb's 7-8 same-named
  methods per name (`Next`, `Seek`, `SeekToFirst`, `Name` — one per iterator
  class; 746 filtered functions collapse to 529 distinct names) are all scored
  against whichever body won the per-name reduction. **leveldb's absolute GED is
  therefore not comparable to a C project's** — rank C++ targets against each
  other. Called out in the TOML header, `docs/metrics.md`, and
  `docs/benchmarking.md`. Qualified-name keying (Joern `fullName` + DWARF
  parent-DIE walking) is the fix and is explicitly out of scope here.
* **Not publishable to the dataset yet.** These paths still glob `*.i` only and
  were left alone: `publish/layout.py:285`, `publish/cfg_export.py:170`,
  `dataset.py:187`, `evalkit/ingest.py:617`, `scripts/reeval_ged.py:74`,
  `scripts/compute_dataset_info.py:62`, `scripts/run_small.py:70`,
  `scripts/cps_compile_smoke.py:59`. Follow-up.
* **`cpp_compiler` is still read by nothing.** `pipeline/compile.py` builds a
  `GCCCompiler` from `c_compiler` and ignores it. Wiring it would newly define
  `$CXX` in the build env for all 40 existing C projects (it defaults to `g++`),
  which is a behaviour change to the C corpus for no benefit here — leveldb picks
  its compiler explicitly with `-DCMAKE_CXX_COMPILER`. Left unwired, with the
  reason recorded in the TOML.
* **`post_make_cmds` is declared in `ProjectConfig` but never executed** by
  `pipeline/compile.py`; that is why leveldb's CMake-probe-binary cleanup lives
  inside `make_cmd`. Not fixed here.
* The two C++ autopilots in `projects/cps/disabled/` are **still disabled**. Their
  README's stated reason ("pyjoern is C-oriented, so C++ projects produce no `.i`
  and cannot be scored") is now measurably wrong and has been corrected, but
  neither has been *run* through this path, so re-enabling them stays a separate
  measurement exercise.

## CodeQL

CodeQL raised one new high-severity alert, `py/insecure-temporary-file` at
`utils/cfg.py` — `tempfile.mktemp` (deprecated, TOCTOU-race-prone). The pattern
predates this PR, but the language-selection change rewrote that exact line, so
it is attributed here and is fixed rather than dismissed (52ea7a5).

`NamedTemporaryFile(mode="w", delete=False, suffix=...)` — the construct
`extract_cfgs_from_decompilation` already uses a few lines below — replaces it.
The unique basename is load-bearing (Joern names its workspace after the input
file, so concurrent parses of the same filename collide) and is preserved, as is
the language-driven suffix.

Re-measured, not assumed, because a temp-file change that broke Joern's input
would be invisible to lint but fatal to GED:

* `db_impl.cc.ii` still yields **393** functions / 1042 nodes; `version_set.cc.ii`
  still 355 / 954.
* all 39 TUs re-swept: **39/39 parsed, 0 zero-function, 5348 functions**,
  min/median/max 5/118/393 — per-TU counts byte-identical to the pre-fix sweep,
  so the 4-way concurrent parse still does not collide.
* C side still identical to `origin/main` on `grep.i` (252 funcs), zlib
  `deflate.i` (109) and coreutils `tr.i` (192), compared on per-function CFG
  node/edge shape digests rather than counts alone.

No `tempfile.mktemp` remains anywhere in `decbench/` or `scripts/`.

## Verification

* `ruff check` on every touched file: 10 findings, **all pre-existing** — the
  identical set (same lines, same rules) on `origin/main`.
* `black --check`: clean on everything except `compilers/gcc.py` and
  `pipeline/compile.py`, which already fail on `origin/main`; the set of changed
  lines black wants is byte-identical before and after, so no new violation.
* `mypy`: **26 errors before, 26 after** (`--python-version 3.14
  --follow-imports=silent`; a bare `mypy decbench` aborts on angr's own
  site-packages syntax, unrelated to this change).
* `pytest`: **442 passed, 7 skipped, 5 failed** — the 5 are `tests/test_content.py`
  goal-card failures that reproduce identically on a pristine `origin/main`
  checkout. 435 passed before; the 7 new ones are `tests/test_cpp_support.py`.

## Suggested CHANGELOG entry (not applied — maintainer-owned)

> **Added** — C++ project support (`.ii` preprocessed units, Joern C++ frontend
> selection, `DW_AT_specification` DWARF chase) and `projects/cpp/leveldb.toml`.
> C results are unchanged; no metric `cache_version` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McQC7imaNfzj5k5AVumSYN
