### PR TITLE
[AUTOMATED] fix(metrics): C++ type_match scoring artifacts

### DIFF
--- a/decbench/decompilers/raw/ida_raw.py
+++ b/decbench/decompilers/raw/ida_raw.py
@@ -8,7 +8,8 @@ decompiler API directly:
 * decompile each with ``ida_hexrays.decompile(ea)`` -> ``cfunc``
 * C text from ``str(cfunc)``
 * variables from ``cfunc.lvars`` (args carry ``is_arg_var``; stack lvars carry
-  a frame location)
+  a frame location), with argument POSITIONS taken from ``cfunc.argidx`` —
+  ``get_lvars()`` enumerates in allocation order, not declared order
 
 IDA is **not functional on this machine** (only an unusable IDA 8.0 exists and
 ``idapro`` imports but cannot open a database here), so this backend is written
@@ -287,13 +288,33 @@ class RawIDADecompiler(Decompiler):
         return code
 
     @staticmethod
+    def _arg_positions(cfunc: Any, lvars: Any) -> dict[int, int]:
+        """``lvar index -> ABI argument position`` from ``cfunc.argidx``.
+
+        ``get_lvars()`` enumerates in Hex-Rays' internal allocation order, which
+        is NOT the declared argument order — on leveldb 53.8% of IDA's multi-arg
+        functions came out permuted (``ClipToRange`` yields ``a3, a1, a2``).
+        Since type_match matches arguments by ABI position, that silently
+        mis-scored IDA. ``cfunc_t::argidx`` is the canonical argument order; we
+        fall back to the enumeration order only if it is unavailable.
+        """
+        try:
+            order = [int(i) for i in cfunc.argidx]
+        except Exception:  # noqa: BLE001
+            order = []
+        if not order:
+            order = [i for i, lv in enumerate(lvars) if bool(getattr(lv, "is_arg_var", False))]
+        return {lvar_index: pos for pos, lvar_index in enumerate(order)}
+
+    @staticmethod
     def _extract_variables(cfunc: Any) -> list[VariableInfo]:
         """Pull arguments (ABI order) and stack locals from ``cfunc.lvars``.
 
         Hex-Rays ``lvar_t`` objects expose ``is_arg_var``, ``name``, ``width``
         (size in bytes), ``type()`` (a ``tinfo_t`` whose ``_print()``/``dstr()``
         gives a C type), and ``location`` for stack vars (``is_stk_off()`` /
-        ``stkoff()``).
+        ``stkoff()``). Argument POSITIONS come from ``cfunc.argidx``, not from
+        the enumeration order (see :meth:`_arg_positions`).
         """
         variables: list[VariableInfo] = []
         try:
@@ -301,8 +322,9 @@ class RawIDADecompiler(Decompiler):
         except Exception:  # noqa: BLE001
             return variables
 
-        arg_position = 0
-        for lvar in lvars:
+        arg_positions = RawIDADecompiler._arg_positions(cfunc, lvars)
+        fallback_position = len(arg_positions)
+        for lvar_index, lvar in enumerate(lvars):
             try:
                 name = str(getattr(lvar, "name", "") or "")
                 tinfo = lvar.type() if hasattr(lvar, "type") else None
@@ -321,6 +343,10 @@ class RawIDADecompiler(Decompiler):
                 continue
 
             if is_arg:
+                position = arg_positions.get(lvar_index)
+                if position is None:
+                    position = fallback_position
+                    fallback_position += 1
                 variables.append(
                     VariableInfo(
                         name=name,
@@ -328,10 +354,9 @@ class RawIDADecompiler(Decompiler):
                         stack_offset=None,
                         size=size,
                         kind="arg",
-                        arg_index=arg_position,
+                        arg_index=position,
                     )
                 )
-                arg_position += 1
             else:
                 stack_offset = None
                 try:

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -72,6 +72,38 @@ TYPE_MAP: dict[str, str] = {
 
 QUALIFIERS = ["unsigned", "signed", "const", "volatile", "register", "static", "extern"]
 
+# A trailing run of ``*``s, so TYPE_MAP can be applied to the POINTEE.
+_PTR_SUFFIX = re.compile(r"^(.*?)((?:\s*\*)+)$")
+
+# One C++ namespace/class qualifier, e.g. the ``leveldb::`` of
+# ``leveldb::TableBuilder *``. Digits cannot start a token, so a Ghidra symbol
+# version prefix like ``GLIBC_2.2.5::`` is left alone.
+_NAMESPACE_QUALIFIER = re.compile(r"\b[A-Za-z_]\w*\s*::\s*")
+
+
+def _map_pointee(form: str) -> str:
+    """``TYPE_MAP`` applied through a pointer spelling: ``int4 *`` -> ``int*``.
+
+    The scalar rows already normalize ``int4``, but a pointer spelling never
+    reached them, so a decompiler writing ``int4 *`` could not match DWARF's
+    ``int*`` while one writing ``int *`` could.
+    """
+    m = _PTR_SUFFIX.match(form)
+    if m is None:
+        return form
+    mapped = TYPE_MAP.get(m.group(1).strip())
+    return form if mapped is None else mapped + m.group(2)
+
+
+def _strip_namespaces(form: str) -> str:
+    """``leveldb::TableBuilder*`` -> ``TableBuilder*``.
+
+    DWARF records a C++ class/typedef under its UNQUALIFIED ``DW_AT_name``, so
+    a decompiler printing the fully-qualified name could never match ground
+    truth on a C++ target.
+    """
+    return _NAMESPACE_QUALIFIER.sub("", form).strip()
+
 
 def normalize_type(type_str: str) -> set[str]:
     """Normalize a type string to a set of equivalent representations.
@@ -111,9 +143,13 @@ def normalize_type(type_str: str) -> set[str]:
 
     forms |= {re.sub(r"\s*\*", "*", f) for f in forms}
 
+    forms |= {_strip_namespaces(f) for f in forms}
+
+    forms |= {_map_pointee(f) for f in forms}
+
     forms |= {TYPE_MAP[f] for f in forms if f in TYPE_MAP}
 
-    return forms
+    return {f for f in forms if f}
 
 
 # Uncommitted types recover a variable's SIZE but not a committed C type. Matching
@@ -418,7 +454,13 @@ def _parse_type_die(die: Any, dwarfinfo: Any) -> tuple[list[str], int]:
         names.extend(child_names)
         return names, size
 
-    elif tag == "DW_TAG_pointer_type":
+    elif tag in (
+        "DW_TAG_pointer_type",
+        "DW_TAG_reference_type",
+        "DW_TAG_rvalue_reference_type",
+    ):
+        # A reference is a pointer in the ABI and every decompiler renders it as
+        # one; without this arm every reference-typed GT variable became "void".
         child_names, _ = _parse_type_die(type_die, dwarfinfo)
         if not child_names:
             child_names = ["void"]
@@ -771,7 +813,7 @@ class TypeMatchMetric(Metric):
     display_name = "Type Correctness"
     description = "Accuracy of variable type recovery vs DWARF ground truth"
 
-    cache_version = "4"
+    cache_version = "5"
 
     weight = 1.0
     lower_is_better = False

--- a/docs/decompilers.md
+++ b/docs/decompilers.md
@@ -47,6 +47,9 @@ Key conventions (all families):
 - Functions outside `.text` (PLT/thunks) and CRT helpers are skipped.
 - `FunctionDecompilation.variables` (`VariableInfo`) carries stack vars/args
   for the type metric; line maps are best-effort (angr/Ghidra populate them).
+  `VariableInfo.arg_index` must be the **ABI position**, not the order the tool
+  happens to enumerate its locals in — type_match pairs arguments by that index
+  (see [metrics.md](metrics.md#argument-positions-must-be-abi-positions)).
 - **Decompiler identity is `name` or `name@version`** (`spec.py`): the
   registry resolves `ghidra@12.1` to a versioned instance whose `.id` flows
   through results/scoreboard/report as a distinct column. Per-version settings

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -73,6 +73,12 @@ Compares decompiled variable types against DWARF ground truth (read via
 pyelftools). Works at **all opt levels**: ground truth keeps every variable
 with ANY DWARF location
 (register loclists included; only fully optimized-out vars are dropped).
+Current `cache_version="5"`, bumped for the pointer-`TYPE_MAP` rule below — the
+only one of the three normalization rules that changes an existing C value. The
+per-function key covers the decompiled variables and the DWARF ground truth but
+NOT `normalize_type`, so only a normalization change can serve stale values;
+a change to what DWARF yields mints a new key on its own and must NOT bump
+(see [Metric caching](#metric-caching)).
 
 Unified 3-pass matching against `FunctionDecompilation.variables`:
 
@@ -94,6 +100,40 @@ on the in-class declaration it references. Without that chase, leveldb's
 ground truth is 97 functions instead of 4,236. See
 [DWARF reference chains](#dwarf-reference-chains-c-vs-c) for why this does not
 change any C value.
+
+### Type-string normalization (`normalize_type`)
+
+A type matches when the ground-truth and decompiled form SETS intersect, so
+`normalize_type` returns every equivalent spelling of one type string. Adding a
+form can only ever create a match, never destroy one — an audit over leveldb
+plus zlib/bzip2/grep/coreutils (30k+ function×decompiler pairs) found zero
+per-function score decreases from the normalization rules below.
+
+- **`TYPE_MAP` applies through pointers.** `int4 *` normalizes to `int*`
+  exactly as the scalar `int4` normalizes to `int`. No new equivalence is
+  declared: the pointee is looked up in the same table, so `int4 *` still does
+  not match `long long*`, and a scalar never becomes a pointer.
+- **C++ namespace qualifiers are stripped.** DWARF records a class or typedef
+  under its UNQUALIFIED `DW_AT_name` (`TableBuilder`), so a decompiler printing
+  `leveldb::TableBuilder *` needs the qualifier dropped to reach ground truth.
+  Only `identifier::` tokens are removed, which cannot start with a digit — a
+  Ghidra symbol-version prefix like `GLIBC_2.2.5::stderr` is left alone. C
+  spellings gain no forms from this rule.
+- **A C++ reference is ground truth as a pointer.** `DW_TAG_reference_type` and
+  `DW_TAG_rvalue_reference_type` share the `DW_TAG_pointer_type` arm of
+  `_parse_type_die`, because a reference is a pointer in the ABI and every
+  decompiler renders it as one. Without it every reference-typed ground-truth
+  variable was `void` and unmatchable for all decompilers (17.5% of leveldb's).
+  C has no reference DIEs, so this rule cannot move a C result.
+
+### Argument positions must be ABI positions
+
+Pass 1 pairs a DWARF formal parameter with the decompiled variable carrying the
+same `arg_index`, so a backend that fills `arg_index` in any other order
+silently scores itself against the wrong ground-truth variable. Hex-Rays'
+`cfunc.get_lvars()` enumerates in allocation order, NOT declared order, so
+`decompilers/raw/ida_raw.py` takes positions from `cfunc.argidx`. Any new
+backend must do the same.
 
 ### DWARF reference chains (C vs C++)
 

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -80,6 +80,88 @@ class TestRegistry:
             assert dec.get_version() is None
 
 
+class _FakeTinfo:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def dstr(self) -> str:
+        return self._text
+
+
+class _FakeLvar:
+    """The slice of Hex-Rays' ``lvar_t`` that ``_extract_variables`` reads."""
+
+    def __init__(self, name: str, type_str: str, is_arg: bool, width: int = 8) -> None:
+        self.name = name
+        self.is_arg_var = is_arg
+        self.width = width
+        self.location = None
+        self._tinfo = _FakeTinfo(type_str)
+
+    def type(self) -> _FakeTinfo:
+        return self._tinfo
+
+
+class _FakeCfunc:
+    def __init__(self, lvars: list[_FakeLvar], argidx: list[int] | None) -> None:
+        self._lvars = lvars
+        if argidx is not None:
+            self.argidx = argidx
+
+    def get_lvars(self) -> list[_FakeLvar]:
+        return self._lvars
+
+
+class TestIDAArgumentOrder:
+    """``get_lvars()`` enumerates in allocation order, so argument positions must
+    come from ``cfunc.argidx`` — otherwise type_match's by-ABI-position pass
+    compares the wrong pairs."""
+
+    @staticmethod
+    def _lvars() -> list[_FakeLvar]:
+        return [
+            _FakeLvar("a3", "int", True),
+            _FakeLvar("a1", "leveldb::Slice *", True),
+            _FakeLvar("a2", "char *", True),
+            _FakeLvar("v4", "int", False),
+        ]
+
+    def test_arg_index_follows_argidx_not_enumeration(self) -> None:
+        from decbench.decompilers.raw.ida_raw import RawIDADecompiler
+
+        cfunc = _FakeCfunc(self._lvars(), argidx=[1, 2, 0])
+        args = [v for v in RawIDADecompiler._extract_variables(cfunc) if v.kind == "arg"]
+        assert {v.name: v.arg_index for v in args} == {"a1": 0, "a2": 1, "a3": 2}
+        assert [v.type for v in sorted(args, key=lambda v: v.arg_index)] == [
+            "leveldb::Slice *",
+            "char *",
+            "int",
+        ]
+
+    def test_locals_are_untouched(self) -> None:
+        from decbench.decompilers.raw.ida_raw import RawIDADecompiler
+
+        cfunc = _FakeCfunc(self._lvars(), argidx=[1, 2, 0])
+        locals_ = [v for v in RawIDADecompiler._extract_variables(cfunc) if v.kind == "stack"]
+        assert [v.name for v in locals_] == ["v4"]
+        assert all(v.arg_index is None for v in locals_)
+
+    def test_falls_back_to_enumeration_without_argidx(self) -> None:
+        """An IDA build not exposing ``argidx`` keeps the previous behaviour."""
+        from decbench.decompilers.raw.ida_raw import RawIDADecompiler
+
+        cfunc = _FakeCfunc(self._lvars(), argidx=None)
+        args = [v for v in RawIDADecompiler._extract_variables(cfunc) if v.kind == "arg"]
+        assert {v.name: v.arg_index for v in args} == {"a3": 0, "a1": 1, "a2": 2}
+
+    def test_arg_var_missing_from_argidx_gets_a_trailing_slot(self) -> None:
+        from decbench.decompilers.raw.ida_raw import RawIDADecompiler
+
+        cfunc = _FakeCfunc(self._lvars(), argidx=[1, 2])
+        args = [v for v in RawIDADecompiler._extract_variables(cfunc) if v.kind == "arg"]
+        assert {v.name: v.arg_index for v in args} == {"a1": 0, "a2": 1, "a3": 2}
+
+
 @pytest.mark.parametrize("name", ["angr", "ida", "ghidra"])
 class TestSmokeDecompile:
     def test_decompile_tiny_binary(self, name: str, tiny_binary: Path, tmp_path: Path) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -597,6 +597,121 @@ int main() {
         assert result.metadata["matched_by"] == "structured"
         assert result.metadata["tp"] == 1
 
+    def test_type_map_reaches_pointer_spellings(self) -> None:
+        """``int4 *`` must normalize like ``int4`` does, one indirection out."""
+        from decbench.metrics.type_match import normalize_type
+
+        assert "int*" in normalize_type("int4 *")
+        assert "int*" in normalize_type("int4*")
+        assert "long long*" in normalize_type("undefined8 *")
+        assert "char**" in normalize_type("undefined1 **")
+        # An unmapped pointee is left exactly as it was.
+        assert normalize_type("Slice *") == {"Slice *", "Slice*"}
+
+    def test_pointer_normalization_does_not_cross_widths(self) -> None:
+        """The pointee mapping declares no new equivalence: ``int4 *`` is not
+        ``long long*``, and a scalar never becomes a pointer."""
+        from decbench.metrics.type_match import normalize_type
+
+        assert "long long*" not in normalize_type("int4 *")
+        assert not any("*" in f for f in normalize_type("int4"))
+
+    def test_namespace_qualifier_is_stripped(self) -> None:
+        """DWARF's ``DW_AT_name`` is unqualified, so IDA's ``leveldb::X *``
+        needs the qualifier dropped to reach ground truth."""
+        from decbench.metrics.type_match import normalize_type
+
+        assert "TableBuilder*" in normalize_type("leveldb::TableBuilder *")
+        assert "Mutex*" in normalize_type("leveldb::port::Mutex *")
+        assert "string" in normalize_type("std::string")
+
+    def test_namespace_strip_leaves_c_types_alone(self) -> None:
+        """No C spelling gains a form from the qualifier strip — including a
+        Ghidra symbol-version prefix, whose token starts with a digit."""
+        from decbench.metrics.type_match import normalize_type
+
+        assert normalize_type("unsigned int") == {"unsigned int", "int"}
+        assert normalize_type("char *") == {"char *", "char*"}
+        assert normalize_type("GLIBC_2.2.5::stderr") == {"GLIBC_2.2.5::stderr"}
+
+    def test_namespaced_pointer_matches_unqualified_ground_truth(self) -> None:
+        """End to end: IDA's C++ spelling scores against the DWARF name."""
+        from decbench.metrics.type_match import TypeMatchMetric
+
+        func = FunctionDecompilation(
+            name="Add",
+            address=0x1000,
+            decompiled_code="// no decls",
+            variables=[
+                VariableInfo(name="a1", type="leveldb::TableBuilder *", kind="arg", arg_index=0),
+            ],
+        )
+        gt_vars = [
+            {"name": "this", "type": ["TableBuilder*"], "is_arg": True, "arg_index": 0},
+        ]
+
+        result = TypeMatchMetric().compute_for_function(func, ground_truth_vars=gt_vars)
+        assert result.value == 1.0
+
+    def test_reference_ground_truth_is_a_pointer(self, tmp_path) -> None:
+        """A C++ reference parameter must land as a pointer type, not ``void``.
+
+        Every decompiler renders a reference as a pointer, so ``void`` made those
+        ground-truth variables unmatchable for all of them.
+        """
+        import shutil
+        import subprocess
+
+        if shutil.which("g++") is None:
+            pytest.skip("needs g++")
+
+        from decbench.metrics.type_match import extract_ground_truth_types
+
+        src = tmp_path / "r.cc"
+        src.write_text(
+            "struct Blob { int a; int b; };\n"
+            "int Take(const Blob& in, Blob&& moved) { return in.a + moved.b; }\n"
+            "int main() { Blob b{1, 2}; return Take(b, Blob{3, 4}); }\n"
+        )
+        binary = tmp_path / "r.bin"
+        subprocess.run(
+            ["g++", "-g", "-O0", str(src), "-o", str(binary)], check=True, capture_output=True
+        )
+
+        take = extract_ground_truth_types(binary).get("Take")
+        assert take is not None
+        by_name = {v["name"]: v for v in take}
+        assert "Blob*" in by_name["in"]["type"]
+        assert "Blob*" in by_name["moved"]["type"]
+        assert by_name["in"]["type"] != ["void"]
+
+    def test_c_ground_truth_has_no_reference_types(self, tmp_path) -> None:
+        """The reference arm cannot move a C result: C has no reference DIEs."""
+        import shutil
+        import subprocess
+
+        if shutil.which("gcc") is None:
+            pytest.skip("needs gcc")
+
+        from decbench.utils import binfmt
+
+        src = tmp_path / "c.c"
+        src.write_text(
+            "struct Blob { int a; };\n"
+            "int take(const struct Blob *in, int n) { return in->a + n; }\n"
+            "int main(void) { struct Blob b = {1}; return take(&b, 2); }\n"
+        )
+        binary = tmp_path / "c.bin"
+        subprocess.run(
+            ["gcc", "-g", "-O0", str(src), "-o", str(binary)], check=True, capture_output=True
+        )
+
+        dw = binfmt.dwarf_info(binary)
+        assert dw is not None
+        tags = {die.tag for cu in dw.iter_CUs() for die in cu.iter_DIEs()}
+        assert "DW_TAG_reference_type" not in tags
+        assert "DW_TAG_rvalue_reference_type" not in tags
+
 
 class TestByteMatchMetric:
     """Tests for the byte match metric."""


### PR DESCRIPTION
Four independent scoring artifacts made `type_match` understate C++ type recovery
for **every** decompiler. Each was measured on the leveldb C++ corpus before being
fixed, each is fixed and measured independently, and each carries its own
C-corpus non-regression evidence.

The headline: IDA's published C++ `type_match` was a **6x** understatement
(6 → 37 perfects on leveldb O0), and 17.5% of leveldb's ground-truth variables
were unmatchable by construction for everyone.

## The four fixes

### 1. `TYPE_MAP` never reached pointer spellings — `metrics/type_match.py`

`normalize_type("int4 *")` returned `{"int4 *", "int4*"}`. The scalar row
`int4 -> int` existed but a pointer spelling never reached it, so kuna's
`int4 *` could not match DWARF's `int*` while Ghidra's `int *` could. In
`ClipToRange<int, int>` that alone cost kuna a perfect score (0.667) against
Ghidra's 1.0 for a semantically identical signature.

Measured reach on leveldb O0: 149 kuna / 240 ida / 339 ghidra / 4064 binja
decompiled variables are spelled `<TYPE_MAP key> *`.

The fix looks the **pointee** up in the same table (`_map_pointee`). It declares
no new equivalence: `int4 *` still does not match `long long*`, and a scalar
never becomes a pointer.

### 2. Namespace-qualified types could never match DWARF — `metrics/type_match.py`

Ground truth reads `DW_AT_name`, which is **unqualified** (`TableBuilder`), while
IDA emits `leveldb::TableBuilder *`. Measured on leveldb O0: **0** ground-truth
type forms contain `::`, against 349/4175 IDA, 3391/24358 binja, 38/3433 angr and
19/3697 ghidra decompiled variables that do.

`_strip_namespaces` adds an unqualified form. Only `identifier::` tokens are
removed, and a token cannot start with a digit, so a Ghidra symbol-version prefix
like `GLIBC_2.2.5::stderr` is left intact.

Known accepted limit: `leveldb::Slice` and `other::Slice` both collapse to
`Slice`. That collapse is inherent in the ground truth, not introduced here —
DWARF's `DW_AT_name` records both as `Slice`, so the metric could never have
told them apart.

### 3. IDA's `arg_index` was in local-variable order, not ABI order — `decompilers/raw/ida_raw.py`

`_extract_variables` numbered arguments by walking `cfunc.get_lvars()`, which
enumerates in Hex-Rays' internal allocation order. `type_match` pass 1 matches
arguments **by ABI position**, so IDA was silently compared against the wrong
ground-truth variable roughly half the time.

Measured (extraction order vs the order in IDA's own printed signature, counting
only functions where the two are permutations of the same names):

| corpus | IDA multi-arg functions with scrambled positions |
|---|---|
| leveldb `libleveldb.so.1.23` (C++) | 171/318 (53.8%) |
| leveldb `leveldbutil` (C++) | 3/3 |
| grep (C) | 38/64 (59.4%) |
| zlib `example` (C) | 65/102 (63.7%) |
| bzip2 (C) | 31/48 (64.6%) |

Every other backend measured 0/N, so this is an IDA-backend bug, not a metric
one. Positions now come from `cfunc.argidx`, Hex-Rays' canonical argument order,
falling back to the enumeration order if a build does not expose it.

### 4. `_parse_type_die` had no `DW_TAG_reference_type` arm — `metrics/type_match.py`

Every C++ reference fell through to `["void"], 0`. leveldb's DWARF carries
**3043 `DW_TAG_reference_type` + 663 `DW_TAG_rvalue_reference_type`** DIEs, and
**722 of 4136 (17.5%)** ground-truth variables were typed exactly `void` —
unmatchable by construction, for every decompiler.

References now share the `DW_TAG_pointer_type` arm, because a reference is a
pointer in the ABI and every decompiler renders it as one. That drops the
unmatchable-`void` population from **722 (17.5%) to 14 (0.3%)**.

## Before / after — leveldb O0, all five decompilers

Recomputed from the existing scored checkpoint with `DECBENCH_NO_CACHE=1`
(kuna 890096b6, ghidra 12.1, ida 9.2, angr 9.2.223, binja 5.3.9757); each row
turns on exactly one fix so the effect is attributable. Cells are
`perfect / mean` over the same n=525 scored functions in every row.

#### leveldb O0 — type_match, `perfect / mean` over n=525 scored functions

| case | kuna | ghidra | ida | angr | binja |
|---|---|---|---|---|---|
| **before** (origin/main) | 7 / 0.1176 | 35 / 0.1890 | 6 / 0.1067 | 8 / 0.1395 | 8 / 0.1374 |
| + fix 1 only (pointer TYPE_MAP) | 9 / 0.1277 | 36 / 0.1948 | 6 / 0.1135 | 8 / 0.1395 | 10 / 0.1433 |
| + fix 2 only (namespace strip) | 7 / 0.1176 | 35 / 0.1890 | 30 / 0.1618 | 8 / 0.1433 | 9 / 0.1468 |
| + fix 3 only (IDA arg order) | 7 / 0.1176 | 35 / 0.1890 | 7 / 0.1269 | 8 / 0.1395 | 8 / 0.1374 |
| + fix 4 only (DWARF references) | 7 / 0.1176 | 43 / 0.2216 | 6 / 0.1067 | 8 / 0.1395 | 8 / 0.1374 |
| **after** (all four) | 9 / 0.1277 | 44 / 0.2274 | 37 / 0.2106 | 8 / 0.1433 | 11 / 0.1526 |

Corrected ranking: **ghidra 44 > ida 37 >> binja 11 > kuna 9 ~= angr 8**.

Fix 3's numbers come from a real IDA re-run through `run_benchmark`'s
stripped-binary + address-filter + DWARF-relabel flow. That re-run reproduced the
frozen checkpoint exactly — identical function sets, **byte-identical
`decompiled_code` for all 537 functions**, and identical `VariableInfo` tuples
apart from `arg_index` — so the delta is the fix and nothing else. The scrambled
count went 171/318 → **0/318**.

## C-corpus non-regression

Control: `results/full_run` (read-only; nothing was written to it). Same
methodology, same isolation.

#### zlib O0 — `perfect / mean`, n=764,764,764,764,764

| case | kuna | ghidra | ida | angr | binja |
|---|---|---|---|---|---|
| **before** | 58 / 0.3385 | 58 / 0.3224 | 51 / 0.2576 | 76 / 0.5019 | 87 / 0.4939 |
| + fix 1 (pointer TYPE_MAP) | 62 / 0.3478 | 58 / 0.3453 | 51 / 0.2691 | 76 / 0.5019 | 92 / 0.5107 |
| + fix 2 (namespace strip) | 58 / 0.3385 | 58 / 0.3224 | 51 / 0.2576 | 76 / 0.5019 | 87 / 0.4939 |
| + fix 4 (DWARF references) | 58 / 0.3385 | 58 / 0.3224 | 51 / 0.2576 | 76 / 0.5019 | 87 / 0.4939 |
| + fix 3 (IDA arg order) | 58 / 0.3385 | 58 / 0.3224 | 51 / 0.3170 | 76 / 0.5019 | 87 / 0.4939 |
| **after** (all four) | 62 / 0.3478 | 58 / 0.3453 | 51 / 0.3466 | 76 / 0.5019 | 92 / 0.5107 |

#### bzip2 O0 — `perfect / mean`, n=108,108,108,108,107

| case | kuna | ghidra | ida | angr | binja |
|---|---|---|---|---|---|
| **before** | 7 / 0.3666 | 7 / 0.4313 | 15 / 0.4544 | 26 / 0.6400 | 18 / 0.5638 |
| + fix 1 (pointer TYPE_MAP) | 7 / 0.3807 | 7 / 0.4414 | 17 / 0.4723 | 26 / 0.6400 | 19 / 0.5929 |
| + fix 2 (namespace strip) | 7 / 0.3666 | 7 / 0.4313 | 15 / 0.4544 | 26 / 0.6400 | 18 / 0.5638 |
| + fix 4 (DWARF references) | 7 / 0.3666 | 7 / 0.4313 | 15 / 0.4544 | 26 / 0.6400 | 18 / 0.5638 |
| + fix 3 (IDA arg order) | 7 / 0.3666 | 7 / 0.4313 | 15 / 0.4967 | 26 / 0.6400 | 18 / 0.5638 |
| **after** (all four) | 7 / 0.3807 | 7 / 0.4414 | 17 / 0.5253 | 26 / 0.6400 | 19 / 0.5929 |

#### grep O0 — `perfect / mean`, n=101,101,101,101,101

| case | kuna | ghidra | ida | angr | binja |
|---|---|---|---|---|---|
| **before** | 18 / 0.3965 | 20 / 0.4300 | 14 / 0.3682 | 23 / 0.5218 | 22 / 0.5336 |
| + fix 1 (pointer TYPE_MAP) | 19 / 0.4160 | 21 / 0.4456 | 22 / 0.4376 | 23 / 0.5218 | 24 / 0.5492 |
| + fix 2 (namespace strip) | 18 / 0.3965 | 20 / 0.4300 | 14 / 0.3682 | 23 / 0.5218 | 22 / 0.5336 |
| + fix 4 (DWARF references) | 18 / 0.3965 | 20 / 0.4300 | 14 / 0.3682 | 23 / 0.5218 | 22 / 0.5336 |
| + fix 3 (IDA arg order) | 18 / 0.3965 | 20 / 0.4300 | 15 / 0.4188 | 23 / 0.5218 | 22 / 0.5336 |
| **after** (all four) | 19 / 0.4160 | 21 / 0.4456 | 23 / 0.4955 | 23 / 0.5218 | 24 / 0.5492 |

**Per fix:**

- **Fix 1 (pointer `TYPE_MAP`) — DOES move C, upward only.** zlib kuna 58→62 and
  binja 87→92 perfects; grep ida 14→22, kuna 18→19, ghidra 20→21, binja 22→24;
  bzip2 ida 15→17, binja 18→19. This is correct: the metric already accepts
  `int4 == int` for scalars, and C output contains the same pointer spellings, so
  the previous behaviour penalized the spelling rather than the recovery.
- **Fix 2 (namespace strip) — ZERO movement on C.** Identical perfect counts and
  identical means to four decimals for all five decompilers on every C project.
  A test asserts a C spelling gains no forms and that `GLIBC_2.2.5::stderr` is
  untouched.
- **Fix 3 (IDA arg order) — DOES move C, and by more than it moves C++.** IDA
  mean +0.0594 (zlib), +0.0506 (grep), +0.0423 (bzip2), vs +0.0202 on leveldb;
  perfects +1 on grep, unchanged elsewhere. This is a decompiler-backend
  correctness fix, so the C corpus is *supposed* to move: IDA was previously
  scored against mis-paired ground-truth variables on ~60% of its multi-arg C
  functions. No other decompiler is touched.
- **Fix 4 (DWARF references) — ZERO movement on C, structurally.** C has no
  `DW_TAG_reference_type`; a test compiles a C translation unit and asserts
  neither reference tag appears in its DWARF.

**Monotonicity audit.** Across leveldb (C++) plus zlib, bzip2, grep and
coreutils, comparing every per-function score before and after fixes 1+2+4:

```
leveldb   O0: up=178  same=2447   DOWN=0
zlib      O0: up=234  same=5578   DOWN=0
bzip2     O0: up=39   same=814    DOWN=0
grep      O0: up=44   same=755    DOWN=0
coreutils O0: up=523  same=20300  DOWN=0
```

Zero per-function decreases over 30k+ function x decompiler pairs — the expected
signature of rules that only ADD equivalent spellings.

## `cache_version` decision

Bumped `TypeMatchMetric.cache_version` from `"4"` to `"5"` — **required, and
required by fixes 1 and 2 specifically.**

The per-function cache key (`compute_for_function`) covers the decompiled
variables, the decompiled code, the DWARF ground truth and the calibration shift.
So:

| fix | changes C results? | in the cache key? | needs the bump? |
|---|---|---|---|
| 1. pointer `TYPE_MAP` | **yes** (zlib/bzip2/grep above) | no — `normalize_type` is not keyed | **yes** |
| 2. namespace strip | no (0.0000 delta on 3 C projects) | no — `normalize_type` is not keyed | yes, defensively: same code path as fix 1, and it *does* change C++ values |
| 3. IDA arg order | **yes** (IDA only) | yes — `arg_index` is in the key | no (a re-decompile mints a new key on its own) |
| 4. DWARF references | no (C has no reference DIEs) | yes — `ground_truth_vars` is in the key | no (changed ground truth mints a new key on its own) |

One shared `cache_version` covers the metric, so the bump is a single decision;
fix 1 alone forces it. **What moves for existing (C) projects** is exactly fix 1
plus fix 3 — quantified per project in the table above.

`docs/metrics.md` also states the converse: a change that is provably a no-op
for existing input must NOT bump, since a needless bump forces a corpus-wide
recompute against pinned checkpoints. Fixes 2 and 4 are exactly that kind of
change and neither would have bumped on its own — fix 4 for the same reason as
the `DW_AT_specification` chase already documented there (it changes the ground
truth, which is part of the key). Fix 1 is not a no-op, so the bump stands.

## Tests

11 new tests, all of which fail on `origin/main` where they should and pass where
they should:

- `tests/test_metrics.py` — pointer `TYPE_MAP` reach; that it crosses no widths
  and makes no scalar a pointer; namespace stripping incl. nested and `std::`;
  that C spellings and `GLIBC_2.2.5::` are untouched; an end-to-end
  `leveldb::TableBuilder *` vs `TableBuilder*` scoring 1.0; a real g++ build whose
  `const Blob&` / `Blob&&` parameters come back as `Blob*`; a real gcc build
  asserting C DWARF has no reference tags.
- `tests/test_decompilers.py` — `TestIDAArgumentOrder` against a fake Hex-Rays
  `cfunc`: positions follow `argidx` not enumeration, locals untouched, fallback
  when `argidx` is absent, and an arg missing from `argidx` gets a trailing slot.
  Runs without IDA installed.

On `origin/main` exactly the 6 behaviour-change tests fail and the 5
non-regression/control tests pass; with the fixes all 11 pass.

## Gates

- `pytest`: 453 passed, 7 skipped, **5 failed** — the same 5 pre-existing
  `tests/test_content.py` failures present on `origin/main` (442 passed there;
  the +11 is this PR's tests).
- `ruff check` on the four touched files: clean. Repo-wide count unchanged at 33
  (all pre-existing, none in touched files).
- `black --check`: `type_match.py`, `test_metrics.py`, `test_decompilers.py`
  clean. `ida_raw.py` still reports two pre-existing reformats on lines this PR
  does not touch (it reports the same on `origin/main`); left alone to keep the
  diff honest.
- `mypy`: blocked at baseline by an angr syntax error under Python 3.14, same as
  on `origin/main`. With `--follow-imports=skip` the touched files report the
  same 3 errors as their `origin/main` versions — no new ones.

## Docs

`docs/metrics.md` (the owner) gains a **Type-string normalization** subsection
covering all three normalization rules with their C-impact statement, an
**Argument positions must be ABI positions** subsection stating the contract that
fix 3 restores, and a note on which kinds of change force the `cache_version`
bump. `docs/decompilers.md` gains a one-line pointer on the backend side, since
`VariableInfo.arg_index` is a backend-authored field.

## Follow-up (not in this PR)

The published `results/full_run` numbers are stale for `type_match` on every
project. Refreshing them needs a reeval overlay pass
(`scripts/reeval_typematch.py` + `scripts/finalize_results.py`) plus an IDA
re-decompile for fix 3, which is a separate change with its own
"nothing extreme changed" review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McQC7imaNfzj5k5AVumSYN