### PR TITLE
fix(metrics): honor ARM function encoding in byte_match

### DIFF
--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -230,7 +230,7 @@ class ByteMatchMetric(Metric):
     requires_source_cfg = False
     requires_decompiled_cfg = False
 
-    cache_version = "5"
+    cache_version = "6"
 
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)
@@ -280,7 +280,10 @@ class ByteMatchMetric(Metric):
                 },
             )
         flags = binfmt.producer_flags(original_binary_path) + ["-c", "-fno-builtin", "-w"]
-        arch_mode = binfmt.capstone_arch_mode(info)
+        thumb = binfmt.elf_function_is_thumb(
+            original_binary_path, decompiled.name, decompiled.address
+        )
+        arch_mode = binfmt.capstone_arch_mode(info, thumb=thumb)
 
         original_bytes = binfmt.function_bytes(
             original_binary_path, decompiled.name, decompiled.address

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -34,6 +34,7 @@ import struct
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, cast
 
 _ELF_MACHINES = {0x28: "arm", 0xB7: "aarch64", 0x3E: "x86-64", 0x03: "x86", 0xF3: "riscv"}
 _PE_MACHINES = {0x14C: "x86", 0x8664: "x86-64", 0xAA64: "aarch64", 0x1C0: "arm"}
@@ -147,6 +148,40 @@ def capstone_arch_mode(info: BinInfo, thumb: bool = False):
     if info.arch == "aarch64":
         return capstone.CS_ARCH_ARM64, capstone.CS_MODE_ARM
     return None
+
+
+def elf_function_is_thumb(path: Path, func_name: str, address: int) -> bool:
+    """Return whether an ARM ELF function symbol selects Thumb encoding.
+
+    ARM ``STT_FUNC`` symbol values carry the Thumb-state marker in bit zero.
+    Capstone accepts the same bytes in A32 mode without necessarily failing, so
+    the symbol table is the authoritative mode source rather than a decoding
+    heuristic.
+    """
+    try:
+        from elftools.elf.elffile import ELFFile
+
+        with path.open("rb") as stream:
+            elf = ELFFile(stream)
+            if elf.header["e_machine"] != "EM_ARM":
+                return False
+            symtab = elf.get_section_by_name(".symtab")
+            if symtab is None:
+                return False
+            symbol_table = cast(Any, symtab)
+            for symbol in symbol_table.iter_symbols():
+                if symbol["st_info"]["type"] != "STT_FUNC" or symbol["st_size"] <= 0:
+                    continue
+                raw_address = symbol["st_value"]
+                if (
+                    symbol.name == func_name
+                    or (raw_address & ~1) == address
+                    or raw_address == address
+                ):
+                    return bool(raw_address & 1)
+    except Exception:
+        pass
+    return False
 
 
 _DWARF_SECS = (
@@ -416,9 +451,16 @@ def _elf_function_bytes(path: Path, func_name: str, address: int) -> bytes | Non
             symtab = elf.get_section_by_name(".symtab")
             if symtab is None:
                 return None
+            is_arm = elf.header["e_machine"] == "EM_ARM"
             for sym in symtab.iter_symbols():
-                if (sym.name == func_name or sym["st_value"] == address) and sym["st_size"] > 0:
-                    addr, size = sym["st_value"], sym["st_size"]
+                raw_address = sym["st_value"]
+                symbol_address = raw_address & ~1 if is_arm else raw_address
+                if (
+                    sym.name == func_name
+                    or symbol_address == address
+                    or raw_address == address
+                ) and sym["st_size"] > 0:
+                    addr, size = symbol_address, sym["st_size"]
                     for section in elf.iter_sections():
                         sa, ss = section["sh_addr"], section["sh_size"]
                         if sa <= addr < sa + ss:
@@ -463,9 +505,12 @@ def _elf_object_function(obj_path: Path, func_name: str) -> bytes | None:
             symtab = elf.get_section_by_name(".symtab")
             if text is None or symtab is None:
                 return None
+            is_arm = elf.header["e_machine"] == "EM_ARM"
             for sym in symtab.iter_symbols():
                 if sym.name == func_name and sym["st_size"] > 0:
                     off = sym["st_value"]
+                    if is_arm:
+                        off &= ~1
                     return text.data()[off : off + sym["st_size"]]
     except Exception:
         pass

--- a/tests/test_arm_thumb_extraction.py
+++ b/tests/test_arm_thumb_extraction.py
@@ -1,0 +1,180 @@
+"""ARM/Thumb function extraction and disassembly mode.
+
+The ARM ELF ABI encodes Thumb state in bit 0 of an ``STT_FUNC`` symbol value:
+a function recorded at ``0x08000001`` begins at ``0x08000000``. Ignoring the
+marker caused final binaries and relocatable objects to be sliced one byte late,
+then decoded in A32 mode. Capstone can return plausible wrong instructions or an
+empty listing for that input.
+
+The production byte-match metric does not award an automatic perfect score to
+two empty listings: it falls back to raw-byte similarity. The defect is still
+metric-unsound because the intended normalized instruction comparison silently
+becomes a comparison of misaligned bytes or wrong-mode instructions.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from decbench.metrics.byte_match import _disassemble_bytes
+from decbench.utils import binfmt
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("arm-none-eabi-gcc") is None,
+    reason="arm-none-eabi-gcc not available",
+)
+
+_SRC = """
+int lcd_add(int a, int b) { int t = a + b; return t * 3; }
+int lcd_sub(int a, int b) { return a - b; }
+"""
+
+_TEXT_BASE = 0x08000000
+_EXPECTED = {
+    "lcd_add": (
+        bytes.fromhex("084400eb40007047"),
+        ["add r0, r1", "add.w r0, r0, r0, lsl #1", "bx lr"],
+    ),
+    "lcd_sub": (bytes.fromhex("401a7047"), ["subs r0, r0, r1", "bx lr"]),
+}
+
+
+@pytest.fixture(scope="module")
+def thumb_artifacts(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """An unstripped Cortex-M4 Thumb object and linked ELF."""
+    directory = tmp_path_factory.mktemp("thumb")
+    source = directory / "fixture.c"
+    obj = directory / "fixture.o"
+    elf = directory / "fixture.elf"
+    source.write_text(_SRC)
+    subprocess.run(
+        [
+            "arm-none-eabi-gcc",
+            "-mcpu=cortex-m4",
+            "-mthumb",
+            "-O1",
+            "-c",
+            str(source),
+            "-o",
+            str(obj),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "arm-none-eabi-gcc",
+            "-nostdlib",
+            "-Wl,--entry=lcd_add",
+            f"-Wl,-Ttext={_TEXT_BASE:#x}",
+            str(obj),
+            "-o",
+            str(elf),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return obj, elf
+
+
+@pytest.fixture(scope="module")
+def arm_elf(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A real A32 negative control for Thumb-state detection."""
+    directory = tmp_path_factory.mktemp("arm")
+    source = directory / "fixture.c"
+    elf = directory / "fixture.elf"
+    source.write_text(_SRC)
+    subprocess.run(
+        [
+            "arm-none-eabi-gcc",
+            "-march=armv7-a",
+            "-marm",
+            "-O1",
+            "-nostdlib",
+            "-Wl,--entry=lcd_add",
+            f"-Wl,-Ttext={_TEXT_BASE:#x}",
+            str(source),
+            "-o",
+            str(elf),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return elf
+
+
+def test_symbols_really_carry_the_thumb_bit(thumb_artifacts: tuple[Path, Path]) -> None:
+    """Guard the ABI premise against a toolchain behavior change."""
+    from elftools.elf.elffile import ELFFile
+
+    _, elf_path = thumb_artifacts
+    with elf_path.open("rb") as stream:
+        symtab = ELFFile(stream).get_section_by_name(".symtab")
+        assert symtab is not None
+        values = {
+            symbol.name: symbol["st_value"]
+            for symbol in symtab.iter_symbols()
+            if symbol.name in _EXPECTED
+        }
+
+    assert values
+    assert all(value & 1 for value in values.values()), values
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED))
+def test_final_elf_extraction_masks_the_thumb_bit(
+    thumb_artifacts: tuple[Path, Path], name: str
+) -> None:
+    expected_bytes, _ = _EXPECTED[name]
+    address = _TEXT_BASE + (0 if name == "lcd_add" else 8)
+
+    got = binfmt.function_bytes(thumb_artifacts[1], name, address)
+
+    assert got == expected_bytes
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED))
+def test_relocatable_object_extraction_masks_the_thumb_bit(
+    thumb_artifacts: tuple[Path, Path], name: str
+) -> None:
+    expected_bytes, _ = _EXPECTED[name]
+
+    got = binfmt.object_text_bytes(thumb_artifacts[0], name)
+
+    assert got == expected_bytes
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED))
+def test_thumb_functions_decode_in_thumb_mode(
+    thumb_artifacts: tuple[Path, Path], name: str
+) -> None:
+    expected_bytes, expected_asm = _EXPECTED[name]
+    address = _TEXT_BASE + (0 if name == "lcd_add" else 8)
+    elf_path = thumb_artifacts[1]
+
+    assert binfmt.elf_function_is_thumb(elf_path, name, address) is True
+    info = binfmt.detect(elf_path)
+    assert info is not None
+    arch_mode = binfmt.capstone_arch_mode(info, thumb=True)
+
+    assert _disassemble_bytes(expected_bytes, address, arch_mode) == expected_asm
+
+
+def test_a32_function_is_not_classified_as_thumb(arm_elf: Path) -> None:
+    assert binfmt.elf_function_is_thumb(arm_elf, "lcd_add", _TEXT_BASE) is False
+
+
+def test_wrong_mode_is_silently_not_instruction_equivalent(
+    thumb_artifacts: tuple[Path, Path],
+) -> None:
+    elf_path = thumb_artifacts[1]
+    info = binfmt.detect(elf_path)
+    assert info is not None
+    arm_mode = binfmt.capstone_arch_mode(info, thumb=False)
+    sub_bytes, sub_asm = _EXPECTED["lcd_sub"]
+
+    assert _disassemble_bytes(sub_bytes, _TEXT_BASE + 8, arm_mode) != sub_asm


### PR DESCRIPTION
## Summary

- mask the ARM Thumb-state bit when extracting function bytes from linked ELF files
- mask the same bit when extracting recompiled functions from relocatable objects
- select Capstone Thumb/A32 mode from the original STT_FUNC symbol
- bump the byte_match cache version
- add real ARM toolchain tests for linked extraction, object extraction, Thumb decoding, and an A32 negative control

## Why

ARM ELF function symbols encode Thumb state in bit zero. Treating that bit as part of the address sliced every Thumb function one byte late; decoding the result as A32 then silently replaced the intended normalized instruction comparison with misaligned raw-byte fallback or wrong-mode instructions.

The production path does **not** award an automatic 1.0 for two empty disassemblies; it falls back to raw-byte similarity. This PR intentionally corrects that earlier diagnosis while retaining the three concrete extraction/mode fixes.

## Validation

- `uv run --extra dev pytest -q tests/test_arm_thumb_extraction.py`: 9 passed
- relevant metric suite: 64 passed, 1 pre-existing GCC 15/C23 fixup failure (`long helper_fn();` is interpreted as a zero-argument prototype)
- full suite: 453 passed, 13 skipped, 8 failures; the other failures are current-main content/evalkit/backend drift and are unrelated to these paths
- `uv run --extra dev ruff check decbench/metrics/byte_match.py decbench/utils/binfmt.py tests/test_arm_thumb_extraction.py`: pass
- repository mypy remains red on existing errors; the new symbol-table iteration is explicitly typed without adding a new error
