### PR TITLE
build(corpus): make persistent rebuild reproducible

### DIFF
--- a/docker/compile.Dockerfile
+++ b/docker/compile.Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python-is-python3 \
     autoconf automake libtool gettext autopoint rsync bison texinfo gperf \
     help2man pkg-config meson ninja-build cmake flex file device-tree-compiler \
-    libtool-bin libssl-dev uuid-dev libgnutls28-dev \
+    libtool-bin libssl-dev uuid-dev libgnutls28-dev zlib1g-dev \
+    libattr1-dev libmd-dev libncurses-dev libestr-dev libfastjson-dev \
+    libcurl4-gnutls-dev \
     gcc g++ \
     gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi \
     libstdc++-arm-none-eabi-newlib \

--- a/projects/sailr/libacl.toml
+++ b/projects/sailr/libacl.toml
@@ -10,7 +10,7 @@ name = "libacl"
 version = "2.3.1"
 
 # Source configuration - release tarball ships a pre-generated ./configure
-source_remote = "https://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz"
+source_remote = "https://download-mirror.savannah.gnu.org/releases/acl/acl-2.3.1.tar.xz"
 remote_type = "tar"
 
 # Build directories

--- a/scripts/compile_all.py
+++ b/scripts/compile_all.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+import struct
 import sys
 import time
 import traceback
@@ -41,38 +42,53 @@ def gather_tomls() -> list[Path]:
     return sorted(out, key=lambda p: p.stem)
 
 
-OPT_LEVELS = [
-    OptimizationLevel.O0,
-    OptimizationLevel.O2,
-    OptimizationLevel.O2_NOINLINE,
-]
+def _is_linked_image(path: Path) -> bool:
+    """Return whether ``path`` is a linked ELF or PE executable image."""
+    try:
+        with path.open("rb") as image:
+            magic = image.read(4)
+            if magic == b"\x7fELF":
+                image.seek(16)
+                return struct.unpack("<H", image.read(2))[0] in (2, 3)
+            if not magic.startswith(b"MZ"):
+                return False
+            image.seek(0x3C)
+            pe_offset = struct.unpack("<I", image.read(4))[0]
+            image.seek(pe_offset)
+            if image.read(4) != b"PE\0\0":
+                return False
+            image.seek(pe_offset + 22)
+            characteristics = struct.unpack("<H", image.read(2))[0]
+            return bool(characteristics & 0x0002)  # IMAGE_FILE_EXECUTABLE_IMAGE
+    except (OSError, struct.error):
+        return False
 
 
 def _count_outputs(out_dir: Path, opt: str, name: str) -> tuple[int, int]:
-    """Return (elf_binary_count, preprocessed_file_count) in the compiled dir."""
-    import struct
+    """Return (linked_binary_count, preprocessed_file_count)."""
 
     compiled = out_dir / opt / name / "compiled"
     if not compiled.is_dir():
         return (0, 0)
     skip = (".o", ".a", ".s", ".h", *PREPROC_EXTS, *SOURCE_EXTS)
-    elfs = 0
+    binaries = 0
     for entry in compiled.iterdir():
         if not entry.is_file() or entry.is_symlink():
             continue
         if entry.suffix in skip:
             continue
-        try:
-            with open(entry, "rb") as f:
-                if f.read(4) != b"\x7fELF":
-                    continue
-                f.seek(16)
-                if struct.unpack("<H", f.read(2))[0] in (2, 3):
-                    elfs += 1
-        except (OSError, struct.error):
-            continue
+        binaries += int(_is_linked_image(entry))
     i_files = sum(len(list(compiled.glob(f"*{ext}"))) for ext in PREPROC_EXTS)
-    return (elfs, i_files)
+    return (binaries, i_files)
+
+
+def build_tasks(tomls: list[Path], out_dir: Path) -> list[tuple[str, str, str]]:
+    """Build only the optimization levels declared by each project."""
+    return [
+        (str(toml), opt.value, str(out_dir))
+        for toml in tomls
+        for opt in Project.from_toml(toml).compilation.optimization_levels
+    ]
 
 
 def _build_one(toml_path: str, opt_value: str, out_dir: str) -> dict:
@@ -84,7 +100,7 @@ def _build_one(toml_path: str, opt_value: str, out_dir: str) -> dict:
         opt = OptimizationLevel(opt_value)
         results = compile_project(project, Path(out_dir), opt, clean=True)
         successes = sum(1 for r in results if getattr(r, "success", False))
-        elfs, i_files = _count_outputs(Path(out_dir), opt_value, name)
+        binaries, i_files = _count_outputs(Path(out_dir), opt_value, name)
         errs = [
             (r.error_message or "")[:300]
             for r in results
@@ -93,19 +109,19 @@ def _build_one(toml_path: str, opt_value: str, out_dir: str) -> dict:
         return {
             "project": name,
             "opt": opt_value,
-            "elf_binaries": elfs,
+            "linked_binaries": binaries,
             "i_files": i_files,
             "compile_results": len(results),
             "successes": successes,
             "errors": errs[:3],
             "seconds": round(time.time() - start, 1),
-            "ok": elfs > 0,
+            "ok": binaries > 0,
         }
     except Exception as e:  # noqa: BLE001 - report, never crash the pool
         return {
             "project": name,
             "opt": opt_value,
-            "elf_binaries": 0,
+            "linked_binaries": 0,
             "i_files": 0,
             "compile_results": 0,
             "successes": 0,
@@ -125,10 +141,10 @@ def main() -> int:
     if only:
         tomls = [t for t in tomls if t.stem in only]
 
-    tasks = [(str(t), opt.value, str(out_dir)) for t in tomls for opt in OPT_LEVELS]
+    tasks = build_tasks(tomls, out_dir)
     print(
-        f"Compiling {len(tomls)} projects x {len(OPT_LEVELS)} opts "
-        f"= {len(tasks)} builds, {workers} workers -> {out_dir}",
+        f"Compiling {len(tasks)} declared project/optimization builds, "
+        f"{workers} workers -> {out_dir}",
         flush=True,
     )
 
@@ -143,7 +159,7 @@ def main() -> int:
             flag = "OK " if r["ok"] else "FAIL"
             print(
                 f"[{done}/{len(tasks)}] {flag} {r['project']:18s} {r['opt']:11s} "
-                f"elf={r['elf_binaries']:<4d} i={r['i_files']:<4d} "
+                f"bin={r['linked_binaries']:<4d} i={r['i_files']:<4d} "
                 f"{r['seconds']:.0f}s"
                 + (f"  ERR: {r['errors'][0][:120]}" if not r["ok"] and r["errors"] else ""),
                 flush=True,
@@ -151,9 +167,9 @@ def main() -> int:
 
     by_proj: dict[str, dict[str, int]] = {}
     for r in reports:
-        by_proj.setdefault(r["project"], {})[r["opt"]] = r["elf_binaries"]
+        by_proj.setdefault(r["project"], {})[r["opt"]] = r["linked_binaries"]
 
-    print("\n==== PER-PROJECT ELF BINARY COUNTS ====", flush=True)
+    print("\n==== PER-PROJECT LINKED BINARY COUNTS ====", flush=True)
     print(f"{'project':20s} {'O0':>6s} {'O2':>6s} {'O2-noinline':>12s}", flush=True)
     fully_ok, partial, broken = [], [], []
     for proj in sorted(by_proj):

--- a/tests/test_compile_all_driver.py
+++ b/tests/test_compile_all_driver.py
@@ -1,0 +1,41 @@
+"""Regression coverage for the persistent corpus compilation driver."""
+
+from __future__ import annotations
+
+import importlib.util
+import struct
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "compile_all_driver", ROOT / "scripts" / "compile_all.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+DRIVER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(DRIVER)
+
+
+def _minimal_pe() -> bytes:
+    image = bytearray(0x80)
+    image[:2] = b"MZ"
+    struct.pack_into("<I", image, 0x3C, 0x40)
+    image[0x40:0x44] = b"PE\0\0"
+    struct.pack_into("<H", image, 0x56, 0x0002)  # IMAGE_FILE_EXECUTABLE_IMAGE
+    return bytes(image)
+
+
+def test_count_outputs_includes_linked_pe_images(tmp_path: Path) -> None:
+    compiled = tmp_path / "O0" / "firmware" / "compiled"
+    compiled.mkdir(parents=True)
+    (compiled / "firmware.exe").write_bytes(_minimal_pe())
+    (compiled / "firmware.i").write_text("int firmware(void);\n")
+
+    assert DRIVER._count_outputs(tmp_path, "O0", "firmware") == (1, 1)
+
+
+def test_build_tasks_honors_each_projects_declared_optimization_levels() -> None:
+    toml = ROOT / "projects" / "cps" / "u-boot.toml"
+
+    tasks = DRIVER.build_tasks([toml], Path("/tmp/decbench-output"))
+
+    assert [task[1] for task in tasks] == ["O2", "O2-noinline"]


### PR DESCRIPTION
## Summary

- count linked PE images as well as ELF images in the persistent corpus build report
- schedule only optimization levels declared by each project manifest
- install the system development packages required by the current 41-project corpus
- switch libacl 2.3.1 to the responsive Savannah mirror

## Verification

- `pytest -q tests/test_compile_all_driver.py` (2 passed)
- `ruff check scripts/compile_all.py tests/test_compile_all_driver.py`
- real persistent rebuild: 41 projects, 122/122 declared cells complete, 880 linked binaries, 11,885 preprocessed source files

The rebuilt tree is retained outside the repository; this PR contains only the reproducibility fixes found while building it.