### PR TITLE
[AUTOMATED] fix(metrics): narrow the pointee normalization and close the C++ collection gaps

### DIFF
--- a/decbench/evalkit/ingest.py
+++ b/decbench/evalkit/ingest.py
@@ -44,6 +44,7 @@ from decbench.models.decompilation import (
     DecompilerMetadata,
     FunctionDecompilation,
 )
+from decbench.utils.langs import preprocessed_by_stem
 
 if TYPE_CHECKING:
     from decbench.models.metrics import MetricResult
@@ -614,11 +615,11 @@ def _evaluate_group(
     best: dict = {}
     if needs_source:
         compiled = tree / opt / project / "compiled"
-        i_by_stem = {p.stem: p for p in sorted(compiled.glob("*.i"))}
+        i_by_stem = preprocessed_by_stem(compiled)
         if not i_by_stem:
             _warn(
                 warnings,
-                f"{project}/{opt}: no preprocessed .i sources in {compiled} — "
+                f"{project}/{opt}: no preprocessed .i/.ii sources in {compiled} — "
                 f"source-CFG metrics (GED) will not score",
             )
         else:

--- a/decbench/evalkit/resolve.py
+++ b/decbench/evalkit/resolve.py
@@ -26,7 +26,7 @@ import os
 import struct
 from pathlib import Path
 
-from decbench.utils.langs import PREPROC_EXTS, strip_source_ext
+from decbench.utils.langs import PREPROC_EXTS, build_stem_index, strip_source_ext
 
 _l = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
         return {}
     addr2name: dict[int, str] = {}
     file_tables: dict[int, list[str | None]] = {}
-    stem_index = {strip_source_ext(s): s for s in (stems or ())}
+    stem_index = build_stem_index(stems or ())
     try:
         for cu in dw.iter_CUs():
             for die in cu.iter_DIEs():

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -72,8 +72,26 @@ TYPE_MAP: dict[str, str] = {
 
 QUALIFIERS = ["unsigned", "signed", "const", "volatile", "register", "static", "extern"]
 
-# A trailing run of ``*``s, so TYPE_MAP can be applied to the POINTEE.
+# A trailing run of ``*``s, so a pointee spelling can be normalized.
 _PTR_SUFFIX = re.compile(r"^(.*?)((?:\s*\*)+)$")
+
+# Spellings that mean "N bytes of UNKNOWN type" rather than naming a C type:
+# Ghidra's and kuna's TYPE_UNKNOWN (``undefinedN``) and Hex-Rays' unknown-width
+# stack slots (``_QWORD`` …). Every decompiler that emits one of these also has a
+# committed spelling for the same width in the same output (Ghidra ``uint``, IDA
+# ``__int32``, kuna ``int4`` — a TYPE_INT core type, distinct from its TYPE_UNKNOWN
+# ``xunknown4``), so choosing a placeholder is positive evidence that the type was
+# NOT recovered.
+_PLACEHOLDER_TYPES = re.compile(r"^(?:undefined\d*|_(?:BYTE|WORD|DWORD|QWORD))$")
+
+# The subset of TYPE_MAP that may be applied to a POINTEE. A pointer spelling names
+# the type of the thing pointed AT, so routing the whole table through a pointer
+# would declare ``undefined8 *`` ("pointer to 8 unknown bytes") equal to ``size_t *``
+# — crediting a non-recovery as a recovery, and contradicting _UNCOMMITTED_TYPES'
+# rule that a width-only spelling against a pointer is a real miss.
+_POINTEE_MAP: dict[str, str] = {
+    k: v for k, v in TYPE_MAP.items() if not _PLACEHOLDER_TYPES.match(k)
+}
 
 # One C++ namespace/class qualifier, e.g. the ``leveldb::`` of
 # ``leveldb::TableBuilder *``. Digits cannot start a token, so a Ghidra symbol
@@ -82,16 +100,18 @@ _NAMESPACE_QUALIFIER = re.compile(r"\b[A-Za-z_]\w*\s*::\s*")
 
 
 def _map_pointee(form: str) -> str:
-    """``TYPE_MAP`` applied through a pointer spelling: ``int4 *`` -> ``int*``.
+    """``_POINTEE_MAP`` applied through a pointer spelling: ``size_t *`` -> ``long long*``.
 
-    The scalar rows already normalize ``int4``, but a pointer spelling never
-    reached them, so a decompiler writing ``int4 *`` could not match DWARF's
-    ``int*`` while one writing ``int *`` could.
+    Only COMMITTED pointee spellings are mapped (see :data:`_POINTEE_MAP`); a
+    width-only placeholder such as ``undefined8`` or ``_QWORD`` is left alone, so
+    ``undefined8 *`` stays a miss against ``size_t*``. Applies to both sides of
+    the comparison, since ``normalize_type`` is shared by the decompiled and the
+    DWARF ground-truth payload.
     """
     m = _PTR_SUFFIX.match(form)
     if m is None:
         return form
-    mapped = TYPE_MAP.get(m.group(1).strip())
+    mapped = _POINTEE_MAP.get(m.group(1).strip())
     return form if mapped is None else mapped + m.group(2)
 
 
@@ -154,7 +174,10 @@ def normalize_type(type_str: str) -> set[str]:
 
 # Uncommitted types recover a variable's SIZE but not a committed C type. Matching
 # one against a same-width ground-truth SCALAR is fair; against a pointer or
-# aggregate it is a real miss, so those are excluded from _UNCOMMITTED_GT_SCALARS.
+# aggregate it is a real miss, so those are excluded from _SIZE_SCALARS. This set is
+# wider than _PLACEHOLDER_TYPES on purpose: it is the GENEROSITY rule (which
+# spellings may match any same-width scalar), not a claim that every member fails to
+# name a type.
 _UNCOMMITTED_TYPES = re.compile(
     r"^\s*(?:"
     r"undefined\d*"
@@ -367,10 +390,14 @@ def _parse_variable_die(
     for t in type_names:
         all_forms.update(normalize_type(t))
 
+    # SORTED, not list(set(...)): this payload goes into the type_match cache key
+    # via stable_hash -> json.dumps, which orders dict keys but not list elements.
+    # A set's iteration order depends on PYTHONHASHSEED, so unsorted lists made
+    # the key differ between processes and ~77% of the disk cache went unread.
     return {
         "name": name,
-        "type": list(all_forms),
-        "rbp_offset": list(set(offsets)),
+        "type": sorted(all_forms),
+        "rbp_offset": sorted(set(offsets)),
         "size": size,
         "is_arg": is_arg,
         "arg_index": arg_index if is_arg else None,
@@ -813,7 +840,7 @@ class TypeMatchMetric(Metric):
     display_name = "Type Correctness"
     description = "Accuracy of variable type recovery vs DWARF ground truth"
 
-    cache_version = "5"
+    cache_version = "6"
 
     weight = 1.0
     lower_is_better = False

--- a/decbench/pipeline/executor.py
+++ b/decbench/pipeline/executor.py
@@ -13,10 +13,29 @@ from decbench.pipeline.compile import compile_projects
 from decbench.pipeline.decompile import decompile_projects
 from decbench.pipeline.evaluate import evaluate_projects
 from decbench.scoring.scoreboard import build_scoreboard_from_function_data
-from decbench.utils.langs import PREPROC_EXTS
+from decbench.utils.langs import preprocessed_by_stem, strip_source_ext
 
 if TYPE_CHECKING:
     from decbench.models.scoreboard import Scoreboard
+
+
+def keep_sources_of_retained_binaries(project: Project, opt: OptimizationLevel) -> None:
+    """Drop preprocessed sources whose binary was cut by ``--binary-limit``/``--binary-sample``.
+
+    The two key shapes differ between C and C++: a C unit's preprocessed stem is
+    ``foo`` (from ``foo.i``) but CMake makes a C++ one ``db_impl.cc`` (from
+    ``db_impl.cc.ii``), which can never equal a binary stem. Comparing raw stems
+    therefore emptied the dict for every C++ project, and the run scored zero
+    functions with no error at all.
+    """
+    if opt not in project.preprocessed_sources:
+        return
+    keep = {b.stem for b in project.compiled_binaries.get(opt, [])}
+    project.preprocessed_sources[opt] = {
+        name: path
+        for name, path in project.preprocessed_sources[opt].items()
+        if strip_source_ext(name) in keep
+    }
 
 
 class PipelineConfig(BaseModel):
@@ -153,13 +172,7 @@ class PipelineExecutor:
                                 f"Limited to {self.config.binary_limit} binaries "
                                 f"for {project.name}/{opt.value}"
                             )
-                    if opt in project.preprocessed_sources:
-                        limited_names = {b.stem for b in project.compiled_binaries.get(opt, [])}
-                        project.preprocessed_sources[opt] = {
-                            name: path
-                            for name, path in project.preprocessed_sources[opt].items()
-                            if name in limited_names
-                        }
+                    keep_sources_of_retained_binaries(project, opt)
 
         if self.config.binary_sample is not None:
             import random
@@ -177,13 +190,7 @@ class PipelineExecutor:
                                 f"Sampled {self.config.binary_sample} binaries "
                                 f"for {project.name}/{opt.value}: {names}"
                             )
-                    if opt in project.preprocessed_sources:
-                        sampled_names = {b.stem for b in project.compiled_binaries.get(opt, [])}
-                        project.preprocessed_sources[opt] = {
-                            name: path
-                            for name, path in project.preprocessed_sources[opt].items()
-                            if name in sampled_names
-                        }
+                    keep_sources_of_retained_binaries(project, opt)
 
         if not self.config.skip_decompile:
             print(f"Decompiling with {self.config.decompilers or 'all'} decompilers...")
@@ -323,9 +330,7 @@ class PipelineExecutor:
                 else:
                     print(f"Warning: no ELF binaries found in {compiled_dir}")
 
-                i_files = {
-                    f.stem: f for ext in PREPROC_EXTS for f in sorted(compiled_dir.glob(f"*{ext}"))
-                }
+                i_files = preprocessed_by_stem(compiled_dir)
                 if i_files:
                     project.preprocessed_sources[opt] = i_files
                     print(

--- a/decbench/utils/langs.py
+++ b/decbench/utils/langs.py
@@ -10,8 +10,12 @@ tuples instead.
 
 from __future__ import annotations
 
+import logging
 import os
+from collections.abc import Iterable
 from pathlib import Path
+
+_l = logging.getLogger(__name__)
 
 C_SOURCE_EXTS = (".c",)
 CXX_SOURCE_EXTS = (".cc", ".cpp", ".cxx", ".c++", ".C")
@@ -46,3 +50,55 @@ def strip_source_ext(name: str) -> str:
     """
     stem, ext = os.path.splitext(name)
     return stem if ext in SOURCE_EXTS else name
+
+
+def preprocessed_by_stem(directory: Path | str) -> dict[str, Path]:
+    """Every preprocessed translation unit in ``directory``, keyed by file stem.
+
+    Globs BOTH extensions. A collection site that hard-codes ``*.i`` finds
+    nothing at all in a C++ project's ``compiled/`` (which holds ``*.ii``) and
+    then reports "no sources" instead of an error, so every source-side metric
+    silently abstains. Collisions (``parser.i`` beside ``parser.ii``, both stem
+    ``parser``) keep the first in ``PREPROC_EXTS`` order and warn.
+    """
+    directory = Path(directory)
+    out: dict[str, Path] = {}
+    if not directory.is_dir():
+        return out
+    for ext in PREPROC_EXTS:
+        for path in sorted(directory.glob(f"*{ext}")):
+            if path.stem in out:
+                _l.warning(
+                    "preprocessed stem collision in %s: %s is shadowed by %s",
+                    directory,
+                    path.name,
+                    out[path.stem].name,
+                )
+                continue
+            out[path.stem] = path
+    return out
+
+
+def build_stem_index(stems: Iterable[str]) -> dict[str, str]:
+    """``{strip_source_ext(stem): stem}``, warning on any collision.
+
+    ``main.cc`` and ``main.cpp`` both strip to ``main``, so a naive dict
+    comprehension drops one translation unit and every function defined in it
+    is silently excluded from the run. No shipped project mixes languages in
+    one directory, so this is a guard rather than a fix: the first stem in
+    sorted order wins and the loss is logged instead of being invisible.
+    """
+    index: dict[str, str] = {}
+    for stem in sorted(stems):
+        key = strip_source_ext(stem)
+        if key in index:
+            _l.warning(
+                "source-stem collision on %r: %r is shadowed by %r; functions "
+                "declared in it will not be matched",
+                key,
+                stem,
+                index[key],
+            )
+            continue
+        index[key] = stem
+    return index

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -143,9 +143,13 @@ Three things are worth knowing before reading a C++ number:
   iterator class) all collapse onto whichever body won the per-name reduction.
   Rank C++ targets against each other; do not read leveldb's GED next to
   grep's. Qualified-name keying is the fix and is not implemented.
-- **Not publishable to the dataset yet.** The publish/dataset paths still glob
-  only `*.i`, so a C++ project's source CFGs never make it into the exported
-  tree (see metrics.md for the file list).
+- **Not publishable to the dataset yet.** Four files still glob only `*.i` —
+  `publish/cfg_export.py`, `publish/layout.py`, `dataset.py`, and
+  `scripts/compute_dataset_info.py` — so a C++ project's source CFGs never make
+  it into the exported tree. Every *evaluation* collection site now globs both
+  extensions via `utils/langs.py preprocessed_by_stem`;
+  `tests/test_cpp_support.py` pins that list, so adding a fifth `*.i`-only glob
+  fails the suite.
 
 CMake-based C++ TOMLs have two traps worth copying from leveldb's: leave
 `CMAKE_BUILD_TYPE` **empty** (a named type appends its own `-O` flag AFTER
@@ -379,6 +383,18 @@ coverage (`--allow-drops` / `DECBENCH_ALLOW_DROPS=1` overrides;
 `--audit` scans checkpoints/artifacts/overlays/published for silent gaps.
 After adding a decompiler, refresh the overlays and re-finalize before
 publishing.
+
+**A reeval can only fix what the checkpoint recorded.** `reeval_typematch.py`
+recomputes the METRIC from `FunctionDecompilation.variables`; it cannot repair a
+backend that stored the wrong thing. The live case: PR #60 fix 3 corrected IDA's
+`arg_index` from Hex-Rays allocation order to `cfunc.argidx`, but every
+`checkpoints/*.pkl` in `results/full_run` was written BEFORE that fix and still
+carries the scrambled indices, so re-scoring from checkpoints reproduces the old
+IDA numbers exactly. **The published IDA type_match column can only be corrected
+by re-running IDA** (`run_benchmark.py ... --decompilers ida`, then refresh the
+overlays and finalize). The same reasoning applies to any future backend-side
+fix: ask whether the change is in the metric (reeval is enough) or in what the
+decompiler recorded (re-run required).
 
 ```bash
 # Recompute ONLY byte_match over an existing tree WITHOUT re-decompiling

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,6 +38,17 @@ chooses the temp-file suffix from the input (`.ii` -> `.cpp`, `.i` -> `.c`)
 via `temp_parse_suffix`. Handing a `.ii` to Joern as `.c` scores nothing at
 all (measured on a leveldb TU: 0 functions as `.c`, 393 as `.cpp`).
 
+Every collection site therefore globs BOTH extensions through
+`utils/langs.py preprocessed_by_stem` — `pipeline/executor.py`,
+`evalkit/ingest.py`, `scripts/reeval_ged.py`, `scripts/run_small.py`,
+`scripts/cps_compile_smoke.py`. A site that hard-codes `*.i` does not error on a
+C++ project; it reports "no sources" and every source-side metric silently
+abstains, which is how `scripts/reeval_ged.py` produced a `ged_new.json` with no
+C++ entries at all. The **only** remaining `*.i`-only globs are the
+dataset/publish family — `publish/cfg_export.py`, `publish/layout.py`,
+`dataset.py`, `scripts/compute_dataset_info.py` — which is why a C++ project is
+not publishable to the dataset yet (see benchmarking.md).
+
 byte_match/type_match don't use the preprocessed units
 (`requires_source_cfg = False`; gcc-recompile and DWARF respectively), and
 sample source extraction only *falls back* to them. So do NOT disable
@@ -73,12 +84,21 @@ Compares decompiled variable types against DWARF ground truth (read via
 pyelftools). Works at **all opt levels**: ground truth keeps every variable
 with ANY DWARF location
 (register loclists included; only fully optimized-out vars are dropped).
-Current `cache_version="5"`, bumped for the pointer-`TYPE_MAP` rule below — the
-only one of the three normalization rules that changes an existing C value. The
+Current `cache_version="6"`, bumped for the narrowed pointee rule below — the
+only one of the normalization rules that changes an existing C value. The
 per-function key covers the decompiled variables and the DWARF ground truth but
 NOT `normalize_type`, so only a normalization change can serve stale values;
 a change to what DWARF yields mints a new key on its own and must NOT bump
 (see [Metric caching](#metric-caching)).
+
+**The ground-truth payload must be ORDER-STABLE.** `_parse_variable_die` returns
+`type` and `rbp_offset` as SORTED lists. They land in the cache key through
+`stable_hash` → `json.dumps(sort_keys=True)`, which orders dict keys but not list
+elements, so building them with `list(set(...))` made the key depend on
+`PYTHONHASHSEED` and the disk cache mostly missed across processes (measured on
+bzip2/ghidra, 108 functions: cold 5 hits / 103 misses, then a second process at
+the default random seed 25/83 and a third 51/57 — versus 108/0 with sorted
+lists). Any new list in that payload must be sorted too.
 
 Unified 3-pass matching against `FunctionDecompilation.variables`:
 
@@ -105,14 +125,45 @@ change any C value.
 
 A type matches when the ground-truth and decompiled form SETS intersect, so
 `normalize_type` returns every equivalent spelling of one type string. Adding a
-form can only ever create a match, never destroy one — an audit over leveldb
-plus zlib/bzip2/grep/coreutils (30k+ function×decompiler pairs) found zero
-per-function score decreases from the normalization rules below.
+form can only ever create a match, never destroy one; *removing* a rule (as the
+pointee narrowing below does) can only destroy matches. Both directions are
+scoring-policy changes and must bump `cache_version`.
 
-- **`TYPE_MAP` applies through pointers.** `int4 *` normalizes to `int*`
-  exactly as the scalar `int4` normalizes to `int`. No new equivalence is
-  declared: the pointee is looked up in the same table, so `int4 *` still does
-  not match `long long*`, and a scalar never becomes a pointer.
+- **`TYPE_MAP` applies through pointers, but only for COMMITTED pointees.**
+  `int4 *` normalizes to `int*` exactly as the scalar `int4` normalizes to
+  `int`, and `size_t *` to `long long*`. **This does declare new equivalences**
+  — every same-width, sign-agnostic pair the scalar table already equates now
+  also holds one indirection out (`int32_t*` ↔ `int*`, `int64_t*` ↔ `size_t*`,
+  `uchar *` ↔ `unsigned char*`). Enumerated over the C corpus (838 binary×opt
+  slices, 3,693 decompiled and 3,102 ground-truth spellings), the rule turns
+  **152 (decompiled, ground-truth) spelling pairs from a miss into a match**;
+  the earlier claim that it "declares no new equivalence" was false.
+
+  What it must NOT do is credit a *non-recovery*. `_POINTEE_MAP` therefore
+  excludes the nine TYPE_MAP rows that name a WIDTH rather than a type —
+  `undefined`/`undefined1`/`undefined2`/`undefined4`/`undefined8` (Ghidra's and
+  kuna's `TYPE_UNKNOWN`) and `_BYTE`/`_WORD`/`_DWORD`/`_QWORD` (Hex-Rays'
+  unknown-width slots). `undefined8 *` is "pointer to 8 unknown bytes" and stays
+  a **miss** against `size_t*`, matching `_uncommitted_size`'s rule that a
+  width-only spelling against a pointer is a real miss. Routing the whole table
+  through the pointer instead (the state between PRs #60 and #65) declared 203
+  pairs equal, 51 of them with a placeholder pointee.
+
+  The excluded set is deliberately NARROWER than `_UNCOMMITTED_TYPES`, which is
+  a *generosity* rule (which spellings may match any same-width scalar) rather
+  than a claim that its members fail to name a type. IDA's `__int8`, Ghidra's
+  `uchar`, and kuna's `int4`/`int8` are committed integer spellings — each of
+  those decompilers emits a *separate* placeholder for an unrecovered slot
+  (`_BYTE`, `undefined1`, and kuna's `xunknown4`, which prints as `undefined4`),
+  so choosing the named spelling is evidence of a real recovery. Excluding them
+  as well would cost IDA 9 of its 37 perfect functions on grep (mean −0.033)
+  for no gain in correctness.
+
+  Both sides of the comparison go through `normalize_type`, so the rule applies
+  to the DWARF payload as well. On C that is measurably a no-op: `_parse_type_die`
+  already walks the whole typedef chain and returns every name, so a ground-truth
+  `size_t*` already carries `long unsigned int*` → `long long*`. The ground-truth
+  payload hash is **identical with and without the rule on all 690 C binaries**.
 - **C++ namespace qualifiers are stripped.** DWARF records a class or typedef
   under its UNQUALIFIED `DW_AT_name` (`TableBuilder`), so a decompiler printing
   `leveldb::TableBuilder *` needs the qualifier dropped to reach ground truth.
@@ -218,6 +269,12 @@ over seen (decompiled, source) pairs skip recomputation.
   are pinned and a needless bump forces a corpus-wide recompute. The C++
   `DW_AT_specification` chase is the worked example — see
   [DWARF reference chains](#dwarf-reference-chains-c-vs-c).
+- **Keep every key input order-stable.** `stable_hash` canonicalizes through
+  `json.dumps(sort_keys=True)`, which orders dict keys but NOT list elements, so
+  a `list(set(...))` anywhere in a key input makes the key depend on
+  `PYTHONHASHSEED` and the cache misses across processes while still being
+  fail-safe (a miss just recomputes). Sort such lists at construction, and pin
+  `PYTHONHASHSEED` when measuring cache behaviour.
 - Cache root: `DECBENCH_CACHE_DIR`; disable entirely with
   `DECBENCH_NO_CACHE=1`.
 

--- a/projects/cpp/disabled/leveldb.toml
+++ b/projects/cpp/disabled/leveldb.toml
@@ -49,9 +49,13 @@ pre_make_cmds = [
 # The `rm` drops CMake's compiler-probe binaries (a.out,
 # CMakeDetermineCompilerABI_*.bin), which are real ELF executables under
 # build/CMakeFiles/<cmake-version>/ and would otherwise be collected as targets.
-# It lives in make_cmd because ProjectConfig.post_make_cmds is declared but never
-# executed by pipeline/compile.py.
-make_cmd = 'cmake --build build -j && rm -rf build/CMakeFiles/3.*'
+# That directory is named after the CMake VERSION, so the glob must not hard-code
+# a major: CMake 4.x writes build/CMakeFiles/4.0.x/, which a `3.*` glob leaves in
+# place, silently adding the probes to the benchmark. `[0-9]*` is the version
+# directories and nothing else. It lives in make_cmd because
+# ProjectConfig.post_make_cmds is declared but never executed by
+# pipeline/compile.py.
+make_cmd = 'cmake --build build -j && rm -rf build/CMakeFiles/[0-9]*'
 
 labels = ["cpp", "library", "database", "key-value-store"]
 

--- a/scripts/cps_compile_smoke.py
+++ b/scripts/cps_compile_smoke.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from decbench.models.project import Project
 from decbench.pipeline.compile import compile_project
+from decbench.utils.langs import preprocessed_by_stem
 
 _EM = {0x28: "ARM", 0xB7: "AArch64", 0x3E: "x86-64", 0x03: "x86"}
 
@@ -56,7 +57,7 @@ def main() -> int:
             elfs[m] = elfs.get(m, 0) + 1
             if m in ("ARM", "AArch64"):
                 arm_bins.append(entry.name)
-    i_files = list(compiled.glob("*.i")) if compiled.is_dir() else []
+    i_files = list(preprocessed_by_stem(compiled).values())
 
     ok = sum(1 for r in results if r.success)
     print(f"compile results: {ok} ok / {len(results)} total")

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -28,6 +28,10 @@ import pickle
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from decbench.utils.langs import preprocessed_by_stem  # noqa: E402
+
 DECOMPILERS = (
     "angr",
     "ghidra",
@@ -71,7 +75,7 @@ def build_source_cfgs(root: Path, projects: list[str], workers: int) -> Path:
             continue
         ifiles = [
             str(f)
-            for f in sorted(comp.glob("*.i"))
+            for f in preprocessed_by_stem(comp).values()
             if "conftest" not in f.name and not f.name.startswith("a-")
         ]
         if ifiles:

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -45,7 +45,7 @@ from decbench.results_store import PROJECT_DIRS  # noqa: F401,E402
 from decbench.results_store import gather_project_tomls as gather_tomls
 from decbench.utils import binfmt  # noqa: E402
 from decbench.utils.cfg import extract_cfgs_from_source
-from decbench.utils.langs import strip_source_ext  # noqa: E402
+from decbench.utils.langs import build_stem_index, strip_source_ext  # noqa: E402
 
 OPT_LEVELS = [
     OptimizationLevel.O0,
@@ -176,7 +176,7 @@ def project_source_functions(
         return {}
     addr2name: dict[int, str] = {}
     file_tables: dict[int, list] = {}
-    stem_index = {strip_source_ext(s): s for s in source_stems}
+    stem_index = build_stem_index(source_stems)
     try:
         for cu in dw.iter_CUs():
             for die in cu.iter_DIEs():

--- a/scripts/run_small.py
+++ b/scripts/run_small.py
@@ -50,6 +50,7 @@ from decbench.scoring.function_data_builder import build_function_data  # noqa: 
 from decbench.scoring.report_extras import attach_extras  # noqa: E402
 from decbench.scoring.scoreboard import build_scoreboard, render_scoreboard_text  # noqa: E402
 from decbench.utils.cfg import extract_cfgs_from_source  # noqa: E402
+from decbench.utils.langs import preprocessed_by_stem  # noqa: E402
 
 
 def _is_elf(path: Path) -> bool:
@@ -67,7 +68,7 @@ def _is_elf(path: Path) -> bool:
 
 def _discover(compiled: Path) -> tuple[list[Path], dict[str, Path]]:
     binaries = sorted(p for p in compiled.iterdir() if p.is_file() and _is_elf(p))
-    sources = {p.stem: p for p in sorted(compiled.glob("*.i"))}
+    sources = preprocessed_by_stem(compiled)
     return binaries, sources
 
 

--- a/tests/test_cpp_support.py
+++ b/tests/test_cpp_support.py
@@ -138,3 +138,114 @@ def test_cu_is_cxx_distinguishes_the_languages(tmp_path: Path) -> None:
     c = _build(tmp_path, "h.c", C_SRC, "gcc", "-O0")
     assert all(binfmt.cu_is_cxx(d.cu) for d in _subprograms(cxx))
     assert not any(binfmt.cu_is_cxx(d.cu) for d in _subprograms(c))
+
+
+def test_preprocessed_by_stem_finds_both_extensions(tmp_path: Path) -> None:
+    """A collection site that globs only ``*.i`` sees nothing in a C++ tree."""
+    from decbench.utils.langs import preprocessed_by_stem
+
+    assert preprocessed_by_stem(tmp_path / "missing") == {}
+    (tmp_path / "grep.i").write_text("")
+    (tmp_path / "db_impl.cc.ii").write_text("")
+    (tmp_path / "notes.txt").write_text("")
+    assert preprocessed_by_stem(tmp_path) == {
+        "grep": tmp_path / "grep.i",
+        "db_impl.cc": tmp_path / "db_impl.cc.ii",
+    }
+
+
+def test_preprocessed_by_stem_warns_on_a_shadowed_unit(tmp_path: Path, caplog) -> None:
+    """``parser.i`` and ``parser.ii`` share a stem; the loss must not be silent."""
+    import logging
+
+    from decbench.utils.langs import preprocessed_by_stem
+
+    (tmp_path / "parser.i").write_text("")
+    (tmp_path / "parser.ii").write_text("")
+    with caplog.at_level(logging.WARNING):
+        found = preprocessed_by_stem(tmp_path)
+    assert found == {"parser": tmp_path / "parser.i"}
+    assert "collision" in caplog.text
+
+
+def test_build_stem_index_warns_instead_of_dropping_silently(caplog) -> None:
+    """``main.cc`` and ``main.cpp`` both strip to ``main``."""
+    import logging
+
+    from decbench.utils.langs import build_stem_index
+
+    assert build_stem_index(["grep", "db_impl.cc"]) == {"grep": "grep", "db_impl": "db_impl.cc"}
+    with caplog.at_level(logging.WARNING):
+        index = build_stem_index(["main.cc", "main.cpp"])
+    assert index == {"main": "main.cc"}
+    assert "collision" in caplog.text
+
+
+def test_binary_limit_keeps_a_cxx_projects_sources(tmp_path: Path) -> None:
+    """--binary-limit/--binary-sample must not empty preprocessed_sources.
+
+    The keys are ``db_impl.cc`` (from ``db_impl.cc.ii``) and can never equal a
+    binary stem, so comparing raw stems dropped every C++ source and the project
+    scored zero functions with no error.
+    """
+    from decbench.models.project import OptimizationLevel, Project, ProjectConfig
+    from decbench.pipeline.executor import keep_sources_of_retained_binaries
+
+    opt = OptimizationLevel.O2
+    project = Project(
+        name="leveldb",
+        config=ProjectConfig(name="leveldb", repo_url="https://example.invalid/leveldb"),
+    )
+    project.compiled_binaries[opt] = [tmp_path / "db_impl", tmp_path / "grep"]
+    project.preprocessed_sources[opt] = {
+        "db_impl.cc": tmp_path / "db_impl.cc.ii",
+        "grep": tmp_path / "grep.i",
+        "version_set.cc": tmp_path / "version_set.cc.ii",
+    }
+
+    keep_sources_of_retained_binaries(project, opt)
+
+    assert set(project.preprocessed_sources[opt]) == {"db_impl.cc", "grep"}
+
+
+def test_every_source_collection_site_globs_both_extensions() -> None:
+    """No `*.i`-only glob outside the dataset/publish family.
+
+    Those four are C-only by disclosure (docs/benchmarking.md); anywhere else a
+    hard-coded ``*.i`` means a C++ project silently gets no sources and no score.
+    """
+    import re
+
+    repo = Path(__file__).resolve().parent.parent
+    allowed = {
+        "decbench/publish/cfg_export.py",
+        "decbench/publish/layout.py",
+        "decbench/dataset.py",
+        "scripts/compute_dataset_info.py",
+    }
+    pattern = re.compile(r"""glob\(\s*["']\*\.i["']""")
+    offenders = set()
+    for path in sorted(repo.rglob("*.py")):
+        rel = path.relative_to(repo).as_posix()
+        if rel.startswith(("tests/", ".venv/", "build/")):
+            continue
+        if pattern.search(path.read_text(errors="replace")):
+            offenders.add(rel)
+    extra = sorted(offenders - allowed)
+    assert not extra, f"undisclosed .i-only collection sites: {extra}"
+
+
+def test_leveldb_cmake_probe_cleanup_is_version_agnostic() -> None:
+    """CMake 4.x writes build/CMakeFiles/4.0.x/, so a `3.*` glob leaves its
+    compiler-probe binaries in the tree as benchmark targets."""
+    repo = Path(__file__).resolve().parent.parent
+    candidates = [
+        repo / "projects/cpp/leveldb.toml",
+        repo / "projects/cpp/disabled/leveldb.toml",
+    ]
+    toml_path = next((p for p in candidates if p.is_file()), None)
+    if toml_path is None:
+        pytest.skip("leveldb.toml not present")
+    text = toml_path.read_text()
+    assert "CMakeFiles/3." not in text
+    assert "rm -rf build/CMakeFiles/[0-9]*" in text

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -597,24 +597,125 @@ int main() {
         assert result.metadata["matched_by"] == "structured"
         assert result.metadata["tp"] == 1
 
-    def test_type_map_reaches_pointer_spellings(self) -> None:
+    def test_type_map_reaches_committed_pointer_spellings(self) -> None:
         """``int4 *`` must normalize like ``int4`` does, one indirection out."""
         from decbench.metrics.type_match import normalize_type
 
         assert "int*" in normalize_type("int4 *")
         assert "int*" in normalize_type("int4*")
-        assert "long long*" in normalize_type("undefined8 *")
-        assert "char**" in normalize_type("undefined1 **")
+        assert "long long*" in normalize_type("size_t *")
+        assert "char**" in normalize_type("uint8_t **")
         # An unmapped pointee is left exactly as it was.
         assert normalize_type("Slice *") == {"Slice *", "Slice*"}
 
     def test_pointer_normalization_does_not_cross_widths(self) -> None:
-        """The pointee mapping declares no new equivalence: ``int4 *`` is not
-        ``long long*``, and a scalar never becomes a pointer."""
+        """``int4 *`` is not ``long long*``, and a scalar never becomes a pointer."""
         from decbench.metrics.type_match import normalize_type
 
         assert "long long*" not in normalize_type("int4 *")
         assert not any("*" in f for f in normalize_type("int4"))
+
+    def test_placeholder_pointees_are_never_mapped(self) -> None:
+        """A pointer to N UNKNOWN bytes is not a recovery of a committed type.
+
+        ``undefinedN`` (Ghidra/kuna TYPE_UNKNOWN) and ``_BYTE``/``_WORD``/
+        ``_DWORD``/``_QWORD`` (Hex-Rays unknown-width slots) are the only
+        TYPE_MAP rows excluded from the pointee mapping; every other row names a
+        committed C type and is mapped.
+        """
+        from decbench.metrics.type_match import _POINTEE_MAP, TYPE_MAP, normalize_type
+
+        assert set(TYPE_MAP) - set(_POINTEE_MAP) == {
+            "undefined",
+            "undefined1",
+            "undefined2",
+            "undefined4",
+            "undefined8",
+            "_BYTE",
+            "_WORD",
+            "_DWORD",
+            "_QWORD",
+        }
+        for form in ("undefined8 *", "_QWORD *", "_BYTE *", "undefined *", "undefined1 **"):
+            assert normalize_type(form) == {form, form.replace(" ", "")}
+        # The scalar rows are untouched -- only the POINTER spelling is excluded.
+        assert "long long" in normalize_type("undefined8")
+        assert "int" in normalize_type("_DWORD")
+
+    def test_uncommitted_pointer_is_a_miss_against_ground_truth(self) -> None:
+        """End to end: ``undefined8 *`` must not score as a recovery of ``size_t *``."""
+        from decbench.metrics.type_match import TypeMatchMetric, normalize_type
+
+        # The DWARF payload is normalized at extraction time, so normalize here too.
+        gt_vars = [
+            {
+                "name": "n",
+                "type": sorted(normalize_type("size_t*")),
+                "is_arg": True,
+                "arg_index": 0,
+            }
+        ]
+
+        def score(decompiled_type: str) -> float:
+            func = FunctionDecompilation(
+                name="f",
+                address=0x1000,
+                decompiled_code="// no decls",
+                variables=[VariableInfo(name="a1", type=decompiled_type, kind="arg", arg_index=0)],
+            )
+            return TypeMatchMetric().compute_for_function(func, ground_truth_vars=gt_vars).value
+
+        assert score("undefined8 *") == 0.0
+        assert score("_QWORD *") == 0.0
+        # ... while a committed spelling of the same type still matches.
+        assert score("size_t *") == 1.0
+        assert score("unsigned long long *") == 1.0
+
+    def test_ground_truth_payload_is_hash_seed_independent(self, tmp_path) -> None:
+        """The DWARF payload feeds the metric cache key through ``stable_hash``,
+        which sorts dict keys but NOT list elements. Unsorted lists made the key
+        depend on ``PYTHONHASHSEED``, so the disk cache mostly missed across
+        processes."""
+        import os
+        import shutil
+        import subprocess
+        import sys
+
+        cc = shutil.which("cc") or shutil.which("gcc")
+        if cc is None:
+            pytest.skip("no C compiler available")
+
+        src = tmp_path / "t.c"
+        src.write_text(
+            "#include <stddef.h>\n"
+            "int helper(int first, char *second, size_t third) {\n"
+            "    long fourth = first * 2;\n"
+            "    unsigned char fifth = (unsigned char)third;\n"
+            "    return fourth + (second != 0) + fifth;\n"
+            "}\n"
+            "int main(int argc, char **argv) { return helper(argc, argv[0], 1); }\n"
+        )
+        binary = tmp_path / "t"
+        subprocess.run([cc, "-g", "-O0", "-o", str(binary), str(src)], check=True)
+
+        prog = (
+            "import json,sys;"
+            "from decbench.caching import stable_hash;"
+            "from decbench.metrics.type_match import extract_ground_truth_types;"
+            "print(stable_hash(extract_ground_truth_types(sys.argv[1])))"
+        )
+        digests = set()
+        for seed in ("0", "1", "12345"):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            out = subprocess.run(
+                [sys.executable, "-c", prog, str(binary)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            digests.add(out.stdout.strip())
+        assert len(digests) == 1, f"ground-truth hash varies with PYTHONHASHSEED: {digests}"
 
     def test_namespace_qualifier_is_stripped(self) -> None:
         """DWARF's ``DW_AT_name`` is unqualified, so IDA's ``leveldb::X *``


### PR DESCRIPTION
An adversarial audit of the two merged PRs (#59 C++ support, #60 C++ type_match
artifacts) found one **scoring-policy defect** plus four correctness/disclosure
gaps. All are fixed here. Every fix ships a regression test; **all 9 new tests
fail on `origin/main`**.

All numbers below were re-measured from the frozen `results/full_run/checkpoints`
with `DECBENCH_NO_CACHE=1` and `PYTHONHASHSEED=0` (the seed pin matters — see
finding 9). `results/full_run` was read only.

---

## Finding 1 — the pointee mapping over-declared equivalence (HIGH)

`_map_pointee` looked the pointee up in the **whole** `TYPE_MAP`, so Ghidra's
`undefined8 *` ("pointer to 8 unknown bytes") matched DWARF's `size_t*`, IDA's
`_QWORD *` matched `long int*`, and `_BYTE *`/`undefined1 *`/`undefined *`
matched `char*`. That credits a *non-recovery* as a recovery and directly
contradicts the module's own `_uncommitted_size` policy ("a pointer spelling is a
committed type"; "against a pointer it is a real miss"). PR #60's commit message
and `docs/metrics.md` both said the rule "declares no new equivalence" — false.

### The new rule, stated exactly

> `_map_pointee` maps a pointee through `_POINTEE_MAP`, which is `TYPE_MAP` minus
> the nine rows that name a **width** rather than a type:
> `undefined`, `undefined1`, `undefined2`, `undefined4`, `undefined8` (Ghidra's
> and kuna's `TYPE_UNKNOWN`) and `_BYTE`, `_WORD`, `_DWORD`, `_QWORD` (Hex-Rays'
> unknown-width slots). Every other row names a committed C type and **is**
> mapped, so `int4 *` → `int*` and `size_t *` → `long long*`, exactly as the
> scalar table already equates `int4` ≡ `int` and `size_t` ≡ `long long`. The
> rule applies to both sides, because `normalize_type` is shared with the DWARF
> payload. **This does declare new equivalences** — the docs now say so.

`undefined8 *` and `_QWORD *` are now misses against `size_t*`.

### Re-run of the pair enumeration

Vocabulary co-occurrence over the C corpus (690 C binaries / 838 binary×opt
slices, 341,009 function×decompiler instances, 3,693 decompiled and 3,102
ground-truth raw spellings, 311,245 distinct pairs). A pair's "occurrences" is
the number of (decompiled var, ground-truth var) combinations in the same
function, summed over the corpus. The audit's 160 was measured on a smaller
slice; on this corpus the merged rule flips **203** pairs:

| rule | pairs MISS→MATCH | of which have a placeholder pointee |
|---|---|---|
| PR #60 as merged (whole `TYPE_MAP`) | 203 (211,579 occurrences) | **51** (66,676 occ.) |
| this PR (`_POINTEE_MAP`) | 152 (144,903 occ.) | **0** |

Every one of the 51 removed pairs has an `undefined*`/`_BYTE`/`_WORD`/`_DWORD`/
`_QWORD` pointee. The audit's offender table, row by row:

| decompiled | ground truth | verdict |
|---|---|---|
| `_QWORD *` (IDA) | `long int*`, `size_t*` | **dropped** |
| `undefined8 *` (Ghidra) | `long int*`, `size_t*` | **dropped** |
| `_BYTE *` / `undefined *` / `undefined1 *` | `char*`, `uint8_t*` | **dropped** |
| `char*` / `const char *` | `uint8_t*` | kept — see below |
| `int64_t*` | `long int*`, `size_t*` | kept — see below |
| `int8 *` (kuna) | `size_t*` | kept — see below |

### The arguable rows, decided with evidence

**`int64_t*` ≡ `long int*`/`size_t*` — kept.** Both are committed LP64 spellings
of the same width, and the metric already ignores signedness (`QUALIFIERS`
strips `unsigned`). The scalar table already declares `int64_t` ≡ `size_t` ≡
`long long`; refusing the same equivalence one indirection out would be
internally inconsistent.

**`char*` ≡ `uint8_t*` — kept, and it is nearly free.** `_parse_type_die` walks
the whole typedef chain, so a ground-truth `uint8_t*` already carries
`unsigned char*` → `char*` without any pointee mapping. This pair is loud in the
vocabulary enumeration (65k occurrences in the audit's count) and almost silent
end to end.

**`int8 *` (kuna) ≡ `size_t*` — kept; the audit is wrong that this is a
placeholder.** kuna's type factory registers `int1/int2/int4/int8` as `TYPE_INT`
core types and `xunknown1/2/4/8` as `TYPE_UNKNOWN`
(`kuna-decomp/src/infra/architecture.rs:2992-3007`), and kuna does emit
`undefined5/6/7` in this corpus. So `int8` is kuna's *committed* 8-byte integer —
the counterpart of Ghidra's `long`, not of its `undefined8`.

**I did not use `_UNCOMMITTED_TYPES` as the denylist, and the task's own text is
why.** The task said both "the narrow original intent was legitimate — `int4 *`
should normalize to `int *`" and "exclude anything `_UNCOMMITTED_TYPES` covers",
but that regex covers `u?int[1-8]`, so the second instruction deletes the first.
`_UNCOMMITTED_TYPES` is a **generosity** rule (which spellings may match any
same-width scalar), not a classification of "pseudo": it lists `uchar` and
`__int8`, which are Ghidra's and IDA's spellings of `unsigned char`. Each of
those decompilers emits a *separate* placeholder for an unrecovered slot
(`_BYTE`, `undefined1`), so choosing the named spelling is evidence of a real
recovery. I measured the strict variant anyway (`strict` column below): it costs
IDA 9 of its 37 perfect functions on grep (mean −0.033) and kuna 12 on zlib, for
no gain in correctness — it would score a demonstrably correct
`unsigned __int8 *` ≡ `unsigned char *` as a miss.

---

## Finding 2 — the C impact was understated (docs correction)

Reproduced exactly, then re-measured. Perfect functions (score = 1.0) per
(decompiler, project) over 70,999 function×decompiler pairs from
zlib/grep/gzip/bzip2/coreutils:

| decompiler / project | pre-#60 | main today | **this PR** | strict variant |
|---|---|---|---|---|
| kuna / zlib | 74 | 86 *(PR #60 said "+4")* | **86** | 74 |
| ida / grep | 28 | 41 *(PR #60 said "+8")* | **37** | 28 |
| ghidra / gzip | 58 | 65 | **58** | 58 |
| ida / gzip | 62 | 68 | **63** | 62 |
| binja / zlib | 110 | 115 | **115** | 115 |
| ghidra / grep | 35 | 37 | **36** | 36 |
| binja / grep | 40 | 42 | **42** | 42 |
| ida / bzip2 | 16 | 18 | **16** | 16 |
| ghidra / coreutils | 502 | 526 | **504** | 504 |
| ida / coreutils | 480 | 527 | **485** | 480 |
| kuna / coreutils | 466 | 483 | **483** | 468 |
| **corpus total** | **4814** | **4972** | **4889** | 4845 |

Corpus mean: `0.221968` → `0.227481` (main) → **`0.225339`** (this PR).
Largest per-function mean delta from the merged rule: ida/grep `0.2774 → 0.3331`
(**+0.056**), matching the audit; after narrowing it is `0.3118`.

Per-function movement:

| comparison | improved | worsened | mean delta |
|---|---|---|---|
| pre-#60 → main | 1,920 | 0 | +0.005513 |
| pre-#60 → this PR | 1,371 | 0 | +0.003372 |
| **main → this PR** | 0 | **575** | −0.002142 |

So this PR removes 575 of main's 1,920 per-function improvements and adds none.
That is a **scoring-policy change**, stated as such in `docs/metrics.md`.

**One audit sub-claim did not reproduce.** The audit reported that `_map_pointee`
"changes the DWARF GT payload on 136/190 C binaries". It does not: the
ground-truth payload hash is **identical with and without the rule on all 690 C
binaries**, and a form-set-level diff on zlib/example (806 vars), grep (2,215)
and coreutils/ls (1,609) shows **zero** changed variables. The reason is
mechanical — `_parse_type_die` already returns every name in a typedef chain, so
a ground-truth `size_t*` already carries `long unsigned int*` → `long long*`.
I suspect the 136/190 was an artifact of finding 9: with the pre-fix unsorted
payload, *any* cross-process hash comparison differs by `PYTHONHASHSEED`.

---

## Finding 3 — the "zero decreases" claim (docs correction)

`docs/metrics.md` scoped the sentence to the normalization rules, which held
(pre-#60 → this PR is 1,371 up / **0** down over 70,999 pairs). PR #60's *commit
message* generalized it across all four fixes, where the audit's counterexample
(`grep/O2-noinline is_device_mode 1.0 → 0.0`, from fix 3) makes it false. The
docs sentence is rewritten to say plainly that adding a form can only create a
match, that removing one (as this PR does) can only destroy matches, and that
both directions are policy changes that must bump `cache_version`. I did not
re-verify the fix-3 counterexample: the checkpoints carry pre-fix `arg_index`
(see the operational note), so it is not reproducible without re-running IDA.

---

## Finding 4 — C++ projects scored zero functions under `--binary-limit` (MEDIUM)

`executor.py:157,181` filtered `preprocessed_sources` by comparing its keys to
binary stems. The keys are `db_impl.cc` (from `db_impl.cc.ii`) and can never
equal a binary stem, so the dict emptied, `run_benchmark.py:169` returned `{}`,
and the project scored zero functions with no error. Both call sites now go
through one extracted helper, `keep_sources_of_retained_binaries`, which compares
through `strip_source_ext`.

## Finding 5 — undisclosed `*.i`-only collection sites (MEDIUM)

Fixed via a new `utils/langs.py preprocessed_by_stem` (globs both extensions,
warns on stem collisions): `scripts/reeval_ged.py:74` — the script that produced
`ged_new.json`, which is why that overlay has no C++ entries at all —
`evalkit/ingest.py:617`, `scripts/run_small.py:70`, `scripts/cps_compile_smoke.py:59`,
plus `executor.py`'s discovery map. The three **disclosed** dataset/publish sites
(`publish/cfg_export.py`, `publish/layout.py`, `dataset.py`) are left alone as
instructed; the docs now name them plus `scripts/compute_dataset_info.py`, an
eighth site the audit's list missed. `tests/test_cpp_support.py` pins that
allowlist, so a ninth `*.i`-only glob fails the suite.

## Finding 6 — silent stem-collision drops (LOW/MEDIUM, latent)

`build_stem_index` replaces the `{strip_source_ext(s): s for s in ...}`
comprehensions in `run_benchmark.py:179` and `evalkit/resolve.py:68`; the
`.i`/`.ii` shadowing at `executor.py:327` is handled by `preprocessed_by_stem`.
Behaviour is unchanged and deterministic (first in sorted / `PREPROC_EXTS` order
wins) — the loss is now **logged** instead of invisible.

## Finding 7 — leveldb's CMake probe cleanup (LOW)

`rm -rf build/CMakeFiles/3.*` → `rm -rf build/CMakeFiles/[0-9]*`. CMake 4.x
writes `build/CMakeFiles/4.0.x/`, so on cmake ≥ 4 the compiler-probe binaries
(`a.out`, `CMakeDetermineCompilerABI_*.bin`) silently became benchmark targets.
PR #64 moves this file to `projects/cpp/disabled/`; that is a pure rename, which
merges cleanly with a content edit, and the new test accepts either path.

## Finding 9 — the type_match cache key was hash-seed dependent (MEDIUM)

`_parse_variable_die` built `type` and `rbp_offset` with `list(set(...))`. That
payload is a cache key input via `stable_hash` → `json.dumps(sort_keys=True)`,
which orders dict *keys* but not list *elements*, so the key depended on
`PYTHONHASHSEED`. Both lists are now `sorted()`. Measured on bzip2/ghidra
(108 functions), same cache dir, three consecutive processes at the default
random seed:

| | run 1 (cold) | run 2 | run 3 |
|---|---|---|---|
| before | 5 hits / 103 misses | 25 / 83 | 51 / 57 |
| after | 5 / 103 | **108 / 0** | **108 / 0** |

Interaction with the version bump: sorting changes the key's **content**, which
already invalidates every stored entry on its own. The `cache_version` **5 → 6**
bump is for finding 1, which changes computed values without changing the key.
Both land together, so there is exactly one corpus-wide recompute.

---

## Operational consequence (recorded, not fixed)

`checkpoints/*.pkl` in `results/full_run` were written before PR #60's fix 3, so
they carry IDA's pre-fix `arg_index`. `scripts/reeval_typematch.py` recomputes the
*metric* from stored variables and cannot repair what the backend recorded —
**the published IDA type_match column can only be corrected by re-running IDA.**
This is now in `docs/benchmarking.md` beside the overlay/finalize flow, with the
general rule: ask whether a fix is in the metric (reeval suffices) or in what the
decompiler recorded (re-run required).

---

## Tests

Nine new tests, all failing on `origin/main`:

- `test_placeholder_pointees_are_never_mapped` — pins the exact 9-row exclusion set
- `test_uncommitted_pointer_is_a_miss_against_ground_truth` — `undefined8 *`/`_QWORD *` vs `size_t*` score 0.0; `size_t *`/`unsigned long long *` score 1.0
- `test_type_map_reaches_committed_pointer_spellings` — `int4 *` → `int*` still works
- `test_ground_truth_payload_is_hash_seed_independent` — same digest under `PYTHONHASHSEED` 0/1/12345 (verified to fail pre-fix: three different digests)
- `test_binary_limit_keeps_a_cxx_projects_sources`
- `test_preprocessed_by_stem_finds_both_extensions` / `..._warns_on_a_shadowed_unit`
- `test_build_stem_index_warns_instead_of_dropping_silently`
- `test_every_source_collection_site_globs_both_extensions`
- `test_leveldb_cmake_probe_cleanup_is_version_agnostic`

Gates: `462 passed, 5 failed, 7 skipped` — the same 5 pre-existing
`test_content.py` failures as `origin/main` (453 passed there). ruff **33** and
black **12 files**, both unchanged from the `origin/main` baseline.

## What I did NOT touch

Everything the audit verified as sound: the `cu_is_cxx` gate, fix 2
(`_strip_namespaces`), fix 3's `cfunc.argidx` mechanism, the reference-type arm,
the temp-file change, and the 4 → 5 `cache_version` bump. `results/full_run` was
read only; no overlay or published number was regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McQC7imaNfzj5k5AVumSYN
