### PR TITLE
Support building and scoring the corpus on a non-x86 host

### DIFF
--- a/decbench/compilers/gcc.py
+++ b/decbench/compilers/gcc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import struct
@@ -11,6 +12,8 @@ from pathlib import Path
 from decbench.compilers.base import Compiler, CompileResult
 from decbench.models.project import opt_gcc_flags
 from decbench.utils.langs import PREPROC_EXTS, SOURCE_EXTS, preprocessed_ext
+
+_l = logging.getLogger(__name__)
 
 # Build by-products that are never a linked binary, so they are skipped before
 # the (more expensive) ELF/PE sniff.
@@ -290,8 +293,9 @@ class GCCCompiler(Compiler):
                         timeout=600,
                         check=True,
                     )
-                except subprocess.CalledProcessError as e:
-                    pass
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                    # Not fatal, but silence hides a ./configure that died on a missing dep.
+                    _l.warning("pre-make command failed, continuing: %s", e)
 
         if make_command:
             try:
@@ -346,7 +350,7 @@ class GCCCompiler(Compiler):
                         if not dest_i.exists():
                             shutil.copy2(i_file, dest_i)
 
-            except subprocess.CalledProcessError as e:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 results.append(CompileResult(
                     source_path=project_dir,
                     success=False,

--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -265,8 +265,9 @@ class ByteMatchMetric(Metric):
         from decbench.utils import binfmt
 
         # Recompile the way the source was compiled (PE -> MinGW, ARM -> arm-none-eabi,
-        # x86 -> gcc, flags from the DWARF producer). Without that toolchain, return a
-        # non-scoring result rather than comparing against a wrong-arch recompile.
+        # host-native -> gcc, otherwise the cross triplet; flags from the DWARF producer).
+        # Without that toolchain, return a non-scoring result rather than comparing
+        # against a wrong-arch recompile.
         info = binfmt.detect(original_binary_path)
         if info is None:
             return MetricValue(value=0.0, metadata={"error": "Unrecognized binary format"})

--- a/decbench/models/function_data.py
+++ b/decbench/models/function_data.py
@@ -184,6 +184,10 @@ class BinaryGroup(BaseModel):
         default_factory=list,
         description="Labels applied to this binary",
     )
+    arch: str | None = Field(
+        default=None,
+        description="Detected machine architecture (e.g. 'x86-64'); None if not recorded",
+    )
     functions: list[FunctionRecord] = Field(
         default_factory=list,
         description="Per-function records for this binary",

--- a/decbench/pipeline/compile.py
+++ b/decbench/pipeline/compile.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
@@ -14,6 +15,25 @@ from decbench.utils.langs import SOURCE_EXTS
 
 if TYPE_CHECKING:
     from decbench.compilers.base import CompileResult
+    from decbench.models.project import CompilationConfig
+
+
+_HOST_CC = "gcc"
+
+
+def corpus_target(compilation: CompilationConfig) -> tuple[str, str | None]:
+    """Resolve the (compiler, target_arch) pair: environment first, project TOML second.
+
+    Only projects that declare the host compiler are retargeted. Anything naming
+    its own cross toolchain (CPS, the MinGW malware targets) is left alone;
+    ``mirai`` declares plain ``gcc`` and follows sailr.
+    """
+    if compilation.c_compiler != _HOST_CC:
+        return compilation.c_compiler, compilation.target_arch
+    return (
+        os.environ.get("DECBENCH_CC") or compilation.c_compiler,
+        os.environ.get("DECBENCH_TARGET_ARCH") or compilation.target_arch,
+    )
 
 
 def download_source(project: Project, target_dir: Path) -> Path:
@@ -147,10 +167,11 @@ def compile_project(
                     check=False,
                 )
 
+        gcc_path, target_arch = corpus_target(compilation)
         compiler = GCCCompiler(
-            gcc_path=compilation.c_compiler,
+            gcc_path=gcc_path,
             base_flags=compilation.base_flags + compilation.extra_flags,
-            target_arch=compilation.target_arch,
+            target_arch=target_arch,
         )
 
         results = compiler.compile_project(

--- a/decbench/scoring/datasets.py
+++ b/decbench/scoring/datasets.py
@@ -90,10 +90,13 @@ _O2_NOINLINE = "O2-noinline"
 _O0 = "O0"
 
 _ARM_LABELS = frozenset({"cps", "arm", "armv7", "aarch64", "arm64", "bare-metal", "embedded-linux"})
+_ARM_ARCHES = frozenset({"arm", "aarch64"})
 
 
 def _is_arm(group: BinaryGroup) -> bool:
-    """Whether a binary group was cross-compiled for a non-x86 (ARM) target."""
+    """Whether a binary group is an ARM target; labels are the pre-``arch`` fallback."""
+    if group.arch:
+        return group.arch in _ARM_ARCHES
     labels = group.labels or []
     return any(label in _ARM_LABELS or label.startswith("cortex-") for label in labels)
 

--- a/decbench/scoring/function_data_builder.py
+++ b/decbench/scoring/function_data_builder.py
@@ -12,6 +12,7 @@ from decbench.scoring.labels import (
     binary_labels_for,
     function_labels_for,
 )
+from decbench.utils import binfmt
 
 if TYPE_CHECKING:
     from decbench.models.decompilation import DecompilationResult
@@ -132,6 +133,15 @@ def _dec_results_for(
     if not binary_results:
         return {}
     return binary_results.get(binary_name) or {}
+
+
+def _binary_arch(dec_map: dict[str, DecompilationResult]) -> str | None:
+    """Detected machine architecture of the binary the decompilers ran on."""
+    for dr in dec_map.values():
+        info = binfmt.detect(dr.binary_path)
+        if info is not None and info.arch != "other":
+            return info.arch
+    return None
 
 
 def build_function_data(
@@ -262,6 +272,7 @@ def build_function_data(
                         opt_level=opt_value,
                         binary=binary_name,
                         labels=bin_labels,
+                        arch=_binary_arch(dec_map),
                         functions=[records[name] for name in func_order],
                     )
                 )

--- a/decbench/scoring/subset.py
+++ b/decbench/scoring/subset.py
@@ -188,15 +188,7 @@ def filter_function_data(
         ]
         if not kept:
             continue
-        new_groups.append(
-            BinaryGroup(
-                project=group.project,
-                opt_level=group.opt_level,
-                binary=group.binary,
-                labels=list(group.labels),
-                functions=kept,
-            )
-        )
+        new_groups.append(group.model_copy(update={"functions": kept}))
 
     return FunctionData(
         schema_version=function_data.schema_version,

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -28,6 +28,7 @@ What's here:
 from __future__ import annotations
 
 import io
+import platform
 import re
 import shutil
 import struct
@@ -36,7 +37,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-_ELF_MACHINES = {0x28: "arm", 0xB7: "aarch64", 0x3E: "x86-64", 0x03: "x86", 0xF3: "riscv"}
+_ELF_MACHINES = {
+    0x28: "arm",
+    0xB7: "aarch64",
+    0x3E: "x86-64",
+    0x03: "x86",
+    0xF3: "riscv",
+    0x08: "mips",
+    0x14: "ppc",
+    0x15: "ppc64",
+}
 _PE_MACHINES = {0x14C: "x86", 0x8664: "x86-64", 0xAA64: "aarch64", 0x1C0: "arm"}
 
 
@@ -58,7 +68,7 @@ def detect(path: Path) -> BinInfo | None:
                     return None
                 f.seek(18)
                 arch = _ELF_MACHINES.get(struct.unpack("<H", f.read(2))[0], "other")
-                bits = 64 if arch in ("x86-64", "aarch64") else 32
+                bits = 64 if arch in ("x86-64", "aarch64", "ppc64") else 32
                 return BinInfo("elf", arch, bits)
             if head == b"MZ":
                 f.seek(0x3C)
@@ -69,9 +79,28 @@ def detect(path: Path) -> BinInfo | None:
                 arch = _PE_MACHINES.get(struct.unpack("<H", f.read(2))[0], "other")
                 bits = 64 if arch in ("x86-64", "aarch64") else 32
                 return BinInfo("pe", arch, bits)
-    except OSError:
+    except (OSError, struct.error):
         return None
     return None
+
+
+_HOST_NATIVE_ARCHES = {
+    "x86_64": ("x86-64", "x86"),
+    "amd64": ("x86-64", "x86"),
+    "i386": ("x86",),
+    "i486": ("x86",),
+    "i586": ("x86",),
+    "i686": ("x86",),
+    "aarch64": ("aarch64",),
+    "arm64": ("aarch64",),
+}
+
+_CROSS_ELF_GCC = {
+    "x86-64": "x86_64-linux-gnu-gcc",
+    "x86": "i686-linux-gnu-gcc",
+    "arm": "arm-none-eabi-gcc",
+    "aarch64": "aarch64-linux-gnu-gcc",
+}
 
 
 def recompiler_for(info: BinInfo) -> str | None:
@@ -79,14 +108,16 @@ def recompiler_for(info: BinInfo) -> str | None:
 
     Returns the compiler executable name, or None for arch/format we can't
     recompile to. Callers should also check :func:`tool_available`.
+
+    Bare ``gcc`` is the answer only where the host builds that architecture
+    natively. Elsewhere it is the cross triplet, so a corpus built for a
+    different architecture than the host abstains (no toolchain) instead of
+    recompiling every function with the host's own ``-march``.
     """
     if info.fmt == "elf":
-        return {
-            "x86-64": "gcc",
-            "x86": "gcc",
-            "arm": "arm-none-eabi-gcc",
-            "aarch64": "aarch64-linux-gnu-gcc",
-        }.get(info.arch)
+        if info.arch in _HOST_NATIVE_ARCHES.get(platform.machine().lower(), ()):
+            return "gcc"
+        return _CROSS_ELF_GCC.get(info.arch)
     if info.fmt == "pe":
         return {
             "x86": "i686-w64-mingw32-gcc",

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -130,6 +130,63 @@ default full run is C-only.
   target list is gated. See `projects/cpp/disabled/README.md` to enable one,
   and read [C++ targets](#c-targets) before using any C++ number.
 
+### Corpus architecture (retargeting on a non-x86 host)
+
+`compilation.c_compiler` is `gcc` in all 26 sailr TOMLs (and the one Linux
+malware target), so those are built for whatever the **host** is; `target_arch`
+only filters which built ELFs are collected, it does not select a compiler. Two env vars retarget
+them without editing every TOML (`pipeline/compile.py:corpus_target`). Unset,
+each project compiles exactly as its TOML declares:
+
+```bash
+export DECBENCH_CC=x86_64-linux-gnu-gcc     # overrides compilation.c_compiler
+export DECBENCH_TARGET_ARCH=x86-64          # overrides compilation.target_arch
+export QEMU_LD_PREFIX=/usr/x86_64-linux-gnu # see below
+```
+
+`DECBENCH_TARGET_ARCH` is matched against the short machine names
+`GCCCompiler._binary_machine` reports — `x86-64`, `x86`, `aarch64`, `arm`,
+`riscv`, `mips`, `ppc`, `ppc64` — not a GNU triplet. A value that matches
+nothing collects nothing. Set both vars together: the sailr TOMLs leave
+`target_arch` unset, so `DECBENCH_CC` alone retargets the compiler with the
+collection filter off, and the host-arch helper tools an autotools build emits
+(`CC_FOR_BUILD`) are collected next to the retargeted binaries.
+
+A project that names its own cross-compiler is left alone by both vars, so the
+CPS (`arm-none-eabi-gcc`, `arm-linux-gnueabihf-gcc`) and MinGW malware
+(`i686-w64-mingw32-gcc`) targets still build and still keep their own
+`target_arch` filter during a full run. `mirai` declares plain `gcc`, so it is
+retargeted like sailr.
+
+`DECBENCH_CC` reaches `pre_make_cmds` and `make_cmd` alike, so `./configure` and
+`make` agree without per-project changes. It resolves the **C** compiler only:
+`cpp_compiler` is untouched, so the (disabled) C++ targets are not retargeted.
+
+The full-run recipe below forwards both vars into the compile container
+(`-e DECBENCH_CC -e DECBENCH_TARGET_ARCH`, a no-op while they are unset). Keep
+them there: without them the targets built inside (`mirai` uses `$CC`) come out
+native while the host-built ones do not, leaving one tree with two
+architectures. The image must then provide `$DECBENCH_CC`, or `mirai` fails to
+build — visibly, in `compile_report.json` — rather than silently switching arch.
+
+**`QEMU_LD_PREFIX` is not optional on an emulated target.** With only `CC` set,
+autoconf decides it is not cross compiling and runs its `AC_TRY_RUN` probes,
+which are foreign binaries; qemu then looks for the loader in the wrong place,
+every run-test fails, and configure silently guesses.
+
+**The architecture is recorded, not inferred.** `BinaryGroup.arch` carries the
+detected machine of each benchmarked binary and `scoring/datasets.py:_is_arm`
+prefers it; labels remain the fallback, so datasets built before the field
+existed keep their membership. The label heuristic alone only recognised
+TOML-declared cross-builds, so a corpus built natively on a non-x86 host was
+filed as the x86 baseline.
+
+**Mind the sysroot.** A cross toolchain typically ships glibc only, so
+dependency-heavy targets (`-lz`, `-lselinux`, …) will not link. A `./configure`
+that dies or hangs that way is now logged rather than swallowed, and a `make`
+that times out is recorded as a failed result, but compare per-project binary
+counts against a known-good run before trusting a scoreboard.
+
 ### C++ targets
 
 C++ works end-to-end as of `projects/cpp/disabled/leveldb.toml` (experimental,
@@ -372,7 +429,8 @@ docker build -f docker/compile.Dockerfile -t decbench-compile .
 # 3) docker-compile cps+malware INTO the same tree (run as host user;
 #    /.dockerenv satisfies the is_malware guard):
 docker run --rm -v "$PWD":/workspace -w /workspace -e PYTHONPATH=/workspace \
-  -e HOME=/tmp --user "$(id -u):$(id -g)" decbench-compile \
+  -e HOME=/tmp -e DECBENCH_CC -e DECBENCH_TARGET_ARCH \
+  --user "$(id -u):$(id -g)" decbench-compile \
   python3 scripts/compile_all.py results/full_run 8 <cps+malware stems...>
 # 4) one decompile+evaluate+report pass over everything (resumes per-project):
 DECBENCH_WORKERS=40 \

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -228,10 +228,11 @@ declaration. The two reference attributes are NOT equivalent:
 
 Assembly similarity after recompiling the decompiled C **the same way the
 source was compiled** — the toolchain and `-m*/-O*` flags matching the
-original binary's own format+arch (PE→MinGW, ARM→arm-none-eabi, x86→gcc;
-flags read from the DWARF producer), via `decbench/utils/binfmt.py`. Returns a
-non-scoring result (an **abstention**, not a 0) if that toolchain isn't
-installed — don't fake a wrong-arch recompile. Works on ELF and PE.
+original binary's own format+arch (PE→MinGW, ARM→arm-none-eabi, and bare `gcc`
+only for an architecture the host builds natively — the cross triplet
+otherwise; flags read from the DWARF producer), via `decbench/utils/binfmt.py`.
+Returns a non-scoring result (an **abstention**, not a 0) if that toolchain
+isn't installed — don't fake a wrong-arch recompile. Works on ELF and PE.
 
 ### The two fairness passes (v5, `cache_version="5"`)
 

--- a/tests/test_corpus_arch.py
+++ b/tests/test_corpus_arch.py
@@ -1,0 +1,160 @@
+"""Tests for architecture handling across the compile -> score path."""
+
+from __future__ import annotations
+
+import logging
+import struct
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from decbench.compilers.gcc import GCCCompiler
+from decbench.models.function_data import BinaryGroup, FunctionData, FunctionRecord
+from decbench.scoring.datasets import _is_arm
+from decbench.scoring.function_data_builder import _binary_arch
+from decbench.scoring.subset import SubsetManifest, filter_function_data
+from decbench.utils import binfmt
+
+_MACHINES = {"x86-64": 0x3E, "aarch64": 0xB7}
+
+
+def _fake_elf(path: Path, arch: str) -> Path:
+    path.write_bytes(b"\x7fELF" + b"\x00" * 14 + struct.pack("<H", _MACHINES[arch]))
+    return path
+
+
+def _group(arch: str | None, labels: list[str]) -> BinaryGroup:
+    return BinaryGroup(project="p", opt_level="O0", binary="b", labels=labels, arch=arch)
+
+
+def test_measured_arch_beats_the_label_heuristic() -> None:
+    """A natively built aarch64 sailr project carries no ARM label."""
+    natively_built = _group("aarch64", ["sailr", "cli-tool", "compression"])
+    assert _is_arm(natively_built) is True
+
+
+def test_measured_x86_overrides_a_stale_arm_label() -> None:
+    assert _is_arm(_group("x86-64", ["cps", "bare-metal"])) is False
+
+
+def test_a_non_arm_target_is_not_filed_as_arm() -> None:
+    assert _is_arm(_group("riscv", [])) is False
+
+
+def test_labels_still_decide_when_arch_was_not_recorded() -> None:
+    """Datasets built before `arch` existed keep their previous membership."""
+    assert _is_arm(_group(None, ["cps"])) is True
+    assert _is_arm(_group(None, ["cortex-m4"])) is True
+    assert _is_arm(_group(None, ["sailr", "cli-tool"])) is False
+
+
+def test_binary_arch_read_from_the_decompiled_binary(tmp_path: Path) -> None:
+    class _Result:
+        def __init__(self, path: Path):
+            self.binary_path = path
+
+    binary = _fake_elf(tmp_path / "bzip2", "aarch64")
+    assert _binary_arch({"angr": _Result(binary)}) == "aarch64"
+    assert _binary_arch({}) is None
+    assert _binary_arch({"angr": _Result(tmp_path / "absent")}) is None
+
+
+def test_an_unrecognised_machine_is_not_recorded(tmp_path: Path) -> None:
+    """binfmt reports an unknown e_machine as "other", which is not an answer."""
+
+    class _Result:
+        def __init__(self, path: Path):
+            self.binary_path = path
+
+    sparc = tmp_path / "sparc"
+    sparc.write_bytes(b"\x7fELF" + b"\x00" * 14 + struct.pack("<H", 0x02))
+    assert _binary_arch({"angr": _Result(sparc)}) is None
+
+
+def test_the_collect_filter_and_the_recorder_agree_on_machine_names() -> None:
+    """The compiler's table matches `DECBENCH_TARGET_ARCH`; binfmt's records `arch`.
+
+    If they drift, an arch the docs invite you to collect is one the dataset cannot record.
+    """
+    assert GCCCompiler._ELF_MACHINES == binfmt._ELF_MACHINES
+    assert GCCCompiler._PE_MACHINES == binfmt._PE_MACHINES
+
+
+def test_a_truncated_binary_does_not_abort_the_build(tmp_path: Path) -> None:
+    """`_binary_arch` runs inside the canonical rebuild; it must not raise."""
+
+    class _Result:
+        def __init__(self, path: Path):
+            self.binary_path = path
+
+    truncated = tmp_path / "trunc"
+    truncated.write_bytes(b"\x7fELF" + b"\x00" * 8)
+    assert _binary_arch({"angr": _Result(truncated)}) is None
+
+
+def test_arch_survives_a_subset_rebuild() -> None:
+    """A subsetted dataset must not fall back to the label heuristic."""
+    group = _group("aarch64", [])
+    group.functions = [FunctionRecord(function="f", size=1, values={"angr": {"ged": 1.0}})]
+    data = FunctionData(decompilers=["angr"], metrics=["ged"], groups=[group])
+    manifest = SubsetManifest(
+        method="std",
+        k=1.0,
+        threshold=0.0,
+        functions=[{"project": "p", "opt": "O0", "binary": "b", "function": "f"}],
+    )
+    assert filter_function_data(data, manifest).groups[0].arch == "aarch64"
+
+
+def test_arch_survives_the_json_round_trip() -> None:
+    group = _group("aarch64", [])
+    assert BinaryGroup.model_validate_json(group.model_dump_json()).arch == "aarch64"
+
+
+def test_failed_pre_make_command_is_logged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="decbench.compilers.gcc"):
+        GCCCompiler(gcc_path="gcc").compile_project(
+            project_dir=tmp_path,
+            output_dir=tmp_path / "out",
+            optimization="O0",
+            pre_commands=["exit 3"],
+            project_root=tmp_path,
+        )
+    assert any("pre-make command failed" in r.message for r in caplog.records)
+
+
+def test_timed_out_pre_make_command_is_logged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A configure whose run-tests hang under emulation is the slow failure mode."""
+    hang = subprocess.TimeoutExpired("./configure", 600)
+    with (
+        caplog.at_level(logging.WARNING, logger="decbench.compilers.gcc"),
+        mock.patch("subprocess.run", side_effect=hang),
+    ):
+        GCCCompiler(gcc_path="gcc").compile_project(
+            project_dir=tmp_path,
+            output_dir=tmp_path / "out",
+            optimization="O0",
+            pre_commands=["./configure"],
+            project_root=tmp_path,
+        )
+    assert any("pre-make command failed" in r.message for r in caplog.records)
+
+
+def test_timed_out_make_is_a_failed_result_not_an_exception(tmp_path: Path) -> None:
+    hang = subprocess.TimeoutExpired("make", 3600)
+    with mock.patch("subprocess.run", side_effect=hang):
+        results = GCCCompiler(gcc_path="gcc").compile_project(
+            project_dir=tmp_path,
+            output_dir=tmp_path / "out",
+            optimization="O0",
+            make_command="make",
+            project_root=tmp_path,
+        )
+    assert [r.success for r in results] == [False]
+    assert "timed out" in (results[0].error_message or "")

--- a/tests/test_corpus_target.py
+++ b/tests/test_corpus_target.py
@@ -1,0 +1,52 @@
+"""Tests for the corpus-architecture override used by the compile pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from decbench.models.project import CompilationConfig
+from decbench.pipeline.compile import corpus_target
+
+
+@pytest.fixture
+def compilation() -> CompilationConfig:
+    return CompilationConfig(c_compiler="gcc", target_arch=None)
+
+
+def test_defaults_to_the_project_config(
+    compilation: CompilationConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unset, every project compiles exactly as its TOML declares."""
+    monkeypatch.delenv("DECBENCH_CC", raising=False)
+    monkeypatch.delenv("DECBENCH_TARGET_ARCH", raising=False)
+    assert corpus_target(compilation) == ("gcc", None)
+
+
+def test_env_retargets_the_corpus(
+    compilation: CompilationConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One env var retargets a whole corpus without editing every project TOML."""
+    monkeypatch.setenv("DECBENCH_CC", "x86_64-linux-gnu-gcc")
+    monkeypatch.setenv("DECBENCH_TARGET_ARCH", "x86-64")
+    assert corpus_target(compilation) == ("x86_64-linux-gnu-gcc", "x86-64")
+
+
+def test_env_does_not_override_with_empty_values(
+    compilation: CompilationConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty var is the same as unset, not a request to compile with ''."""
+    monkeypatch.setenv("DECBENCH_CC", "")
+    monkeypatch.setenv("DECBENCH_TARGET_ARCH", "")
+    assert corpus_target(compilation) == ("gcc", None)
+
+
+def test_a_cross_compiled_project_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CPS/malware targets keep their toolchain and their collection filter.
+
+    Retargeting them would build x86-64 and then collect only ARM: no binaries,
+    no error.
+    """
+    monkeypatch.setenv("DECBENCH_CC", "x86_64-linux-gnu-gcc")
+    monkeypatch.setenv("DECBENCH_TARGET_ARCH", "x86-64")
+    config = CompilationConfig(c_compiler="arm-none-eabi-gcc", target_arch="arm")
+    assert corpus_target(config) == ("arm-none-eabi-gcc", "arm")

--- a/tests/test_recompiler_arch.py
+++ b/tests/test_recompiler_arch.py
@@ -1,0 +1,59 @@
+"""Tests for choosing a recompiler when the host is not the target."""
+
+from __future__ import annotations
+
+import platform
+from unittest import mock
+
+import pytest
+
+from decbench.utils.binfmt import BinInfo, recompiler_for
+
+
+@pytest.mark.parametrize(
+    ("arch", "expected"),
+    [("x86-64", "gcc"), ("x86", "gcc"), ("aarch64", "aarch64-linux-gnu-gcc")],
+)
+def test_an_x86_host_is_unchanged(arch: str, expected: str) -> None:
+    with mock.patch.object(platform, "machine", return_value="x86_64"):
+        assert recompiler_for(BinInfo("elf", arch, 64)) == expected
+
+
+def test_a_non_x86_host_does_not_recompile_x86_with_its_own_gcc() -> None:
+    """`byte_match` would otherwise pass `-march=x86-64` to an aarch64 gcc.
+
+    That fails for every function, scoring 0.0 rather than abstaining, so a
+    retargeted corpus reads as "decompiled fine, bytes never matched".
+    """
+    with mock.patch.object(platform, "machine", return_value="aarch64"):
+        assert recompiler_for(BinInfo("elf", "x86-64", 64)) == "x86_64-linux-gnu-gcc"
+        assert recompiler_for(BinInfo("elf", "aarch64", 64)) == "gcc"
+
+
+@pytest.mark.parametrize("host", ["x86_64", "AMD64", "i686", "i386"])
+def test_every_intel_host_spelling_builds_x86_natively(host: str) -> None:
+    """`platform.machine()` says `AMD64` on Windows and `i686` on a 32-bit host.
+
+    Missing a spelling costs a real recompile: the host's own `gcc` is there and
+    works, but `byte_match` abstains as if no toolchain existed.
+    """
+    with mock.patch.object(platform, "machine", return_value=host):
+        assert recompiler_for(BinInfo("elf", "x86", 32)) == "gcc"
+
+
+@pytest.mark.parametrize("host", ["ARM64", "arm64", "aarch64"])
+def test_arm_host_spellings_are_native(host: str) -> None:
+    with mock.patch.object(platform, "machine", return_value=host):
+        assert recompiler_for(BinInfo("elf", "aarch64", 64)) == "gcc"
+
+
+def test_a_32_bit_host_cannot_build_the_64_bit_target() -> None:
+    with mock.patch.object(platform, "machine", return_value="i686"):
+        assert recompiler_for(BinInfo("elf", "x86-64", 64)) == "x86_64-linux-gnu-gcc"
+
+
+def test_pe_and_bare_metal_arm_are_host_independent() -> None:
+    for host in ("x86_64", "aarch64"):
+        with mock.patch.object(platform, "machine", return_value=host):
+            assert recompiler_for(BinInfo("pe", "x86-64", 64)) == "x86_64-w64-mingw32-gcc"
+            assert recompiler_for(BinInfo("elf", "arm", 32)) == "arm-none-eabi-gcc"


### PR DESCRIPTION
Refs #68.

Nothing changes on an x86-64 Linux host: with the env vars unset every project compiles as its TOML declares, existing datasets keep their preset membership, and recompiler selection is byte-identical. Two commits, each green alone.

**`compile: let DECBENCH_CC/DECBENCH_TARGET_ARCH retarget the corpus`**
- `GCCCompiler` clobbers an inherited `CC`, so retargeting meant editing 26 TOMLs. `corpus_target()` resolves (compiler, target_arch) from the environment first, only for projects that declare plain `gcc`; CPS and the MinGW malware targets keep their own toolchain and filter.

**`arch: measure the target architecture instead of assuming x86`**
- `BinaryGroup.arch` records the detected machine of the benchmarked binary; `_is_arm()` prefers it over the label heuristic, which only ever recognised TOML-declared cross-builds. `None` for pre-existing datasets, so nothing moves.
- `binfmt.recompiler_for` returns bare `gcc` only for architectures the host builds natively, the cross triplet otherwise. Previously a non-x86 host recompiled every function with its own gcc and the binary's `-march`, scoring 0.0 everywhere instead of abstaining.
- A failed or hung `pre_make_cmds` step is logged; a `make` timeout is a failed `CompileResult` rather than an escaped exception.
- `binfmt._ELF_MACHINES` gains `mips`/`ppc`/`ppc64` to match the compiler's table; a test pins them equal.
- `docs/benchmarking.md` §Corpus architecture, including the `QEMU_LD_PREFIX` trap for autoconf under emulation.

Known limits, listed rather than fixed: `arch` is detected at scoring time, so a finalize from the wrong cwd records `None` and falls back to labels (I can stamp it at decompile time if you'd prefer); on a corpus that is *all* ARM, `unoptimized-arm` equals `unoptimized`. No `CHANGELOG.md` entry — say the word. No cross-built corpus is offered as a result: stock cross toolchains ship glibc only, so which sailr targets link is a separate exercise.
