### PR TITLE
[AUTOMATED] fix(metrics): preserve DWARF source TU ownership

### DIFF
--- a/decbench/evalkit/ingest.py
+++ b/decbench/evalkit/ingest.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-import os
 import pickle
 import re
 import tempfile
@@ -535,58 +534,21 @@ def _opt_key(section: dict, opt: str) -> Any:
     return enum_key
 
 
-def _stems_for_addrs(binary: Path, addrs: set[int], stems: set[str]) -> set[str]:
-    """The ``.i`` TU stems whose DWARF subprograms cover ``addrs``.
+def _function_owners_for_addrs(
+    binary: Path, addrs: set[int], stems: set[str]
+) -> dict[int, tuple[str, str]]:
+    """The DWARF function/TU owners for target ``addrs``.
 
     Mirrors ``project_source_functions``' ``stem_out`` (scripts/run_benchmark.py)
     so Joern parses only the translation units that hold the target functions.
     Empty result means "unknown" — the caller falls back to every TU.
     """
     if not stems or not addrs:
-        return set()
+        return {}
     from decbench.utils import binfmt
 
-    try:
-        dw = binfmt.dwarf_info(binary)
-    except Exception:  # noqa: BLE001
-        return set()
-    if dw is None:
-        return set()
-    matched: set[str] = set()
-    try:
-        for cu in dw.iter_CUs():
-            lp = dw.line_program_for_CU(cu)
-            version = 4
-            if lp is not None:
-                version = lp.header.get("version", cu.header.get("version", 4))
-            files: list[str | None] = [] if version >= 5 else [None]
-            if lp is not None:
-                for fe in lp["file_entry"]:
-                    nm = fe.name
-                    files.append(nm.decode() if isinstance(nm, bytes) else nm)
-            for die in cu.iter_DIEs():
-                if die.tag != "DW_TAG_subprogram":
-                    continue
-                attrs = die.attributes
-                if "DW_AT_low_pc" not in attrs:
-                    continue
-                if int(attrs["DW_AT_low_pc"].value) not in addrs:
-                    continue
-                fi = attrs.get("DW_AT_decl_file")
-                if fi is None or not (0 <= fi.value < len(files)) or files[fi.value] is None:
-                    continue
-                base = os.path.basename(files[fi.value])  # type: ignore[arg-type]
-                stem = base[:-2] if base.endswith(".c") else base
-                if stem in stems:
-                    matched.add(stem)
-                    continue
-                for s in stems:
-                    if s.endswith("-" + stem) or s.endswith("_" + stem):
-                        matched.add(s)
-                        break
-    except Exception:  # noqa: BLE001
-        return set()
-    return matched
+    owners = binfmt.source_function_owners(binary, stems)
+    return {addr: owner for addr, owner in owners.items() if addr in addrs}
 
 
 def _evaluate_group(
@@ -612,6 +574,7 @@ def _evaluate_group(
     )
 
     src_by_stem: dict[str, dict] = {}
+    owners_by_binary: dict[str, dict[int, tuple[str, str]]] = {}
     best: dict = {}
     if needs_source:
         compiled = tree / opt / project / "compiled"
@@ -624,12 +587,15 @@ def _evaluate_group(
             )
         else:
             needed: set[str] = set()
+            parse_all = False
             for e in entries:
-                got = _stems_for_addrs(e.binary, e.addrs, set(i_by_stem))
-                if not got:
-                    needed = set(i_by_stem)
-                    break
-                needed |= got
+                got = _function_owners_for_addrs(e.binary, e.addrs, set(i_by_stem))
+                owners_by_binary[e.stem] = got
+                if set(got) != e.addrs:
+                    parse_all = True
+                needed.update(tu_stem for _name, tu_stem in got.values())
+            if parse_all:
+                needed = set(i_by_stem)
             for stem in sorted(needed):
                 try:
                     src_by_stem[stem] = extract_cfgs_from_source(i_by_stem[stem]) or {}
@@ -643,7 +609,16 @@ def _evaluate_group(
 
     out: dict[str, dict[str, MetricResult]] = {}
     for e in entries:
-        src = resolved_source_for_binary(e.stem, src_by_stem, best) if needs_source else None
+        src = (
+            resolved_source_for_binary(
+                e.stem,
+                src_by_stem,
+                best,
+                function_owners=owners_by_binary.get(e.stem),
+            )
+            if needs_source
+            else None
+        )
         try:
             out[e.stem] = evaluate_decompilation(e.result, src, metric_names)
         except Exception as exc:  # noqa: BLE001

--- a/decbench/pipeline/evaluate.py
+++ b/decbench/pipeline/evaluate.py
@@ -77,6 +77,7 @@ def evaluate_project(
     parallel: bool = True,
     workers: int | None = None,
     precomputed_source_cfgs: dict[str, dict[str, DiGraph]] | None = None,
+    source_function_owners: dict[str, dict[int, tuple[str, str]]] | None = None,
 ) -> dict[str, dict[str, dict[str, MetricResult]]]:
     """Evaluate all decompilations for a project.
 
@@ -85,6 +86,10 @@ def evaluate_project(
             binary name instead of re-extracting them from the preprocessed
             sources. Lets a caller extract source CFGs once and reuse them for
             both a decompile filter and this evaluation.
+        source_function_owners: Optional per-binary DWARF
+            ``low_pc -> (name, declaration-file TU)`` provenance for resolving
+            precomputed source CFGs. When source CFGs are extracted here, the
+            same provenance is read from each compiled binary automatically.
     """
     if isinstance(optimization, str):
         optimization = OptimizationLevel(optimization)
@@ -136,16 +141,38 @@ def evaluate_project(
     else:
         logger.warning("No preprocessed sources for %s/%s", project.name, optimization)
 
-    # TU-aware matching: prefer the binary's OWN translation unit so per-program
-    # functions hit the right body, falling back cross-TU only for functions it does
-    # not define. The old name-keyed union scored nologin's 5-node main against
-    # another binary's 56-node main.
+    # TU-aware matching uses exact DWARF declaration-file ownership when available,
+    # then the historical binary-stem convention, then the cross-TU fallback.
     from decbench.utils.cfg import best_source_by_name, resolved_source_for_binary
 
     best_by_name = best_source_by_name(source_cfgs_by_binary)
+    function_owners = dict(source_function_owners or {})
+    if source_function_owners is None and precomputed_source_cfgs is None:
+        from decbench.utils import binfmt
+
+        binaries = {path.stem: path for path in project.compiled_binaries.get(optimization, [])}
+        source_stems = set(source_cfgs_by_binary)
+        for binary_name, dec_results in decompilations.items():
+            binary = binaries.get(binary_name)
+            if binary is None:
+                continue
+            target_addrs = {
+                function.address
+                for decompilation in dec_results.values()
+                for function in decompilation.functions.values()
+            }
+            owners = binfmt.source_function_owners(binary, source_stems)
+            function_owners[binary_name] = {
+                addr: owner for addr, owner in owners.items() if addr in target_addrs
+            }
 
     def _source_for(binary_name: str) -> dict:
-        return resolved_source_for_binary(binary_name, source_cfgs_by_binary, best_by_name)
+        return resolved_source_for_binary(
+            binary_name,
+            source_cfgs_by_binary,
+            best_by_name,
+            function_owners=function_owners.get(binary_name),
+        )
 
     if parallel:
         workers = workers or cpu_count()

--- a/decbench/publish/cfg_export.py
+++ b/decbench/publish/cfg_export.py
@@ -8,8 +8,9 @@ paths read graph topology and each node's ``is_entrypoint`` /
 module writes, per binary, the ``function -> CFG`` map that
 ``pipeline/evaluate.py`` scores that binary against: the project's ``.i`` CFGs
 parsed **per translation unit** and then resolved through
-:func:`decbench.utils.cfg.resolved_source_for_binary` — the binary's own TU wins,
-other TUs are the fallback, and empty prototypes never displace a real body.
+:func:`decbench.utils.cfg.resolved_source_for_binary` — the function's DWARF
+declaration-file TU wins, followed by the binary-stem convention and the
+cross-TU fallback, and empty prototypes never displace a real body.
 Each DiGraph is relabeled to ``0..n-1`` with the entry/exit node ids and the
 degeneracy verdict recorded. :func:`rebuild_cfg` reconstructs a GED-ready
 ``nx.DiGraph`` from one serialized function, so the exact GED value is
@@ -39,6 +40,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from decbench.utils import binfmt
 from decbench.utils.cfg import (
     best_source_by_name,
     extract_cfgs_from_source,
@@ -46,7 +48,7 @@ from decbench.utils.cfg import (
     resolved_source_for_binary,
     strip_system_headers,
 )
-from decbench.utils.results_tree import OPT_LEVELS, compiled_dir
+from decbench.utils.results_tree import OPT_LEVELS, compiled_dir, resolve_binary
 
 if TYPE_CHECKING:
     from networkx import DiGraph
@@ -205,13 +207,17 @@ def _resolved_cfgs_for_opt(
             serialized[key] = relabel_cfg(cfg)
         return serialized[key]
 
-    return {
-        stem: {
+    out: dict[str, dict[str, CfgSerial]] = {}
+    for stem in stems:
+        binary = resolve_binary(compiled_dir(root, opt, project), stem)
+        owners = binfmt.source_function_owners(binary, set(by_tu)) if binary is not None else None
+        out[stem] = {
             name: _serialize(cfg)
-            for name, cfg in resolved_source_for_binary(stem, by_tu, best_by_name).items()
+            for name, cfg in resolved_source_for_binary(
+                stem, by_tu, best_by_name, function_owners=owners
+            ).items()
         }
-        for stem in stems
-    }
+    return out
 
 
 def cfg_json_path(dest: Path, opt: str, project: str, stem: str) -> Path:

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -22,7 +22,9 @@ What's here:
     attribute through ``DW_AT_specification`` (and, in a C++ unit only,
     ``DW_AT_abstract_origin``), which is where C++ out-of-line definitions keep
     their name and decl file; :func:`cu_file_table` resolves the
-    ``DW_AT_decl_file`` index and :func:`cu_is_cxx` reports the unit's language.
+    ``DW_AT_decl_file`` index, :func:`source_function_owners` maps function
+    addresses to their defining translation units, and :func:`cu_is_cxx` reports
+    the unit's language.
 """
 
 from __future__ import annotations
@@ -425,6 +427,59 @@ def cu_file_table(dwarfinfo, cu, cache: dict[int, list] | None = None) -> list:
     return files
 
 
+def source_function_owners(path: Path, source_stems: set[str]) -> dict[int, tuple[str, str]]:
+    """Map DWARF function addresses to ``(name, defining source-TU stem)``.
+
+    Only definitions whose ``DW_AT_decl_file`` matches one of ``source_stems``
+    are returned. Object-prefixed preprocessed stems such as ``program-main``
+    match a declaration file named ``main.c``.
+    """
+    if not source_stems:
+        return {}
+
+    from decbench.utils.langs import build_stem_index, strip_source_ext
+
+    try:
+        dw = dwarf_info(path)
+    except Exception:  # noqa: BLE001
+        return {}
+    if dw is None:
+        return {}
+
+    owners: dict[int, tuple[str, str]] = {}
+    file_tables: dict[int, list] = {}
+    stem_index = build_stem_index(source_stems)
+    try:
+        for cu in dw.iter_CUs():
+            for die in cu.iter_DIEs():
+                if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
+                    continue
+                name = die_str_attr(die, "DW_AT_name")
+                if name is None:
+                    continue
+                fi, owner = die_attr_owner(die, "DW_AT_decl_file")
+                if fi is None:
+                    continue
+                files = cu_file_table(dw, owner.cu, file_tables)
+                if not (0 <= fi.value < len(files)) or files[fi.value] is None:
+                    continue
+                decl_stem = strip_source_ext(Path(files[fi.value]).name)
+                matched = stem_index.get(decl_stem)
+                if matched is None:
+                    suffix_matches = [
+                        original
+                        for normalized, original in stem_index.items()
+                        if normalized.endswith("-" + decl_stem)
+                        or normalized.endswith("_" + decl_stem)
+                    ]
+                    matched = suffix_matches[0] if len(suffix_matches) == 1 else None
+                if matched is not None:
+                    owners[int(die.attributes["DW_AT_low_pc"].value)] = (name, matched)
+    except Exception:  # noqa: BLE001
+        return {}
+    return owners
+
+
 def _dwarf_function_range(path: Path, func_name: str) -> tuple[int, int] | None:
     """(low_pc, high_pc) absolute VA for a function, from DWARF."""
     di = dwarf_info(path)
@@ -487,9 +542,7 @@ def _elf_function_bytes(path: Path, func_name: str, address: int) -> bytes | Non
                 raw_address = sym["st_value"]
                 symbol_address = raw_address & ~1 if is_arm else raw_address
                 if (
-                    sym.name == func_name
-                    or symbol_address == address
-                    or raw_address == address
+                    sym.name == func_name or symbol_address == address or raw_address == address
                 ) and sym["st_size"] > 0:
                     addr, size = symbol_address, sym["st_size"]
                     for section in elf.iter_sections():

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -321,6 +322,7 @@ def resolved_source_for_binary(
     binary_stem: str,
     source_cfgs_by_binary: dict[str, dict[str, DiGraph]],
     best_by_name: dict[str, DiGraph],
+    function_owners: Mapping[int, tuple[str, str]] | None = None,
 ) -> dict[str, DiGraph]:  # type: ignore
     """Source CFGs to score ONE binary against, TU-aware (fixes name collisions).
 
@@ -332,10 +334,34 @@ def resolved_source_for_binary(
     another binary's 56-node ``main``). Falls back to the cross-TU
     :func:`best_source_by_name` for functions the own TU doesn't define
     (statically-linked library code) or defines only as an empty prototype.
+
+    ``function_owners`` carries exact DWARF ``low_pc -> (name, decl-file TU)``
+    provenance. It takes priority over the binary-stem convention, which is not
+    reliable when a build names an output differently from its defining source.
+    A known owner with no real CFG abstains for that name instead of selecting a
+    same-named function from another translation unit.
     """
     resolved = dict(best_by_name)
     for name, cfg in (source_cfgs_by_binary.get(binary_stem) or {}).items():
         if not is_degenerate_source_cfg(cfg):
+            resolved[name] = cfg
+
+    owned_by_name: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    for name, tu_stem in (function_owners or {}).values():
+        previous = owned_by_name.get(name)
+        if previous is not None and previous != tu_stem:
+            ambiguous.add(name)
+        else:
+            owned_by_name[name] = tu_stem
+    for name in ambiguous:
+        owned_by_name.pop(name, None)
+
+    for name, tu_stem in owned_by_name.items():
+        cfg = (source_cfgs_by_binary.get(tu_stem) or {}).get(name)
+        if cfg is None or is_degenerate_source_cfg(cfg):
+            resolved.pop(name, None)
+        else:
             resolved[name] = cfg
     return resolved
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -462,8 +462,8 @@ inline values — and `function_results.json` is only ever written through
 
 `results/<tree>/{ged,type_match,byte_match}_new.json` (from
 `scripts/reeval_{ged,typematch}.py` / `reeval_bytematch.py`) carry the
-corrected values (sanitized decompiled parses, per-TU source matching,
-non-finite dropped, compilability fixup); the per-project checkpoints still
+corrected values (sanitized decompiled parses, DWARF-owned per-TU source
+matching, non-finite dropped, compilability fixup); the per-project checkpoints still
 hold the ORIGINAL inline values from each decompiler's first evaluation.
 
 `reeval_ged.py` signs each per-slice checkpoint with the GED cache version,

--- a/docs/dataset-publishing.md
+++ b/docs/dataset-publishing.md
@@ -250,10 +250,13 @@ nothing else. Store, per binary, the `function → CFG` map the pipeline used:
 opt level, **keeping them keyed per translation unit**, and then resolving each
 binary's map through the very same
 `best_source_by_name` / `resolved_source_for_binary` pair that
-`pipeline/evaluate.py` scores with: the binary's OWN translation unit wins, the
-cross-TU best-by-name is the fallback, and an empty prototype never displaces a
-real body. Delegating to that pair is what keeps the export from drifting from
-the scoring path (`tests/test_cfg_export.py` asserts the two agree). Each
+`pipeline/evaluate.py` scores with: DWARF `low_pc`/`DW_AT_decl_file` ownership
+wins for each function, the matching binary stem is the compatibility path when
+that ownership is unavailable, and cross-TU best-by-name is the final fallback.
+A known owner with no real source CFG abstains instead of borrowing a same-named
+function from another TU. Delegating to that pair is what keeps the export from
+drifting from the scoring path (`tests/test_cfg_export.py` asserts the two
+agree). Each
 DiGraph's nodes are relabeled to `0..n-1` (stable order); Joern parses are
 **deduplicated by stripped-content hash** so each unique translation unit is
 parsed once (Joern spawns a JVM per parse — the dominant cost; see the module

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -82,12 +82,19 @@ type_match. The publish/dataset paths still glob only `*.i`
 `scripts/compute_dataset_info.py`), so a C++ project cannot be published to the
 dataset yet.
 
-Source-side matching is per-TU: `pipeline/evaluate.py` matches a binary's OWN
-translation unit first, cross-TU best-by-name only as fallback (avoids
-same-name collisions across TUs). It is also per optimization level: an O0
-source CFG is not valid ground truth for O2 merely because both inputs came
-from the same project. The old JOERN_FAILURES.md failure analysis lives in git
-history; Joern parse-health stats render on the site's data page.
+Source-side matching is per-TU: each target function's DWARF `low_pc` and
+`DW_AT_decl_file` select its defining preprocessed translation unit first. The
+binary-stem convention is retained when that provenance is unavailable, and
+cross-TU best-by-name is only the final fallback. This matters when a build
+names an output differently from the source that defines its `main`; using the
+largest same-named graph from another TU is not valid ground truth. Matching is
+also per optimization level: an O0 source CFG is not valid ground truth for O2
+merely because both inputs came from the same project. The old
+JOERN_FAILURES.md failure analysis lives in git history; Joern parse-health
+stats render on the site's data page.
+
+The live evaluator, external eval-kit ingestion, dataset CFG export, and
+canonical `reeval_ged.py` overlay all use this ownership rule.
 
 **C++ name collisions.** Matching is by UNQUALIFIED name on both sides (DWARF
 `DW_AT_name` is `Get`, not `leveldb::DBImpl::Get`, and Joern's C++ frontend

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -45,7 +45,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from decbench.utils.langs import preprocessed_by_stem  # noqa: E402
 
 PREVIOUS_GED_MAX_NODES = 60
-CHECKPOINT_SCHEMA_VERSION = 6
+CHECKPOINT_SCHEMA_VERSION = 7
 SOURCE_CACHE_SCHEMA_VERSION = 1
 HISTORICAL_CANDIDATE_PARSE = "legacy-overlay-evidence-reconciled-v3"
 
@@ -804,15 +804,27 @@ def eval_one(
         old_values,
     ) = task
     from decbench.metrics.ged import GEDMetric
+    from decbench.utils import binfmt
     from decbench.utils.cfg import (
         extract_cfgs_from_source,
         needs_decompiled_preprocessing,
         resolved_source_for_binary,
         sanitize_decompiled_c,
     )
+    from decbench.utils.results_tree import resolve_binary
 
     per_stem, best_by_name = _load_src(src_pkl)
-    src_cfgs = resolved_source_for_binary(stem, per_stem, best_by_name)
+    compiled = Path(c_path).parent.parent / "compiled"
+    binary = resolve_binary(compiled, stem)
+    function_owners = (
+        binfmt.source_function_owners(binary, set(per_stem)) if binary is not None else None
+    )
+    src_cfgs = resolved_source_for_binary(
+        stem,
+        per_stem,
+        best_by_name,
+        function_owners=function_owners,
+    )
     historical_src_cfgs: dict = {}
     if historical_src_pkl:
         historical_per_stem, historical_best = _load_src(historical_src_pkl)
@@ -1110,6 +1122,12 @@ def migrate_compatible_checkpoints(
 ) -> tuple[int, int]:
     """Upgrade checkpoints whose stored and requested historical bases agree."""
     from decbench.utils.cfg import sanitize_decompiled_c
+
+    # The compatibility proof below is specifically for the schema 4/5 -> 6
+    # historical-parse transition. Later schemas change corrected-score inputs
+    # and must be replayed, not relabeled as current.
+    if signature.get("schema_version") != 6:
+        return 0, 0
 
     schema5_signature = dict(signature)
     schema5_signature["schema_version"] = 5

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -44,8 +44,7 @@ from decbench.pipeline.executor import PipelineConfig, PipelineExecutor  # noqa:
 from decbench.results_store import PROJECT_DIRS  # noqa: F401,E402
 from decbench.results_store import gather_project_tomls as gather_tomls
 from decbench.utils import binfmt  # noqa: E402
-from decbench.utils.cfg import extract_cfgs_from_source
-from decbench.utils.langs import build_stem_index, strip_source_ext  # noqa: E402
+from decbench.utils.cfg import extract_cfgs_from_source  # noqa: E402
 
 OPT_LEVELS = [
     OptimizationLevel.O0,
@@ -166,46 +165,10 @@ def project_source_functions(
     symbols), where decompilers only know functions by address. Returns an empty
     map if there is no usable DWARF (caller then falls back to all functions).
     """
-    if not source_stems:
-        return {}
-    try:
-        dw = binfmt.dwarf_info(binary_path)
-    except Exception:  # noqa: BLE001
-        return {}
-    if dw is None:
-        return {}
-    addr2name: dict[int, str] = {}
-    file_tables: dict[int, list] = {}
-    stem_index = build_stem_index(source_stems)
-    try:
-        for cu in dw.iter_CUs():
-            for die in cu.iter_DIEs():
-                if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
-                    continue
-                name = binfmt.die_str_attr(die, "DW_AT_name")
-                if name is None:
-                    continue
-                fi, owner = binfmt.die_attr_owner(die, "DW_AT_decl_file")
-                if fi is None:
-                    continue
-                files = binfmt.cu_file_table(dw, owner.cu, file_tables)
-                if not (0 <= fi.value < len(files)) or files[fi.value] is None:
-                    continue
-                stem = strip_source_ext(os.path.basename(files[fi.value]))
-                matched = stem_index.get(stem)
-                if matched is None:
-                    for norm, original in stem_index.items():
-                        if norm.endswith("-" + stem) or norm.endswith("_" + stem):
-                            matched = original
-                            break
-                if matched is not None:
-                    lp_addr = int(die.attributes["DW_AT_low_pc"].value)
-                    addr2name[lp_addr] = name
-                    if stem_out is not None:
-                        stem_out[lp_addr] = matched
-    except Exception:  # noqa: BLE001
-        return {}
-    return addr2name
+    owners = binfmt.source_function_owners(binary_path, source_stems)
+    if stem_out is not None:
+        stem_out.update({addr: stem for addr, (_name, stem) in owners.items()})
+    return {addr: name for addr, (name, _stem) in owners.items()}
 
 
 def extract_source_cfgs(
@@ -584,6 +547,7 @@ def main() -> int:
             ts = time.time()
             source_stems = set(project.preprocessed_sources.get(opt, {}).keys())
             src_fn_names: dict[str, dict[int, str]] = {}
+            src_fn_owners: dict[str, dict[int, tuple[str, str]]] = {}
             kept_binaries = []
             needed_stems: set[str] = set()
             for b in project.compiled_binaries[opt]:
@@ -594,6 +558,11 @@ def main() -> int:
                     fns = {a: nm for a, nm in fns.items() if allowed and nm in allowed}
                 if fns:
                     src_fn_names[b.stem] = fns
+                    src_fn_owners[b.stem] = {
+                        addr: (func_name, addr_stem[addr])
+                        for addr, func_name in fns.items()
+                        if addr in addr_stem
+                    }
                     kept_binaries.append(b)
                     needed_stems.update(addr_stem[a] for a in fns if a in addr_stem)
             skipped = len(project.compiled_binaries[opt]) - len(kept_binaries)
@@ -665,6 +634,7 @@ def main() -> int:
                         parallel=True,
                         workers=WORKERS,
                         precomputed_source_cfgs=src_cfgs,
+                        source_function_owners=src_fn_owners,
                     )
                 except Exception as e:  # noqa: BLE001
                     print(f"[{name}/{opt.value}] evaluate ERROR: {e}", flush=True)

--- a/tests/test_cfg_export.py
+++ b/tests/test_cfg_export.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import networkx as nx
 import pytest
@@ -194,6 +195,82 @@ def test_each_binary_gets_its_own_translation_unit(project_tree) -> None:
 
     assert len(read_export(dest, "cat")["main"]["nodes"]) == 3
     assert len(read_export(dest, "ls")["main"]["nodes"]) == 10
+
+
+def test_dwarf_owned_translation_unit_precedes_name_fallback(
+    project_tree, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A binary name need not equal the translation unit that defines its functions."""
+    tus = {
+        "new_subid_range-new_subid_range": {"main": chain(4)},
+        "login": {"main": chain(40)},
+    }
+    root, dest = project_tree(tus)
+    monkeypatch.setattr(cfg_export, "resolve_binary", lambda *_args: root / "new_subid_range")
+    monkeypatch.setattr(
+        cfg_export.binfmt,
+        "source_function_owners",
+        lambda *_args: {0x12DA: ("main", "new_subid_range-new_subid_range")},
+    )
+
+    cfg_export.export_project_cfgs(
+        root,
+        dest,
+        "proj",
+        {"O2": ["new_subid_range"]},
+    )
+
+    assert len(read_export(dest, "new_subid_range")["main"]["nodes"]) == 4
+
+
+def test_known_dwarf_owner_does_not_fall_back_to_another_tu() -> None:
+    """Missing source for a known owner is safer than a same-name substitution."""
+    tus = {"login": {"main": chain(40)}}
+    resolved = resolved_source_for_binary(
+        "new_subid_range",
+        tus,
+        best_source_by_name(tus),
+        function_owners={0x12DA: ("main", "new_subid_range-new_subid_range")},
+    )
+
+    assert "main" not in resolved
+
+
+def test_evaluate_project_accepts_precomputed_cfgs_with_dwarf_owners(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The benchmark driver can carry address/TU provenance into evaluation."""
+    from decbench.pipeline import evaluate
+
+    tus = {
+        "new_subid_range-new_subid_range": {"main": chain(4)},
+        "login": {"main": chain(40)},
+    }
+    seen: dict[str, int] = {}
+
+    def evaluate_one(_decompilation, source_cfgs, _metrics):
+        seen["main_nodes"] = source_cfgs["main"].number_of_nodes()
+        return {}
+
+    monkeypatch.setattr(evaluate, "evaluate_decompilation", evaluate_one)
+    project = SimpleNamespace(name="shadow", preprocessed_sources={}, compiled_binaries={})
+
+    evaluate.evaluate_project(
+        project,
+        {"new_subid_range": {"test": object()}},
+        tmp_path,
+        optimization="O0",
+        metrics=["ged"],
+        parallel=False,
+        precomputed_source_cfgs=tus,
+        source_function_owners={
+            "new_subid_range": {
+                0x12DA: ("main", "new_subid_range-new_subid_range"),
+            }
+        },
+    )
+
+    assert seen == {"main_nodes": 4}
 
 
 def test_falls_back_across_tus_for_undefined_functions(project_tree) -> None:

--- a/tests/test_reeval_ged.py
+++ b/tests/test_reeval_ged.py
@@ -749,6 +749,108 @@ def test_eval_one_rejects_reconstructed_fallback_mismatch(
         eval_one(task)
 
 
+def test_eval_one_uses_dwarf_tu_ownership_for_corrected_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decompiled = tmp_path / "O0" / "shadow" / "decompiled"
+    decompiled.mkdir(parents=True)
+    artifact = decompiled / "angr_new_subid_range.c"
+    artifact.write_text("// Function: main @ 0x12da\nint main(void) { return 0; }\n")
+    current_source = tmp_path / "current.pkl"
+    current_source.write_bytes(
+        pickle.dumps(
+            {
+                "per_stem": {
+                    "new_subid_range-new_subid_range": {"main": _graph(4, 3)},
+                    "login": {"main": _graph(40, 39)},
+                }
+            }
+        )
+    )
+    candidate_cfg = _graph(4, 3)
+    monkeypatch.setattr(
+        "decbench.utils.results_tree.resolve_binary",
+        lambda *_args: tmp_path / "O0" / "shadow" / "compiled" / "new_subid_range",
+    )
+    monkeypatch.setattr(
+        "decbench.utils.binfmt.source_function_owners",
+        lambda *_args: {0x12DA: ("main", "new_subid_range-new_subid_range")},
+    )
+    monkeypatch.setattr(
+        "decbench.utils.cfg.extract_cfgs_from_source",
+        lambda *_args, **_kwargs: {"main": candidate_cfg},
+    )
+    seen: list[int] = []
+
+    def compute(_self, _result, *, source_cfg, decompiled_cfg):
+        assert decompiled_cfg is candidate_cfg
+        seen.append(source_cfg.number_of_nodes())
+        return SimpleNamespace(
+            value=0.0,
+            metadata={"method": "vj_ged", "isomorphic": True, "approximated": False},
+        )
+
+    monkeypatch.setattr("decbench.metrics.ged.GEDMetric.compute_for_function", compute)
+
+    key, scores, _audit = eval_one(
+        (
+            "O0",
+            "shadow",
+            "new_subid_range",
+            "angr",
+            str(artifact),
+            str(current_source),
+            "",
+            False,
+            {},
+        )
+    )
+
+    assert key == "O0::shadow::new_subid_range::angr"
+    assert scores == {"main": {"value": 0.0, "perfect": True}}
+    assert seen == [4]
+
+
+def test_checkpoint_schema_tracks_dwarf_tu_ownership(tmp_path: Path) -> None:
+    assert reeval_ged.checkpoint_signature()["schema_version"] == 7
+
+    checkpoint_dir = tmp_path / "reeval_ged"
+    checkpoint_dir.mkdir()
+    artifact = tmp_path / "candidate.c"
+    source = tmp_path / "current.pkl"
+    historical = tmp_path / "historical.pkl"
+    artifact.write_text("int f(void) { return 0; }\n")
+    source.write_bytes(b"current")
+    historical.write_bytes(b"historical")
+    signature = reeval_ged.checkpoint_signature()
+    prior = dict(signature)
+    prior["schema_version"] = 5
+    prior["historical_candidate_parse"] = "legacy-overlay-raw-v1"
+    checkpoint = checkpoint_dir / "O2__proj__bin__angr.json"
+    checkpoint.write_text(json.dumps({"_meta": prior, "scores": {}, "over_previous_limit": {}}))
+    task = (
+        "O2",
+        "proj",
+        "bin",
+        "angr",
+        str(artifact),
+        str(source),
+        str(historical),
+        False,
+        {},
+    )
+
+    migrated, require_replay = migrate_compatible_checkpoints(
+        checkpoint_dir,
+        [task],
+        signature,
+    )
+
+    assert (migrated, require_replay) == (0, 0)
+    assert json.loads(checkpoint.read_text())["_meta"] == prior
+
+
 def test_checkpoint_migration_rejects_stored_fallback_mismatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_source_cfg_ownership.py
+++ b/tests/test_source_cfg_ownership.py
@@ -1,0 +1,95 @@
+"""Deterministic source-CFG ownership regressions that need no compiler or binary fixture."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import networkx as nx
+import pytest
+
+
+def _graph(size: int) -> nx.DiGraph:
+    cfg = nx.DiGraph()
+    cfg.add_edges_from(zip(range(size - 1), range(1, size), strict=True))
+    return cfg
+
+
+def test_source_function_owners_match_object_prefixed_tu_stem(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public owner helper uniquely maps a DWARF decl-file to a prefixed TU."""
+    from decbench.utils import binfmt
+
+    cu = SimpleNamespace(cu_offset=0, header={"version": 4})
+    cu.get_top_DIE = lambda: SimpleNamespace(attributes={})
+    die = SimpleNamespace(
+        tag="DW_TAG_subprogram",
+        cu=cu,
+        attributes={
+            "DW_AT_low_pc": SimpleNamespace(value=0x12DA),
+            "DW_AT_name": SimpleNamespace(value=b"main"),
+            "DW_AT_decl_file": SimpleNamespace(value=1),
+        },
+    )
+    cu.iter_DIEs = lambda: iter((die,))
+    dwarf = SimpleNamespace(iter_CUs=lambda: iter((cu,)))
+    monkeypatch.setattr(binfmt, "dwarf_info", lambda _path: dwarf)
+    monkeypatch.setattr(binfmt, "cu_file_table", lambda *_args: [None, "prog1.c"])
+
+    assert binfmt.source_function_owners(Path("unused"), {"package-prog1"}) == {
+        0x12DA: ("main", "package-prog1")
+    }
+    assert binfmt.source_function_owners(Path("unused"), {"first-prog1", "second-prog1"}) == {}
+
+
+def test_inline_evaluation_carries_partial_dwarf_tu_ownership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Known owners stay exact while unknown addresses retain name fallback."""
+    from decbench.evalkit import ingest
+    from decbench.models.decompilation import (
+        DecompilationResult,
+        DecompilerMetadata,
+        FunctionDecompilation,
+    )
+
+    compiled = tmp_path / "O0" / "shadow" / "compiled"
+    compiled.mkdir(parents=True)
+    for stem in ("new_subid_range-new_subid_range", "login"):
+        (compiled / f"{stem}.i").write_text("")
+    binary = compiled / "new_subid_range"
+
+    main = FunctionDecompilation(name="main", address=0x12DA, decompiled_code="")
+    helper = FunctionDecompilation(name="helper", address=0x2000, decompiled_code="")
+    result = DecompilationResult(
+        binary_path=binary,
+        binary_name=binary.name,
+        decompiler=DecompilerMetadata(decompiler_name="test"),
+        functions={"main": main, "helper": helper},
+    )
+    entry = ingest._Entry("shadow", "O0", binary.name, binary, result, {0x12DA, 0x2000})
+
+    monkeypatch.setattr(
+        ingest,
+        "_function_owners_for_addrs",
+        lambda *_args: {0x12DA: ("main", "new_subid_range-new_subid_range")},
+    )
+    monkeypatch.setattr(
+        "decbench.utils.cfg.extract_cfgs_from_source",
+        lambda path: (
+            {"main": _graph(4)}
+            if path.stem.startswith("new_subid_range")
+            else {"main": _graph(40), "helper": _graph(7)}
+        ),
+    )
+    seen: dict[str, int] = {}
+
+    def evaluate(_result, source_cfgs, _metric_names):
+        seen["main_nodes"] = source_cfgs["main"].number_of_nodes()
+        seen["helper_nodes"] = source_cfgs["helper"].number_of_nodes()
+        return {}
+
+    monkeypatch.setattr("decbench.pipeline.evaluate.evaluate_decompilation", evaluate)
+
+    ingest._evaluate_group(tmp_path, "shadow", "O0", [entry], ["ged"], True, [])
+
+    assert seen == {"main_nodes": 4, "helper_nodes": 7}


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Source-CFG scoring can select another translation unit's same-named function when an executable name does not match its defining source. This silently corrupts GED inputs in eval-kit ingestion, live evaluation, dataset export, and reevaluation.

This carries each DWARF function's address and declaration-file owner through source resolution. Exact ownership wins; unknown ownership retains the existing binary-name and cross-TU fallback, while a known missing owner abstains.

Regressions cover prefixed translation-unit names, ambiguous owners, exact precedence, partial metadata, cache invalidation, and compatibility fallback.

[Validation record](https://github.com/Noelo-Lab/decbench/pull/74#issuecomment-5420445647)
