### PR TITLE
[AUTOMATED] Stabilize byte matching under GCC 15

### DIFF
--- a/decbench/metrics/byte_match.py
+++ b/decbench/metrics/byte_match.py
@@ -230,7 +230,7 @@ class ByteMatchMetric(Metric):
     requires_source_cfg = False
     requires_decompiled_cfg = False
 
-    cache_version = "6"
+    cache_version = "7"
 
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)
@@ -341,7 +341,7 @@ class ByteMatchMetric(Metric):
                 metadata={
                     "compilable": False,
                     "fixup_iterations": fix.iterations,
-                    "error": "Compilation failed",
+                    "error": fix.error or "Compilation failed",
                 },
             )
 

--- a/decbench/metrics/fixup.py
+++ b/decbench/metrics/fixup.py
@@ -88,6 +88,13 @@ _STRUCT_TYPEDEF = re.compile(r"typedef\s+struct\s+(\w+)\s*\{[^{}]*\}\s*\1\s*;")
 
 _STRING_OR_CHAR = re.compile(r'"(?:[^"\\\n]|\\.)*"|\'(?:[^\'\\\n]|\\.)*\'')
 
+_DIAGNOSTIC_LINE = re.compile(r"^(?:.*?:\s*)?((?:fatal )?error):\s*(.+)$", re.MULTILINE)
+_DIAGNOSTIC_CLASS = re.compile(r"\[(-W[^\]\s]+)\]")
+_DIAGNOSTIC_QUOTED = re.compile(r"'[^'\n]*'|‘[^’\n]*’|“[^”\n]*”|\"[^\"\n]*\"")
+_DIAGNOSTIC_ABSOLUTE_PATH = re.compile(r"(?:[A-Za-z]:)?[/\\][^\s:]+")
+_DIAGNOSTIC_SOURCE_EXCERPT = re.compile(r"^\s*\d+\s*\|")
+_DIAGNOSTIC_LIMIT = 400
+
 
 def _sub_outside_strings(pattern: re.Pattern, repl, code: str) -> str:
     """Apply ``pattern.sub(repl, ...)`` only to spans outside string literals."""
@@ -783,6 +790,56 @@ def _errors_with_snippets(stderr: str) -> list[tuple[str, str]]:
     return [(m.group(1), m.group(2)) for m in _RE_ERR_SNIPPET.finditer(stderr)]
 
 
+def _summarize_compiler_errors(stderr: str) -> str:
+    """Return a bounded, deterministic summary of compiler error lines."""
+    classes: set[str] = set()
+    messages: set[str] = set()
+    for line in stderr.splitlines():
+        if _DIAGNOSTIC_SOURCE_EXCERPT.match(line):
+            continue
+        match = _DIAGNOSTIC_LINE.match(line)
+        if match is None:
+            continue
+        severity, message = match.groups()
+        classes.update(_DIAGNOSTIC_CLASS.findall(message))
+        message = _DIAGNOSTIC_CLASS.sub("", message)
+        message = _DIAGNOSTIC_QUOTED.sub("<redacted>", message)
+        message = _DIAGNOSTIC_ABSOLUTE_PATH.sub("<path>", message)
+        if message.endswith(": No such file or directory"):
+            message = re.sub(r"^\S+(?=: No such file or directory$)", "<path>", message)
+        message = " ".join(message.split()).strip()
+        if message:
+            messages.add(f"{severity}: {message}")
+
+    if not messages:
+        return "unrepairable"
+
+    class_prefix = f" [{', '.join(sorted(classes))}]" if classes else ""
+    summary = f"compiler diagnostics{class_prefix}: {'; '.join(sorted(messages))}"
+    if len(summary) <= _DIAGNOSTIC_LIMIT:
+        return summary
+
+    clipped = summary[: _DIAGNOSTIC_LIMIT - 3]
+    boundary = max(clipped.rfind(" "), clipped.rfind(";"))
+    if boundary >= _DIAGNOSTIC_LIMIT // 2:
+        clipped = clipped[:boundary]
+    return clipped.rstrip(" ,;") + "..."
+
+
+def _has_language_mode(flags: list[str]) -> bool:
+    """Whether direct caller flags select a C language mode."""
+    for index, flag in enumerate(flags):
+        if flag in {"-ansi", "--ansi"} or flag.startswith(("-std=", "--std=")):
+            return True
+        if (
+            flag in {"-std", "--std"}
+            and index + 1 < len(flags)
+            and not flags[index + 1].startswith("-")
+        ):
+            return True
+    return False
+
+
 def _build_source(code: str, decls: dict[str, str], structs: dict[str, list[str]]) -> str:
     """Assemble the candidate TU: includes + synthesized structs + injected
     decls/macros + code."""
@@ -904,6 +961,14 @@ def compile_with_fixup(
         flags = ["-O2", "-c", "-fno-builtin"]
     # No -w: implicit-declaration warnings are what drive prototype injection.
     flags = [f for f in flags if f != "-w"]
+    if not _has_language_mode(flags):
+        flags.append("-std=gnu17")
+    flags.extend(
+        [
+            "-Wno-error=incompatible-pointer-types",
+            "-Wno-error=int-conversion",
+        ]
+    )
 
     code = sanitize_tokens(code)
     decls: dict[str, str] = {}
@@ -1349,5 +1414,5 @@ def compile_with_fixup(
     return fail(
         _build_source(code, decls, structs),
         iteration,
-        (last_err or "").strip()[-400:] or "unrepairable",
+        _summarize_compiler_errors(last_err),
     )

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -234,7 +234,7 @@ otherwise; flags read from the DWARF producer), via `decbench/utils/binfmt.py`.
 Returns a non-scoring result (an **abstention**, not a 0) if that toolchain
 isn't installed — don't fake a wrong-arch recompile. Works on ELF and PE.
 
-### The two fairness passes (v5, `cache_version="5"`)
+### The two fairness passes (`cache_version="7"`)
 
 Raw decompiler output rarely recompiles as-is (pseudo-types like
 `undefined4`, illegal tokens like `GLIBC_2.2.5::stderr`), so naive
@@ -251,7 +251,17 @@ before changing them, and bump `cache_version` if you do:
    via `derive_context_decls`, synthesized structs, width-typed globals,
    positional edits) and never redefines what the decompiler declared. This
    *maximizes compilation* uniformly (sailr O0 compile rate ~20-79% raw →
-   ~83-95% fixed, per decompiler).
+   ~83-95% fixed, per decompiler). If the flags passed to
+   `compile_with_fixup` contain no explicit language mode, the fixup uses
+   `-std=gnu17`; explicit `-ansi`/`--ansi` and `-std`/`--std` modes remain
+   unchanged.
+   The loop keeps implicit-function-declaration diagnostics visible so it can
+   inject prototypes, while trailing
+   `-Wno-error=incompatible-pointer-types` and `-Wno-error=int-conversion`
+   flags prevent type-recovery mistakes from blocking this byte-level metric.
+   A terminal failure retains a deterministic summary of compiler error
+   messages and warning-class tags in the per-function metadata, bounded to
+   400 characters and stripped of paths, source excerpts, carets, and notes.
 2. **Operand normalization** in `_disassemble_bytes` (byte_match.py) blanks
    link-time-dependent operands (direct branch/call targets, rip/pc-relative
    memory INCLUDING the unlinked object's bare `[rip]` form) and drops x86-64

--- a/tests/test_byte_match_fixup_policy.py
+++ b/tests/test_byte_match_fixup_policy.py
@@ -1,0 +1,195 @@
+"""Compiler-free policy tests for the byte-match compilability fixup."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from decbench.metrics.byte_match import ByteMatchMetric
+from decbench.metrics.fixup import FixupResult, _summarize_compiler_errors, compile_with_fixup
+from decbench.models.decompilation import FunctionDecompilation
+
+
+def _failed_compile(stderr: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], 1, stderr=stderr)
+
+
+def test_default_mode_demotions_and_implicit_repair(monkeypatch) -> None:
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_compile(
+        src: str, obj_path: Path, compiler: str, flags: list[str]
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((src, list(flags)))
+        if len(calls) == 1:
+            return _failed_compile("error: implicit declaration of function 'missing_helper'")
+        return _failed_compile("error: deliberately unrepairable")
+
+    monkeypatch.setattr("decbench.metrics.fixup._gcc_compile", fake_compile)
+    caller_flags = [
+        "-O2",
+        "-w",
+        "-Werror",
+        "-Werror=implicit-function-declaration",
+        "-Werror=incompatible-pointer-types",
+        "-Werror=int-conversion",
+    ]
+    original_flags = list(caller_flags)
+
+    result = compile_with_fixup("int f(void) { return missing_helper(); }", "f", flags=caller_flags)
+
+    expected_flags = [
+        "-O2",
+        "-Werror",
+        "-Werror=implicit-function-declaration",
+        "-Werror=incompatible-pointer-types",
+        "-Werror=int-conversion",
+        "-std=gnu17",
+        "-Wno-error=incompatible-pointer-types",
+        "-Wno-error=int-conversion",
+    ]
+    assert [flags for _, flags in calls] == [expected_flags, expected_flags]
+    assert "long missing_helper();" in calls[1][0]
+    assert caller_flags == original_flags
+    assert not result.compilable
+
+
+@pytest.mark.parametrize(
+    "language_mode",
+    [
+        ["-ansi"],
+        ["--ansi"],
+        ["-std=gnu11"],
+        ["--std=gnu11"],
+        ["-std", "gnu11"],
+        ["--std", "gnu11"],
+    ],
+)
+def test_preserves_explicit_language_mode(monkeypatch, language_mode: list[str]) -> None:
+    calls: list[list[str]] = []
+
+    def fake_compile(
+        src: str, obj_path: Path, compiler: str, flags: list[str]
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(flags))
+        return _failed_compile("error: deliberately unrepairable")
+
+    monkeypatch.setattr("decbench.metrics.fixup._gcc_compile", fake_compile)
+    caller_flags = ["-O1", *language_mode, "-Werror"]
+    original_flags = list(caller_flags)
+
+    compile_with_fixup("int f(void) { return 0; }", "f", flags=caller_flags)
+
+    assert calls == [
+        [
+            *original_flags,
+            "-Wno-error=incompatible-pointer-types",
+            "-Wno-error=int-conversion",
+        ]
+    ]
+    assert "-std=gnu17" not in calls[0]
+    assert caller_flags == original_flags
+
+
+def test_diagnostic_summary_is_deterministic_and_private() -> None:
+    first = "\n".join(
+        [
+            "/tmp/nix-shell.a/tmpA.c:7:9: error: passing argument 1 of "
+            "'customer_secret_a' makes pointer from integer without a cast "
+            "[-Wint-conversion]",
+            "    7 | send(customer_secret_a);",
+            "      |      ^~~~~~~~~~~~~~~~~",
+            "/tmp/nix-shell.a/tmpA.c:8:2: fatal error: "
+            "'/tmp/nix-shell.a/private-a.h': incompatible pointer type "
+            "[-Wincompatible-pointer-types]",
+            "note: private implementation detail",
+        ]
+    )
+    second = "\n".join(
+        [
+            "/tmp/nix-shell.b/tmpB.c:91:4: error: passing argument 1 of "
+            "'customer_secret_b' makes pointer from integer without a cast "
+            "[-Wint-conversion]",
+            "   91 | entirely_different_private_source();",
+            "      |    ^~~~~",
+            "/tmp/nix-shell.b/tmpB.c:104:8: fatal error: "
+            "'/tmp/nix-shell.b/private-b.h': incompatible pointer type "
+            "[-Wincompatible-pointer-types]",
+            "note: another private implementation detail",
+        ]
+    )
+
+    first_summary = _summarize_compiler_errors(first)
+    second_summary = _summarize_compiler_errors(second)
+
+    assert first_summary == second_summary
+    assert first_summary == (
+        "compiler diagnostics [-Wincompatible-pointer-types, -Wint-conversion]: "
+        "error: passing argument 1 of <redacted> makes pointer from integer without a cast; "
+        "fatal error: <redacted>: incompatible pointer type"
+    )
+    assert len(first_summary) <= 400
+    assert "/tmp" not in first_summary
+    assert "secret" not in first_summary
+    assert "source" not in first_summary
+    assert "note:" not in first_summary
+    assert "^" not in first_summary
+
+
+def test_diagnostic_summary_rejects_source_excerpts_with_error_text() -> None:
+    stderr = "\n".join(
+        [
+            "/tmp/unit.c:7:9: error: incompatible pointer type " "[-Wincompatible-pointer-types]",
+            "    7 | private_label: error: CUSTOMER_PRIVATE_TOKEN",
+            '    8 | log_message("prefix: error: CUSTOMER_PRIVATE_QUOTED");',
+        ]
+    )
+
+    summary = _summarize_compiler_errors(stderr)
+
+    assert summary == (
+        "compiler diagnostics [-Wincompatible-pointer-types]: " "error: incompatible pointer type"
+    )
+    assert "CUSTOMER_PRIVATE_TOKEN" not in summary
+    assert "CUSTOMER_PRIVATE_QUOTED" not in summary
+
+
+def test_terminal_diagnostic_summary_is_bounded_without_midword_cut(monkeypatch) -> None:
+    diagnostic = "unit.c:1:1: error: " + "overflow " * 100 + "[-Wint-conversion]"
+
+    def fake_compile(
+        src: str, obj_path: Path, compiler: str, flags: list[str]
+    ) -> subprocess.CompletedProcess[str]:
+        return _failed_compile(diagnostic)
+
+    monkeypatch.setattr("decbench.metrics.fixup._gcc_compile", fake_compile)
+
+    result = compile_with_fixup("int f(void) { return 0; }", "f")
+
+    assert result.error is not None
+    assert len(result.error) <= 400
+    assert result.error.startswith("compiler diagnostics [-Wint-conversion]: error:")
+    assert result.error.endswith("overflow...")
+
+
+def test_byte_match_retains_fixup_diagnostic(monkeypatch) -> None:
+    diagnostic = "compiler diagnostics [-Wint-conversion]: error: incompatible pointer conversion"
+    failure = FixupResult(None, "int f(void);", False, 2, [], diagnostic)
+    monkeypatch.setattr(
+        "decbench.metrics.fixup.compile_with_fixup", lambda *args, **kwargs: failure
+    )
+    decompiled = FunctionDecompilation(
+        name="f",
+        address=0x1000,
+        decompiled_code="int f(void) { return 0; }",
+    )
+
+    result = ByteMatchMetric()._compute_uncached(decompiled, b"\x90", "gcc", [], None)
+
+    assert result.metadata == {
+        "compilable": False,
+        "fixup_iterations": 2,
+        "error": diagnostic,
+    }


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

Make DecBench's byte-match recompilation stable on GCC 15 while preserving an explicitly selected C language mode.

- Default `compile_with_fixup()` to GNU17 only when its caller did not pass `-ansi`, `--ansi`, or an attached/separated `-std`/`--std` option.
- Keep incompatible pointer/integer conversions non-fatal so declaration recovery can proceed, without suppressing implicit-declaration diagnostics.
- Carry a deterministic, bounded compiler-error summary into ByteMatch metadata. The GCC-oriented summarizer ignores numbered GCC/Clang source excerpts and redacts quoted tokens and absolute paths before retaining genuine error diagnostics.
- Advance the ByteMatch content-cache version because both repaired scores and failure metadata can change.

## Why

GCC 15's current defaults can stop recompilation on common decompiler output before the existing declaration-recovery loop has a chance to repair it. That turns measurable functions into categorical byte-match zeroes and previously discarded the reason for the failure.

The default is deliberately applied at the direct `compile_with_fixup()` boundary. Producer flags are unchanged, and callers that select a language mode remain authoritative.

Focused policy regressions, the native repository suite, a real GCC 15.3 replay, and the complete workspace gate were run. The exact validation record is posted separately.
