### PR TITLE
[AUTOMATED] fix(metrics): sanitize computed gotos before the Joern parse

### DIFF
--- a/decbench/metrics/ged.py
+++ b/decbench/metrics/ged.py
@@ -153,7 +153,7 @@ class GEDMetric(Metric):
     requires_source_cfg = True
     requires_decompiled_cfg = True
 
-    cache_version = "3"
+    cache_version = "4"
 
     def __init__(self, config: MetricConfig | None = None):
         super().__init__(config)

--- a/decbench/utils/cfg.py
+++ b/decbench/utils/cfg.py
@@ -39,6 +39,11 @@ _FUNCTION_MARKER = re.compile(
     re.M,
 )
 
+# GNU computed goto (``goto *EXPR;``). Matched on masked text (see
+# :func:`rewrite_computed_gotos`) so literals and comments are never rewritten;
+# a plain ``goto label;`` has no ``*`` and never matches.
+_COMPUTED_GOTO = re.compile(r"\bgoto\s*\*")
+
 # Tab and newline are the emitted source's own layout, not literal payload.
 _KEEP_RAW_BYTES = frozenset({0x09, 0x0A})
 
@@ -75,11 +80,41 @@ def escape_literal_control_bytes(text: str) -> str:
     return "".join(out)
 
 
+def rewrite_computed_gotos(text: str) -> str:
+    """Replace GNU computed gotos with an empty compound statement.
+
+    ``goto *EXPR;`` is valid GNU C, but Joern parses it into ``UnsupportedStmt``
+    nodes whose block loses its entry-point role — so a correct single-block
+    function scores GED 2 instead of 0. The target of a computed goto is not
+    statically derivable, so the statement contributes no CFG edge either way;
+    replacing it with ``{}`` (rather than deleting it, which would break a
+    braceless ``if (c) goto *p; else ...``) leaves exactly the control flow the
+    surrounding code defines, with block roles intact. Matching runs on the
+    comment/literal-masked text, so a ``"goto *"`` inside a string is never
+    rewritten, and a plain ``goto label;`` never matches. Idempotent: the
+    replacement contains no ``goto *``.
+    """
+    code = _mask_c_noncode(text)
+    pieces: list[str] = []
+    pos = 0
+    for match in _COMPUTED_GOTO.finditer(code):
+        if match.start() < pos:
+            continue
+        end = code.find(";", match.end())
+        if end < 0:
+            continue
+        pieces.append(text[pos : match.start()])
+        pieces.append("{}")
+        pos = end + 1
+    pieces.append(text[pos:])
+    return "".join(pieces)
+
+
 def sanitize_decompiled_c(text: str) -> str:
     """Clean decompiler-specific C quirks that break Joern's parser.
 
     GED only cares about CFG *structure*, so these edits are purely to make the
-    body parseable — they never touch control flow. Four tool-specific quirks:
+    body parseable — they never touch control flow. Five quirks:
 
     * **Aggregate/array return type** (angr/ghidra): ``T [N] name(...)``
       is rewritten to ``T name(...)``. Anchored to the start of a line so a real
@@ -88,12 +123,15 @@ def sanitize_decompiled_c(text: str) -> str:
       is not valid C.
     * **128-bit types** (ida): ``__int128`` is widened to ``long long`` (the exact
       width is irrelevant to the CFG).
+    * **Computed gotos** (any decompiler emitting GNU C): ``goto *EXPR;`` becomes
+      an empty compound statement — see :func:`rewrite_computed_gotos`.
     * **Raw control bytes in literals**: escaped, so a verbatim ``.rodata`` string
       cannot make pyjoern's fast parser emit non-JSON and void the invocation.
     """
     text = _AGG_RETURN.sub(r"\1 \2", text)
     text = _REG_ANNOTATION.sub("", text)
     text = text.replace("unsigned __int128", "unsigned long long").replace("__int128", "long long")
+    text = rewrite_computed_gotos(text)
     return escape_literal_control_bytes(text)
 
 

--- a/tests/test_cfg_sanitize.py
+++ b/tests/test_cfg_sanitize.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from decbench.utils.cfg import escape_literal_control_bytes, sanitize_decompiled_c
+from decbench.utils.cfg import (
+    escape_literal_control_bytes,
+    rewrite_computed_gotos,
+    sanitize_decompiled_c,
+)
 
 
 class TestEscapeLiteralControlBytes:
@@ -55,3 +59,42 @@ class TestSanitizeDecompiledC:
 
     def test_still_widens_int128(self) -> None:
         assert sanitize_decompiled_c("unsigned __int128 x;") == "unsigned long long x;"
+
+    def test_applies_computed_goto_rewrite(self) -> None:
+        assert sanitize_decompiled_c("int f(void)\n{\n    goto *x;\n}\n") == (
+            "int f(void)\n{\n    {}\n}\n"
+        )
+
+
+class TestRewriteComputedGotos:
+    def test_plain_identifier_target(self) -> None:
+        assert rewrite_computed_gotos("goto *x;") == "{}"
+
+    def test_cast_and_parenthesized_target(self) -> None:
+        assert rewrite_computed_gotos("goto *((void *)(a0->field_dc->field_10));") == "{}"
+
+    def test_function_pointer_cast_target(self) -> None:
+        assert rewrite_computed_gotos("goto *(void (*)(void))expr;") == "{}"
+
+    def test_table_indexed_target(self) -> None:
+        assert rewrite_computed_gotos("goto *(fn_table[i]);") == "{}"
+
+    def test_braceless_if_branch_stays_valid(self) -> None:
+        out = rewrite_computed_gotos("if (c)\n    goto *p;\nelse\n    goto done;")
+        assert out == "if (c)\n    {}\nelse\n    goto done;"
+
+    def test_plain_goto_untouched(self) -> None:
+        code = "goto LABEL_800083f;"
+        assert rewrite_computed_gotos(code) == code
+
+    def test_string_literal_untouched(self) -> None:
+        code = 's = "contains goto *x; in a string";'
+        assert rewrite_computed_gotos(code) == code
+
+    def test_comment_untouched(self) -> None:
+        code = "// goto *x;\ngoto real_label;"
+        assert rewrite_computed_gotos(code) == code
+
+    def test_idempotent(self) -> None:
+        once = rewrite_computed_gotos("goto *((void *)(x));")
+        assert rewrite_computed_gotos(once) == once


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

GED's decompiled-side parse scores a *valid*-C construct worse than the
*invalid* form older decompiler versions emitted for the same code. This PR
extends `sanitize_decompiled_c` (the uniform pre-parse sanitization every
decompiler column already goes through) with one rewrite:

* **GNU computed gotos** — `goto *EXPR;` in any form (`goto *x;`,
  `goto *((void *)(expr));`, `goto *(fn_table[i]);`, arbitrary
  parenthesization/casts) is replaced with an empty compound statement `{}`.

The rewrite operates on comment/string-masked text (string literals and
comments are never touched), leaves plain `goto label;` alone, keeps a
braceless `if (c) goto *p; else ...` valid (which is why it is `{}` and not
deletion), and is idempotent. `GEDMetric.cache_version` is bumped to `4`
because the decompiled-side parse input changed (this also invalidates
`scripts/reeval_ged.py` checkpoints via `checkpoint_signature()`).

## Mechanism

GED reads graph topology plus each node's `is_entrypoint`/`is_exitpoint`
roles. pyjoern/Joern parses a computed goto into `UnsupportedStmt` nodes
whose block **loses the entry-point role**, so a *correct* single-block
function scores GED 2 instead of 0. A computed goto's target is not
statically derivable, so the statement can contribute no CFG edge in any
case; replacing it with `{}` preserves exactly the control flow the
surrounding code defines, with block roles intact.

Concrete example (libopencm3 `usbd_ep_stall_set`, a single-block indirect
tail call, source CFG = 1 node with roles (entry, exit)):

* angr@9.2.x master renders `goto a0->field_dc->field_10;` — **invalid C**.
  Joern parses it leniently into an empty single block with roles
  (True, True) -> isomorphic -> GED **0.0**.
* angr master + angr/angr#6974 ("Decompiler: render expression jumps as
  computed gotos") renders `goto *((void *)(a0->field_dc->field_10));` —
  **valid GNU C**. Joern parses it into an `UnsupportedStmt` block with
  `is_entrypoint=False` -> role mismatch -> GED **2.0**.

The current pipeline therefore rewards emitting invalid C, for any
decompiler that renders indirect jumps.

## Validation (all on the published full-config corpus)

**Unit tests**: `tests/test_cfg_sanitize.py` gains 10 cases (the four
computed-goto forms, braceless-if safety, plain gotos / string literals /
comments untouched, idempotency, the `sanitize_decompiled_c` hookup). Full
suite: identical pass/fail set as the base commit plus the new tests (the
pre-existing failures on our machine are environmental and unchanged).

**The 42 regressed functions** (our paired angr-dev-preview vs angr-master
full-config runs; every GED-perfect flip between the two columns traced to
this artifact):

| set | unfixed | fixed |
|---|---|---|
| 42 computed-goto functions (8 USB dispatchers x cdcacm/msc/usbmidi x O2/O2-noinline) | ged 2.0 | **ged 0.0 (all 42)** |
| the same 42 from the angr-master column | 0.0 | 0.0 (bit-identical) |

**Blast radius** — every function of every binary whose decompiled `.c`
contains a computed goto (131 binary-opt artifacts across both run columns,
64,775 functions re-scored under both sanitizers; binaries without the
construct are byte-identical under the new sanitizer, verified by hashing
the sanitized text). The unfixed arm reproduced the recorded pipeline
values exactly (0 drift), so every delta below is the fix:

| direction | functions | GED-perfect flips | GED-distance sum |
|---|---|---|---|
| unchanged | 64,323 | — | — |
| better | 378 | **+155 to perfect** | -2203 |
| worse | 74 | **0 lost** | +271 (median +3, max +29) |

The "worse" rows are functions whose source has real control flow but whose
decompilation is genuinely a single indirect jump (e.g. ChibiOS's
`__ch_delegate_fn0`: source 3 nodes / 3 edges, decompiled body is one
computed goto). The unfixed parse produced `UnsupportedStmt` junk nodes that
happened to collect partial credit against the real source nodes; the fix
removes that accidental credit. No function that was GED-perfect became
imperfect.

**Third-party columns** (published dataset artifacts, counted with the same
masked-text matcher — string literals excluded):

| column | computed gotos (files) | affected |
|---|---|---|
| angr | 64 (26) | yes |
| phoenix | 29 (21) | yes (site-hidden column) |
| ida, ghidra, binja, glaurung, r2dec, kuna, dewolf, manifold, fission, codex, claude-code | 0 | no — sanitized text byte-identical |

Effect direction on the published angr column (20-function sample re-scored
from the published artifacts through the materialized-tree evaluate path):
4 better — `_usbd_reset` 2.0 -> **0.0** in cdcacm/msc/usbmidi (new
perfects) and chibios `test_putchar` 6 -> 5; 3 worse — chibios
`__ch_delegate_fn0` 7 -> 10 (x2) and kmod `main` 60 -> 62 (the junk-credit
removal above); 13 unchanged. A 5-file ida spot re-score is bit-identical,
as the byte-identity proof predicts.

## This changes published scores

Adopting this PR and re-evaluating changes published GED numbers for the
angr and phoenix columns (the others are provably untouched). On our
measurements (paired full-config runs of angr master and an angr
development preview, tool at d9f4f8a, same toolchain both sides):

* angr-master column, full config (site rule, 94,575-fn denominators):
  GED perfect 32017 -> 32039 of 91072 (35.2%, +22 functions), Union
  35675 -> 35693 (37.8% -> 37.9%).
* angr-dev-preview column: GED perfect 32065 -> 32198 (35.2% -> 35.4%,
  +133), Union 35770 -> 35897 (37.9% -> 38.1%), mean GED 13.83 -> 13.81.
* The published angr 9.2.223 row (34.2% GED / 37.0% Union) would also
  shift upward on re-evaluation (64 computed gotos in 26 artifacts; see
  sample above). phoenix (29 in 21) shifts too; every other column is
  hash-provably untouched.
* Paired preview-vs-master GED flips move from +152/-104 to +162/-3: the
  loss column of that comparison was dominated by this parsing artifact.

CHANGELOG: not touched per repository policy; suggested entry — "GED:
computed gotos are sanitized before the Joern parse; valid GNU C jump
rendering no longer scores worse than the equivalent invalid form."

## Related artifact, deliberately NOT fixed here

A goto label closing a block with only a null statement (`LABEL:\n    ;`,
valid C) parses into an extra empty block, while the invalid bare trailing
`LABEL:` older decompilers emitted does not — the same valid-vs-invalid
inversion (it costs angr master + angr/angr#6731 five GED points on one
libopencm3 function, and ida's published column contains 232 such loop
tails). We prototyped the analogous sanitize rewrite and measured it over
every affected binary: 243 functions improved but 132 got worse and it cost
14 GED-perfects, because that empty block sometimes corresponds to a *real*
source block (an empty loop latch) and no textual rewrite can tell the two
apart. That one needs a parser-side (Joern/pyjoern) fix, not sanitization;
we report the data here so the scope cut is explicit.

## References

* angr/angr#6974 — Decompiler: render expression jumps as computed gotos
  (the change that made angr emit the valid form).
* The measurement runs used the public https://github.com/angr/vibr preview
  snapshot; the regression attribution and per-config bisection are
  reproducible from the published dataset artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
