### PR TITLE
[AUTOMATED] feat(binfmt): opt-in DW_AT_abstract_origin chase for C function discovery

### DIFF
--- a/decbench/evalkit/ingest.py
+++ b/decbench/evalkit/ingest.py
@@ -549,8 +549,11 @@ def _function_owners_for_addrs(
     if not stems or not addrs:
         return {}
     from decbench.utils import binfmt
+    from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
 
-    owners = binfmt.source_function_owners(binary, stems)
+    owners = binfmt.source_function_owners(
+        binary, stems, follow_abstract_origin=dwarf_follow_abstract_origin()
+    )
     return {addr: owner for addr, owner in owners.items() if addr in addrs}
 
 

--- a/decbench/evalkit/resolve.py
+++ b/decbench/evalkit/resolve.py
@@ -26,6 +26,7 @@ import os
 import struct
 from pathlib import Path
 
+from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
 from decbench.utils.langs import PREPROC_EXTS, build_stem_index, strip_source_ext
 
 _l = logging.getLogger(__name__)
@@ -53,7 +54,13 @@ def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
     ``main.c``). When ``stems`` is None the decl-file filter is skipped and every
     named subprogram with a ``low_pc`` is kept. Returns an empty map when the
     binary has no usable DWARF.
+
+    The ``DW_AT_abstract_origin`` chase for C concrete out-of-line instances
+    follows the same opt-in policy as the run driver
+    (:func:`decbench.utils.dwarf_policy.dwarf_follow_abstract_origin`), so the
+    eval kit resolves the same function set the run scored.
     """
+    follow = dwarf_follow_abstract_origin()
     from decbench.utils import binfmt
 
     try:
@@ -71,11 +78,13 @@ def _dwarf_addr_to_name(binary: Path, stems: set[str] | None) -> dict[int, str]:
             for die in cu.iter_DIEs():
                 if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
                     continue
-                name = binfmt.die_str_attr(die, "DW_AT_name")
+                name = binfmt.die_str_attr(die, "DW_AT_name", follow_abstract_origin=follow)
                 if name is None:
                     continue
                 if stems is not None:
-                    fi, owner = binfmt.die_attr_owner(die, "DW_AT_decl_file")
+                    fi, owner = binfmt.die_attr_owner(
+                        die, "DW_AT_decl_file", follow_abstract_origin=follow
+                    )
                     if fi is None:
                         continue
                     files = binfmt.cu_file_table(dw, owner.cu, file_tables)

--- a/decbench/metrics/type_match.py
+++ b/decbench/metrics/type_match.py
@@ -310,6 +310,11 @@ def _parse_function_die(die: Any, dwarfinfo: Any) -> tuple[str | None, list[dict
     the in-class declaration it references. C subprograms always name themselves
     on the defining DIE, so the chase never fires and C ground truth is byte-for-
     byte what it was.
+
+    ``DECBENCH_DWARF_ABSTRACT_ORIGIN`` deliberately does not reach here: this map
+    is keyed by name and already reads the abstract instance's parameters, so
+    chasing the origin would let a concrete instance overwrite that entry and move
+    type_match ground truth.
     """
     from decbench.utils import binfmt
 

--- a/decbench/pipeline/evaluate.py
+++ b/decbench/pipeline/evaluate.py
@@ -12,6 +12,7 @@ from decbench.metrics.registry import MetricRegistry
 from decbench.models.metrics import MetricResult
 from decbench.models.project import OptimizationLevel, Project
 from decbench.utils.cfg import extract_cfgs_from_decompilation, extract_cfgs_from_source
+from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +162,9 @@ def evaluate_project(
                 for decompilation in dec_results.values()
                 for function in decompilation.functions.values()
             }
-            owners = binfmt.source_function_owners(binary, source_stems)
+            owners = binfmt.source_function_owners(
+                binary, source_stems, follow_abstract_origin=dwarf_follow_abstract_origin()
+            )
             function_owners[binary_name] = {
                 addr: owner for addr, owner in owners.items() if addr in target_addrs
             }

--- a/decbench/publish/cfg_export.py
+++ b/decbench/publish/cfg_export.py
@@ -48,6 +48,7 @@ from decbench.utils.cfg import (
     resolved_source_for_binary,
     strip_system_headers,
 )
+from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
 from decbench.utils.results_tree import OPT_LEVELS, compiled_dir, resolve_binary
 
 if TYPE_CHECKING:
@@ -210,7 +211,13 @@ def _resolved_cfgs_for_opt(
     out: dict[str, dict[str, CfgSerial]] = {}
     for stem in stems:
         binary = resolve_binary(compiled_dir(root, opt, project), stem)
-        owners = binfmt.source_function_owners(binary, set(by_tu)) if binary is not None else None
+        owners = (
+            binfmt.source_function_owners(
+                binary, set(by_tu), follow_abstract_origin=dwarf_follow_abstract_origin()
+            )
+            if binary is not None
+            else None
+        )
         out[stem] = {
             name: _serialize(cfg)
             for name, cfg in resolved_source_for_binary(

--- a/decbench/utils/binfmt.py
+++ b/decbench/utils/binfmt.py
@@ -348,7 +348,7 @@ def cu_is_cxx(cu) -> bool:
     return attr is not None and attr.value in _CXX_LANGS
 
 
-def die_attr_owner(die, name: str):
+def die_attr_owner(die, name: str, *, follow_abstract_origin: bool = False):
     """``(attribute, owning DIE)`` for ``name``, following DIE reference chains.
 
     gcc splits an out-of-line C++ member definition in two: the defining DIE
@@ -359,18 +359,29 @@ def die_attr_owner(die, name: str):
     visible at all.
 
     ``DW_AT_specification`` is a C++-only construct, so following it can never
-    change a C result. ``DW_AT_abstract_origin`` is NOT — in C, gcc uses it for
-    the out-of-line copy it keeps of a function it also inlined, and following
-    it would newly surface ~10-20% more functions in the existing C corpus
-    (measured: grep at O2 goes 262 -> 314). That hop is therefore taken only in
-    a C++ compilation unit, which leaves every C binary bit-identical.
+    change a C result. ``DW_AT_abstract_origin`` is NOT — in C, gcc and clang use
+    it for the out-of-line copy they keep of a function they also inlined, and
+    following it newly surfaces ~10-20% more functions in the existing C corpus
+    (measured on grep at O2: 262 -> 314 named subprograms across the whole
+    binary, 56 -> 66 after this function's project-TU ``decl_file`` filter). That
+    hop is therefore taken only in a C++ compilation unit by default, which
+    leaves every C binary bit-identical.
+
+    ``follow_abstract_origin=True`` takes that hop in C units too. gcc and clang
+    split a C function that is BOTH inlined somewhere and kept out-of-line into
+    an abstract instance root (``DW_AT_name`` + ``DW_AT_inline``, no ``low_pc``)
+    and a concrete out-of-line instance (``DW_AT_low_pc``, no name, only
+    ``DW_AT_abstract_origin``). Without the hop the concrete body is invisible
+    to any name-keyed walk. OFF by default so every existing C result stays
+    bit-identical; opt in per call site, or process-wide via
+    :func:`decbench.utils.dwarf_policy.dwarf_follow_abstract_origin`.
 
     The owning DIE is returned because a CU-relative attribute value such as
     ``DW_AT_decl_file`` must be read against ITS CU's line program, not the
     starting DIE's.
     """
     cur = die
-    refs = _SPEC_AND_ORIGIN if cu_is_cxx(die.cu) else _SPEC_ONLY
+    refs = _SPEC_AND_ORIGIN if follow_abstract_origin or cu_is_cxx(die.cu) else _SPEC_ONLY
     for _ in range(_DIE_REF_MAX_HOPS + 1):
         attr = cur.attributes.get(name)
         if attr is not None:
@@ -389,14 +400,14 @@ def die_attr_owner(die, name: str):
     return None, None
 
 
-def die_attr(die, name: str):
+def die_attr(die, name: str, *, follow_abstract_origin: bool = False):
     """The attribute ``name``, following DIE reference chains (:func:`die_attr_owner`)."""
-    return die_attr_owner(die, name)[0]
+    return die_attr_owner(die, name, follow_abstract_origin=follow_abstract_origin)[0]
 
 
-def die_str_attr(die, name: str) -> str | None:
+def die_str_attr(die, name: str, *, follow_abstract_origin: bool = False) -> str | None:
     """:func:`die_attr` decoded to ``str``, or None when absent."""
-    attr = die_attr(die, name)
+    attr = die_attr(die, name, follow_abstract_origin=follow_abstract_origin)
     if attr is None:
         return None
     val = attr.value
@@ -427,12 +438,19 @@ def cu_file_table(dwarfinfo, cu, cache: dict[int, list] | None = None) -> list:
     return files
 
 
-def source_function_owners(path: Path, source_stems: set[str]) -> dict[int, tuple[str, str]]:
+def source_function_owners(
+    path: Path, source_stems: set[str], *, follow_abstract_origin: bool = False
+) -> dict[int, tuple[str, str]]:
     """Map DWARF function addresses to ``(name, defining source-TU stem)``.
 
     Only definitions whose ``DW_AT_decl_file`` matches one of ``source_stems``
     are returned. Object-prefixed preprocessed stems such as ``program-main``
     match a declaration file named ``main.c``.
+
+    ``follow_abstract_origin=True`` also resolves a C concrete out-of-line
+    instance through its ``DW_AT_abstract_origin`` (see :func:`die_attr_owner`),
+    which is the only way to see a function the compiler both inlined and emitted
+    out-of-line at ``-O2``. Default OFF: every existing result is unchanged.
     """
     if not source_stems:
         return {}
@@ -454,10 +472,14 @@ def source_function_owners(path: Path, source_stems: set[str]) -> dict[int, tupl
             for die in cu.iter_DIEs():
                 if die.tag != "DW_TAG_subprogram" or "DW_AT_low_pc" not in die.attributes:
                     continue
-                name = die_str_attr(die, "DW_AT_name")
+                name = die_str_attr(
+                    die, "DW_AT_name", follow_abstract_origin=follow_abstract_origin
+                )
                 if name is None:
                     continue
-                fi, owner = die_attr_owner(die, "DW_AT_decl_file")
+                fi, owner = die_attr_owner(
+                    die, "DW_AT_decl_file", follow_abstract_origin=follow_abstract_origin
+                )
                 if fi is None:
                     continue
                 files = cu_file_table(dw, owner.cu, file_tables)

--- a/decbench/utils/dwarf_policy.py
+++ b/decbench/utils/dwarf_policy.py
@@ -1,0 +1,49 @@
+"""Opt-in policy knobs for the DWARF function-discovery walk.
+
+``DECBENCH_DWARF_ABSTRACT_ORIGIN=1`` makes the function-discovery walk
+(:func:`decbench.utils.binfmt.source_function_owners` and the walks that mirror
+it) resolve a C *concrete out-of-line instance* through its
+``DW_AT_abstract_origin``.
+
+Why it is a switch and not the default: gcc and clang split a C function that is
+both inlined at some call site and still emitted out-of-line into an abstract
+instance root (``DW_AT_name`` + ``DW_AT_inline``, no ``low_pc``) and a concrete
+out-of-line instance (``DW_AT_low_pc``, no name, only ``DW_AT_abstract_origin``).
+Neither half survives a walk that wants a ``low_pc`` and then a name, so the real
+body is invisible. Taking the hop makes those bodies visible, and it also newly
+surfaces functions in every already-published C result, which would move
+historical scores. Default OFF keeps every existing result tree bit-identical; a
+run that wants the bodies opts in.
+
+Measured over the public corpus (``projects/{sailr,cps,malware}``, 40 projects,
+288 binaries) at ``-O2``: DWARF-resolved source-function owners go 26,346 ->
+29,956 (+13.7%; +19.0% on the sailr corpus alone), recovering real out-of-line
+bodies such as zlib's ``gz_read`` and ``inflateReset``, bzip2's
+``BZ2_bzWriteOpen``, grep's ``treenext`` and tar's ``chdir_do``. At ``-O0`` the
+sailr and malware corpora are unchanged and three ``always_inline``-heavy
+firmware targets move by 12 owners in total. ``O2-noinline`` still gains 4.8%,
+because ``-fno-inline`` suppresses neither ``always_inline`` nor the
+abstract-instance shape emitted for header-defined statics.
+
+Scope: honoured by the run driver's target-set walk, ``pipeline.evaluate``, the
+offline GED re-evaluation, the source-CFG export and the eval kit, so all of them
+agree on one function set. Deliberately NOT applied to two name-keyed maps, for
+two different reasons. :func:`decbench.metrics.type_match.extract_ground_truth_types`
+has no ``low_pc`` requirement, so it already collects the abstract instance and its
+parameters; taking the hop there would let the unnamed concrete instance overwrite
+that entry and move type_match ground truth. :mod:`decbench.utils.source_extract`
+does require ``low_pc``, so today it simply omits such a function — taking the hop
+there would be additive rather than corrupting, but it is left out so this knob has
+exactly one meaning, the function-discovery set, and nothing else shifts with it.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["dwarf_follow_abstract_origin"]
+
+
+def dwarf_follow_abstract_origin() -> bool:
+    """Whether the function-discovery DWARF walk chases ``DW_AT_abstract_origin`` in C."""
+    return os.environ.get("DECBENCH_DWARF_ABSTRACT_ORIGIN") == "1"

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -294,6 +294,43 @@ DECBENCH_WORKERS=40 GHIDRA_INSTALL_DIR=/home/mahaloz/bin/ghidra_12.1 \
   runs)
 - `DECBENCH_OPT_LEVELS` (comma list, e.g. `"O0"` to narrow the run)
 - `DECBENCH_METRICS` (comma list, e.g. `"ged"` for a GED-only run)
+- `DECBENCH_DWARF_ABSTRACT_ORIGIN` (default off; set to exactly `1` — `0`,
+  `true` and any other value are off) — follow `DW_AT_abstract_origin` when
+  discovering functions in a **C** compilation unit.
+
+### `DECBENCH_DWARF_ABSTRACT_ORIGIN` — recovering inlined-and-out-of-line C bodies
+
+gcc and clang split a C function that is both inlined at some call site and still
+emitted out-of-line into two DIEs: an abstract instance root (`DW_AT_name` +
+`DW_AT_inline`, no `low_pc`) and a concrete out-of-line instance (`DW_AT_low_pc`,
+no name, only `DW_AT_abstract_origin`). The function-discovery walk wants a
+`low_pc` and then a name, so neither half qualifies and the real body is invisible
+to the decompile target set, to `_relabel_to_dwarf`'s address->name map (the body
+stays `sub_XXXX` and is dropped as unresolved), and to `evaluate_project`'s
+`source_function_owners`. Setting the knob takes the `DW_AT_abstract_origin` hop
+in C units and recovers those bodies. C++ units already take the hop
+unconditionally (`DW_AT_specification` chasing is what makes C++ functions visible
+at all), so the knob does not change any C++ result.
+
+Measured over the public corpus (`projects/{sailr,cps,malware}`, 40 projects, 288
+binaries) at `-O2`, DWARF-resolved source-function owners go 26,346 -> 29,956
+(+13.7%; +19.0% on the sailr corpus alone), recovering bodies such as zlib's
+`gz_read` and `inflateReset`, bzip2's `BZ2_bzWriteOpen`, grep's `treenext` and
+tar's `chdir_do`. At `-O0` the sailr and malware corpora are unchanged; three
+`always_inline`-heavy firmware targets move by 12 owners in total. `O2-noinline`
+still gains 4.8% — it is **not** a null control, because `-fno-inline` suppresses
+neither `always_inline` nor the abstract-instance shape emitted for header-defined
+statics.
+
+**It is off by default because turning it on moves published numbers.** With it
+unset, the walk returns exactly what it returned before the knob existed, so every
+existing result tree stays bit-identical. Turn it on and the scored function set
+grows, so a tree built with it on is not comparable to one built with it off —
+treat it like any other change that moves scores (snapshot first, see
+`docs/site.md`). The knob is read process-wide by the run driver, `pipeline`
+evaluation, `scripts/reeval_ged.py`, the source-CFG export and the eval kit, so
+those all agree on one function set; it deliberately does **not** reach
+`metrics/type_match.py` (see `docs/metrics.md`).
 
 ### Per-decompiler wall-clock budgets
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -224,12 +224,30 @@ declaration. The two reference attributes are NOT equivalent:
   in-class declaration). Following it can never change a C result, so it is
   always followed.
 - **`DW_AT_abstract_origin`** is used in C too — for the out-of-line copy gcc
-  keeps of a function it also inlined. Following it in C would newly surface
-  ~10-20% more functions in the pinned corpus (measured on grep at O2: 262 ->
-  314 DWARF subprograms). It is therefore followed **only in a C++
-  compilation unit** (`binfmt.cu_is_cxx`, on `DW_AT_language`), which keeps
-  every existing C binary bit-identical. Enabling it for C is a deliberate,
-  corpus-invalidating change that has not been made.
+  and clang keep of a function they also inlined. Following it in C newly
+  surfaces ~10-20% more functions in the pinned corpus (measured on grep at O2:
+  262 -> 314 named subprograms across the whole binary, 56 -> 66 after the
+  project-TU `decl_file` filter that `source_function_owners` applies). It is
+  therefore followed **unconditionally only in a C++ compilation unit**
+  (`binfmt.cu_is_cxx`, on `DW_AT_language`), which keeps every existing C binary
+  bit-identical.
+
+  Enabling it for C is a deliberate, corpus-invalidating change, so it is an
+  opt-in switch rather than a default: `DECBENCH_DWARF_ABSTRACT_ORIGIN=1` turns
+  it on for the function-discovery walk
+  (`binfmt.source_function_owners`) and everything that mirrors it — the run
+  driver's target set, `pipeline/evaluate.py`, `scripts/reeval_ged.py`, the
+  source-CFG export and the eval kit. Unset, the walk returns exactly what it
+  returned before the switch existed. Rationale and public measurements:
+  [`docs/benchmarking.md`](benchmarking.md).
+
+  **The switch deliberately does not reach `type_match`.**
+  `extract_ground_truth_types` keys its map by function NAME and the abstract
+  instance already supplies the parameters, so the entry is present with or
+  without the hop. Chasing the origin there would merely let a concrete instance
+  overwrite that entry with the same name — moving type_match ground truth for no
+  gain. `_parse_function_die` therefore keeps the plain `die_str_attr` read, and
+  type_match's `cache_version` is untouched by this switch.
 
 ## Recompilation Bytematch — `metrics/byte_match.py`
 

--- a/scripts/reeval_ged.py
+++ b/scripts/reeval_ged.py
@@ -814,13 +814,18 @@ def eval_one(
         resolved_source_for_binary,
         sanitize_decompiled_c,
     )
+    from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
     from decbench.utils.results_tree import resolve_binary
 
     per_stem, best_by_name = _load_src(src_pkl)
     compiled = Path(c_path).parent.parent / "compiled"
     binary = resolve_binary(compiled, stem)
     function_owners = (
-        binfmt.source_function_owners(binary, set(per_stem)) if binary is not None else None
+        binfmt.source_function_owners(
+            binary, set(per_stem), follow_abstract_origin=dwarf_follow_abstract_origin()
+        )
+        if binary is not None
+        else None
     )
     src_cfgs = resolved_source_for_binary(
         stem,

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -45,6 +45,7 @@ from decbench.results_store import PROJECT_DIRS  # noqa: F401,E402
 from decbench.results_store import gather_project_tomls as gather_tomls
 from decbench.utils import binfmt  # noqa: E402
 from decbench.utils.cfg import extract_cfgs_from_source  # noqa: E402
+from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin  # noqa: E402
 
 OPT_LEVELS = [
     OptimizationLevel.O0,
@@ -165,7 +166,9 @@ def project_source_functions(
     symbols), where decompilers only know functions by address. Returns an empty
     map if there is no usable DWARF (caller then falls back to all functions).
     """
-    owners = binfmt.source_function_owners(binary_path, source_stems)
+    owners = binfmt.source_function_owners(
+        binary_path, source_stems, follow_abstract_origin=dwarf_follow_abstract_origin()
+    )
     if stem_out is not None:
         stem_out.update({addr: stem for addr, (_name, stem) in owners.items()})
     return {addr: name for addr, (name, _stem) in owners.items()}

--- a/tests/test_cfg_export.py
+++ b/tests/test_cfg_export.py
@@ -210,7 +210,7 @@ def test_dwarf_owned_translation_unit_precedes_name_fallback(
     monkeypatch.setattr(
         cfg_export.binfmt,
         "source_function_owners",
-        lambda *_args: {0x12DA: ("main", "new_subid_range-new_subid_range")},
+        lambda *_args, **_kwargs: {0x12DA: ("main", "new_subid_range-new_subid_range")},
     )
 
     cfg_export.export_project_cfgs(

--- a/tests/test_dwarf_abstract_origin.py
+++ b/tests/test_dwarf_abstract_origin.py
@@ -1,0 +1,103 @@
+"""The opt-in ``DW_AT_abstract_origin`` chase for C concrete out-of-line instances.
+
+Builds the two-DIE shape gcc and clang emit for a C function that is both inlined
+at some call site and still emitted out-of-line — an abstract instance root
+(``DW_AT_name`` + ``DW_AT_inline``, no ``low_pc``) and a concrete instance
+(``DW_AT_low_pc``, no name, only ``DW_AT_abstract_origin``) — and pins that the
+concrete body is invisible by default and resolved only when the walk opts in.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from decbench.utils import binfmt
+from decbench.utils.dwarf_policy import dwarf_follow_abstract_origin
+
+_ENV = "DECBENCH_DWARF_ABSTRACT_ORIGIN"
+
+
+def _split_instance_cu(language: int | None = None) -> Any:
+    """A CU holding one ordinary subprogram plus one abstract/concrete instance pair."""
+    top_attrs: dict[str, Any] = {}
+    if language is not None:
+        top_attrs["DW_AT_language"] = SimpleNamespace(value=language)
+    cu = SimpleNamespace(cu_offset=0, header={"version": 4})
+    cu.get_top_DIE = lambda: SimpleNamespace(attributes=top_attrs)
+
+    ordinary = SimpleNamespace(
+        tag="DW_TAG_subprogram",
+        cu=cu,
+        attributes={
+            "DW_AT_low_pc": SimpleNamespace(value=0x1000),
+            "DW_AT_name": SimpleNamespace(value=b"gzopen"),
+            "DW_AT_decl_file": SimpleNamespace(value=1),
+        },
+    )
+    abstract = SimpleNamespace(
+        tag="DW_TAG_subprogram",
+        cu=cu,
+        attributes={
+            "DW_AT_name": SimpleNamespace(value=b"gz_read"),
+            "DW_AT_inline": SimpleNamespace(value=1),
+            "DW_AT_decl_file": SimpleNamespace(value=1),
+        },
+    )
+    concrete = SimpleNamespace(
+        tag="DW_TAG_subprogram",
+        cu=cu,
+        attributes={
+            "DW_AT_low_pc": SimpleNamespace(value=0x2000),
+            "DW_AT_abstract_origin": SimpleNamespace(value=abstract),
+        },
+    )
+    concrete.get_DIE_from_attribute = lambda _name: abstract
+    cu.iter_DIEs = lambda: iter((ordinary, abstract, concrete))
+    return cu
+
+
+@pytest.fixture
+def dwarf_walk(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """``source_function_owners`` bound to the split-instance CU, decl-file ``gz.c``."""
+
+    def _walk(*, language: int | None = None, follow: bool) -> dict[int, tuple[str, str]]:
+        cu = _split_instance_cu(language)
+        monkeypatch.setattr(
+            binfmt, "dwarf_info", lambda _path: SimpleNamespace(iter_CUs=lambda: iter((cu,)))
+        )
+        monkeypatch.setattr(binfmt, "cu_file_table", lambda *_args: [None, "gz.c"])
+        return binfmt.source_function_owners(Path("unused"), {"gz"}, follow_abstract_origin=follow)
+
+    return _walk
+
+
+def test_concrete_out_of_line_instance_is_invisible_by_default(dwarf_walk: Any) -> None:
+    """Without the hop the concrete body has no name, so only the ordinary function resolves."""
+    assert dwarf_walk(follow=False) == {0x1000: ("gzopen", "gz")}
+
+
+def test_concrete_out_of_line_instance_resolves_when_the_walk_opts_in(dwarf_walk: Any) -> None:
+    """The hop recovers the out-of-line body at its own ``low_pc``, adding to the default set."""
+    assert dwarf_walk(follow=True) == {
+        0x1000: ("gzopen", "gz"),
+        0x2000: ("gz_read", "gz"),
+    }
+
+
+def test_cxx_units_take_the_hop_regardless_of_the_switch(dwarf_walk: Any) -> None:
+    """C++ CUs already chase the origin, so the switch cannot move a C++ result."""
+    cxx = 0x04
+    assert dwarf_walk(language=cxx, follow=False) == dwarf_walk(language=cxx, follow=True)
+
+
+def test_switch_is_off_unless_the_env_var_is_exactly_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only ``1`` enables the chase; unset, ``0`` and ``true`` all stay off."""
+    monkeypatch.delenv(_ENV, raising=False)
+    assert dwarf_follow_abstract_origin() is False
+    for value in ("0", "true", "yes", ""):
+        monkeypatch.setenv(_ENV, value)
+        assert dwarf_follow_abstract_origin() is False, value
+    monkeypatch.setenv(_ENV, "1")
+    assert dwarf_follow_abstract_origin() is True

--- a/tests/test_reeval_ged.py
+++ b/tests/test_reeval_ged.py
@@ -775,7 +775,7 @@ def test_eval_one_uses_dwarf_tu_ownership_for_corrected_source(
     )
     monkeypatch.setattr(
         "decbench.utils.binfmt.source_function_owners",
-        lambda *_args: {0x12DA: ("main", "new_subid_range-new_subid_range")},
+        lambda *_args, **_kwargs: {0x12DA: ("main", "new_subid_range-new_subid_range")},
     )
     monkeypatch.setattr(
         "decbench.utils.cfg.extract_cfgs_from_source",


### PR DESCRIPTION
## The problem

`gcc` and `clang` split a C function that is **both inlined at some call site and
still emitted out-of-line** into two DIEs:

| DIE | has | lacks |
| --- | --- | --- |
| abstract instance root | `DW_AT_name`, `DW_AT_inline` | `DW_AT_low_pc` |
| concrete out-of-line instance | `DW_AT_low_pc`, `DW_AT_abstract_origin` | `DW_AT_name` |

`binfmt.source_function_owners` wants a `low_pc` and *then* a name, so neither
half qualifies — the root has the name but no address, the concrete instance has
the address but no name — and `die_attr_owner` deliberately refuses the
`DW_AT_abstract_origin` hop in a C compilation unit.

The real body is therefore invisible to:

- the run driver's decompile target set (`project_source_functions`),
- `_relabel_to_dwarf`'s address→name map — the body stays `sub_XXXX` and is
  dropped by `_is_unresolved_name`,
- `evaluate_project`'s `source_function_owners`.

These are functions the decompilers *do* recover; we simply never score them.

## The fix

A keyword-only `follow_abstract_origin` flag on `die_attr_owner` / `die_attr` /
`die_str_attr` / `source_function_owners`, driven process-wide by a new
`decbench/utils/dwarf_policy.py` reading `DECBENCH_DWARF_ABSTRACT_ORIGIN`.

The knob is honoured by every walk that already documents itself as mirroring the
run driver, so they cannot drift apart the moment it is on:
`scripts/run_benchmark.py`, `decbench/pipeline/evaluate.py`,
`scripts/reeval_ged.py`, `decbench/publish/cfg_export.py` (whose docstring
promises it "cannot drift from the scoring path") and the eval kit's `ingest` and
`resolve`.

> **Reviewer note — scope.** Threading the knob beyond `run_benchmark.py` +
> `pipeline/evaluate.py` is a deliberate call, not drive-by scope creep: with the
> knob on and `reeval_ged.py` off, the published overlays would resolve a
> different function set than the run that produced them. Happy to trim it back
> to the two call sites if you would rather land the narrow version first.

## Default OFF, and bit-identical when off

`dwarf_follow_abstract_origin()` is `True` only for the exact value `"1"`; unset,
`"0"` and even `"true"` are all off (documented, so nobody sets `true` and wonders
why nothing changed).

This was verified on **real binaries**, not just unit tests: walking every linked
ELF in `results/full_run` at O0 and O2 — **505 binaries, 60,866 owner entries** —
with this branch and `follow_abstract_origin=False` produces a **byte-for-byte
identical** dump to the same walk on `main`: equal SHA-256, entry for entry,
addresses, names and TU stems. Every existing result tree stays bit-identical.

## Public evidence

At `-O2`, DWARF-resolved source-function owners across the public corpus
(`projects/{sailr,cps,malware}`, 288 binaries):

| corpus | projects | without hop | with hop | delta |
| --- | --- | --- | --- | --- |
| sailr | 26 | 14,183 | 16,876 | **+2,693 (+19.0%)** |
| cps | 10 | 12,001 | 12,867 | +866 (+7.2%) |
| malware | 5 | 162 | 213 | +51 (+31.5%) |
| **total** | **40** | **26,346** | **29,956** | **+3,610 (+13.7%)** |

168 of 288 binaries improve, spanning 38 of 40 projects; **2,068 distinct
function names** are newly resolved. A few individually recognisable ones:

| project | recovered |
| --- | --- |
| zlib | `gz_read`, `gz_write`, `inflateReset`, `crc32_combine64` (+11.7%) |
| bzip2 | `BZ2_bzWriteOpen`, `BZ2_indexIntoF`, `mainGtU` (+33.9%) |
| grep | `treenext`, `treedelta`, `wordchar_next` (+17.9%) |
| tar | `chdir_do`, `assign_string`, `compare_dirnames` (+20.9%) |
| coreutils | `add_file_name`, `atomic_link`, `cached_umask` (+22.2%, 109 binaries) |
| openssh-portable | +1,136 owners (+17.3%) — largest absolute gain |
| freertos | `vTaskSwitchContext`, `xTaskIncrementTick`, `xQueueGenericCreate` |

**The hop only ever adds.** At every non-zero address across all slices it is a
strict superset: nothing is dropped, no name or TU stem changes.

### Other optimization levels

- **`-O0`**: sailr and malware are *exactly* unchanged. Three
  `always_inline`-heavy firmware targets (betaflight +5, cleanflight +4, riot-os
  +3) move by **12 owners in total**, because gcc splits a forced-inline helper
  into abstract and concrete instances even at `-O0`. Not zero, so the docs say
  so.
- **`O2-noinline`**: **not** a null control — it still gains 4.8%, since
  `-fno-inline` suppresses neither `always_inline` nor the abstract-instance
  shape emitted for header-defined statics.

### C++ zero-delta control

leveldb 1.23, built from `projects/cpp/disabled/leveldb.toml` with its own recipe
and flags, compares **equal** for `main` vs knob-off vs knob-on at both levels
(O0 755, O2 606 owners) — the whole owner dict, not just the count.

This control is **not vacuous**: `libleveldb.so.1.23.0` at O2 contains 38 C++ CUs,
0 C CUs, and **323 concrete-instance DIEs** (`low_pc`, no name, has
`DW_AT_abstract_origin`) — every one of them *already* resolved by the existing
`cu_is_cxx()` branch. That is precisely why the delta is zero.

### Compiler generality

Not gcc-specific: zlib 1.2.13 built with clang 14 at `-O2` shows the same
abstract/concrete split (11 concrete-instance DIEs across 15 C CUs) and gains
+10.1%. The `die_attr_owner` docstring now says "gcc and clang" rather than "gcc".

### A corrected figure

`docs/metrics.md` cited "grep at O2: 262 -> 314". That reproduces **exactly**, but
it is the *unfiltered whole-binary* `DW_TAG_subprogram` count across all 48 CUs
(and +52 is precisely grep's 52 concrete-instance DIEs, so the accounting closes).
It is **not** a `source_function_owners` number: after the project-TU `decl_file`
filter, grep goes **56 -> 66 (+17.9%)**. Both figures are now stated with their
scope, in the docs and in the docstring.

## Deliberately left alone

**`metrics/type_match.extract_ground_truth_types`.** Its map is keyed by function
NAME, and the abstract instance already supplies the parameters, so the entry is
present with or without the hop. Chasing the origin there would only let a
concrete instance overwrite that entry under the same name — moving type_match
ground truth for no gain. `_parse_function_die` keeps its plain `die_str_attr`
read and type_match's `cache_version` is **untouched**.

**`utils/source_extract.py`** is also left alone, but for a *different* reason: its
`_dwarf_decl` walk **does** require `DW_AT_low_pc`, so today it simply omits such a
function rather than holding an overwritable entry. Taking the hop there would be
additive, not corrupting — it is left out so this knob means exactly one thing, the
function-discovery set. Both exclusions are documented where a future reader hits
them.

## A known pre-existing wart this surfaces

11 entries keyed at `low_pc == 0` change *which* name wins — all in
`--gc-sections`'d ARM firmware (libopencm3, chibios, crazyflie, u-boot). Those are
garbage-collected functions whose `low_pc` is 0, so dozens already collide on one
dict key with last-writer-wins; the hop only changes which discarded function
lands last. **This collision exists on `main` today and is unrelated to this
change** — volunteering it because a reviewer diffing the dumps will find it.

## Checks

| check | result |
| --- | --- |
| `pytest` | 649 passed, 14 skipped. Same 6 failures as `origin/main` (5 × `test_content.py`, 1 × `test_evalkit.py::test_cli_export_smoke`) — pre-existing, unrelated. |
| `ruff check .` | 27 errors — **identical to `origin/main`**, none in changed files. |
| `black --check` | all 12 changed/new files clean. The 12 pre-existing reformat candidates are unchanged from `main`. |
| `mypy decbench` | 58 errors, **identical to `origin/main`**; the new file adds none. (Bare `mypy decbench` aborts on a numpy stub in this venv; run with `--python-version 3.13` to get past it — pre-existing.) |
| default-off bit-identity | 505 real binaries, 60,866 owners, byte-identical dump vs `main`. |

Two test monkeypatches needed `**_kwargs` added to their `source_function_owners`
lambdas; four new tests in `tests/test_dwarf_abstract_origin.py` pin the split-DIE
shape, the default-off behaviour, the C++ no-op and the strict `"1"` env parsing.

## Suggested CHANGELOG entry — **for a maintainer to apply, not applied here**

`CHANGELOG.md` is deliberately untouched (AGENTS.md). Suggested wording:

```markdown
### Added
- `DECBENCH_DWARF_ABSTRACT_ORIGIN=1` opts the DWARF function-discovery walk into
  following `DW_AT_abstract_origin` in C compilation units, recovering functions
  that gcc/clang both inlined and emitted out-of-line (+13.7% resolved source
  functions at -O2 across the public corpus; +19.0% on sailr). Off by default:
  existing result trees are bit-identical. Does not affect C++ or type_match
  ground truth.
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm4z25V4ypJhwnknGMWT7F
